### PR TITLE
[Refactor] Reduce Error boilerplate with thiserror

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "temporal-sdk-core",
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
+ "thiserror",
  "tokio",
  "tonic",
  "url",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -14,6 +14,7 @@ temporal-client = { version = "0.1.0", path = "./sdk-core/client" }
 temporal-sdk-core = { version = "0.1.0", path = "./sdk-core/core" }
 temporal-sdk-core-api = { version = "0.1.0", path = "./sdk-core/core-api" }
 temporal-sdk-core-protos = { version = "0.1.0", path = "./sdk-core/sdk-core-protos" }
+thiserror = "1.0.31"
 tokio = "1.15"
 tonic = "0.6"
 url = "2.2"

--- a/bridge/src/connection.rs
+++ b/bridge/src/connection.rs
@@ -21,8 +21,8 @@ pub enum ConnectionError {
     #[error(transparent)]
     InvalidConnectionOptions(#[from] ClientOptionsBuilderError),
 
-    #[error("provided RPC call is not supported by the API")]
-    InvalidRpc,
+    #[error("`{0}` RPC call is not supported by the API")]
+    InvalidRpc(String),
 
     #[error(transparent)]
     UnableToConnect(#[from] ClientInitError),
@@ -120,7 +120,7 @@ impl Connection {
             "get_cluster_info" => rpc_call!(self.client, self.runtime, get_cluster_info, bytes),
             "get_system_info" => rpc_call!(self.client, self.runtime, get_system_info, bytes),
             "list_task_queue_partitions" => rpc_call!(self.client, self.runtime, list_task_queue_partitions, bytes),
-            _ => return Err(ConnectionError::InvalidRpc)
+            _ => return Err(ConnectionError::InvalidRpc(rpc.to_string()))
         }
     }
 }


### PR DESCRIPTION
## What was changed
Replace Error boilerplate with `thiserror`

## Why?
Simplifies Connection code and provides a better pattern for error definition moving forward

1. Closes #24 

2. How was this tested:
Behaviour hasn't changed, relying on existing specs to catch any errors

3. Any docs updates needed?
No