### PR TITLE
[Refactor] Reduce globals by introducing a Ruby singleton Runtime

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -120,7 +120,6 @@ name = "bridge"
 version = "0.0.1"
 dependencies = [
  "lazy_static",
- "once_cell",
  "prost",
  "rutie",
  "temporal-client",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Anthony D <anthony@temporal.io>"]
 edition = "2021"
 
 [dependencies]
-once_cell = "1.12.0"
 lazy_static = "1.4.0"
 prost = "0.9"
 # prost-types = "0.7"

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -106,13 +106,7 @@ methods!(
         let runtime = runtime.get_data(&*RUNTIME_WRAPPER);
         let connection = connection.unwrap();
         let connection = connection.get_data(&*CONNECTION_WRAPPER);
-        let worker = Worker::create(
-            runtime.tokio_runtime.clone(),
-            &connection.client,
-            runtime.callback_tx.clone(),
-            &namespace,
-            &task_queue
-        );
+        let worker = Worker::create(runtime, &connection.client, &namespace, &task_queue);
 
         Module::from_existing("Temporal")
             .get_nested_module("Bridge")

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -7,14 +7,11 @@ mod runtime;
 mod worker;
 
 use connection::Connection;
-use once_cell::sync::OnceCell;
 use runtime::Runtime;
 use rutie::{
     Module, Object, Symbol, RString, Encoding, AnyObject, AnyException, Exception, VM, Thread,
     NilClass
 };
-use std::cell::RefCell;
-use std::sync::mpsc::{sync_channel, SyncSender, Receiver};
 use temporal_sdk_core::{Logger, TelemetryOptionsBuilder};
 use worker::{Response, Worker, WorkerResult};
 
@@ -22,36 +19,6 @@ const RUNTIME_THREAD_COUNT: u8 = 2;
 
 fn raise_bridge_exception(message: &str) {
     VM::raise_ex(AnyException::new("Temporal::Bridge::Error", Some(message)));
-}
-
-fn run_callback_loop(sender: SyncSender<Response>, receiver: &mut Receiver<Response>) {
-    let unblock = || { sender.send(Response::Empty {}).expect("Unable to close callback loop"); };
-
-    while let Ok(msg) = Thread::call_without_gvl(|| { receiver.recv() }, Some(unblock)) {
-        match msg {
-            Response::ActivityTask { bytes, callback } => callback(Ok(bytes)),
-            Response::Error { error, callback } => callback(Err(error)),
-            _ => panic!("Unsupported response type"),
-        }
-    }
-}
-
-fn start_callback_loop() -> &'static SyncSender<Response> {
-    static CALLBACK_SENDER: OnceCell<SyncSender<Response>> = OnceCell::new();
-    CALLBACK_SENDER.get_or_init(|| {
-        let (tx, rx): (SyncSender<Response>, Receiver<Response>) = sync_channel(1);
-        let rx = RefCell::new(rx);
-        let return_tx = tx.clone();
-
-        // Ruby callbacks can only be executed from a Ruby thread, therefore
-        // we're using rutie::Thread here instead of the std::thread
-        Thread::new(move || {
-            run_callback_loop(tx.clone(), &mut rx.borrow_mut());
-            NilClass::new()
-        });
-
-        return_tx
-    })
 }
 
 fn wrap_bytes(bytes: &Vec<u8>) -> AnyObject {
@@ -125,15 +92,39 @@ methods!(
             .wrap_data(runtime, &*RUNTIME_WRAPPER)
     }
 
+    fn run_callback_loop() -> NilClass {
+        let runtime = rtself.get_data_mut(&*RUNTIME_WRAPPER);
+
+        let poll = || { runtime.callback_rx.recv() };
+        let unblock = || {
+            runtime.callback_tx.send(Response::Empty {}).expect("Unable to close callback loop");
+        };
+
+        while let Ok(msg) = Thread::call_without_gvl(poll, Some(unblock)) {
+            match msg {
+                Response::ActivityTask { bytes, callback } => callback(Ok(bytes)),
+                Response::Error { error, callback } => callback(Err(error)),
+                _ => panic!("Unsupported response type"),
+            }
+        };
+
+        NilClass::new()
+    }
+
     fn create_worker(runtime: AnyObject, connection: AnyObject, namespace: RString, task_queue: RString) -> AnyObject {
-        let callback_sender = start_callback_loop();
         let namespace = namespace.map_err(|e| VM::raise_ex(e)).unwrap().to_string();
         let task_queue = task_queue.map_err(|e| VM::raise_ex(e)).unwrap().to_string();
         let runtime = runtime.unwrap();
         let runtime = runtime.get_data(&*RUNTIME_WRAPPER);
         let connection = connection.unwrap();
         let connection = connection.get_data(&*CONNECTION_WRAPPER);
-        let worker = Worker::create(runtime.tokio_runtime.clone(), &connection.client, callback_sender.clone(), &namespace, &task_queue);
+        let worker = Worker::create(
+            runtime.tokio_runtime.clone(),
+            &connection.client,
+            runtime.callback_tx.clone(),
+            &namespace,
+            &task_queue
+        );
 
         Module::from_existing("Temporal")
             .get_nested_module("Bridge")
@@ -169,6 +160,7 @@ pub extern "C" fn init_bridge() {
 
         module.define_nested_class("Runtime", None).define(|klass| {
             klass.def_self("init", init_runtime);
+            klass.def("run_callback_loop", run_callback_loop);
         });
 
         module.define_nested_class("Connection", None).define(|klass| {

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -106,7 +106,7 @@ methods!(
         let runtime = runtime.get_data(&*RUNTIME_WRAPPER);
         let connection = connection.unwrap();
         let connection = connection.get_data(&*CONNECTION_WRAPPER);
-        let worker = Worker::create(runtime, &connection.client, &namespace, &task_queue);
+        let worker = Worker::new(runtime, &connection.client, &namespace, &task_queue);
 
         Module::from_existing("Temporal")
             .get_nested_module("Bridge")

--- a/bridge/src/runtime.rs
+++ b/bridge/src/runtime.rs
@@ -7,7 +7,7 @@ use tokio::runtime::{Builder, Runtime as TokioRuntime};
 pub struct Runtime {
     pub tokio_runtime: Arc<TokioRuntime>,
     pub callback_tx: Sender<Response>,
-    pub callback_rx: Receiver<Response>,
+    callback_rx: Receiver<Response>,
 }
 
 impl Runtime {

--- a/bridge/src/runtime.rs
+++ b/bridge/src/runtime.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+use tokio::runtime::{Builder, Runtime as TokioRuntime};
+
+#[derive(Clone)]
+pub struct Runtime {
+    pub tokio_runtime: Arc<TokioRuntime>
+}
+
+impl Runtime {
+    pub fn new(thread_count: u8) -> Self {
+        let tokio_runtime = Arc::new(
+            Builder::new_multi_thread()
+                .worker_threads(thread_count.into())
+                .enable_all()
+                .thread_name("core")
+                .build()
+                .expect("Unable to start a runtime")
+        );
+
+        Runtime { tokio_runtime }
+    }
+}

--- a/bridge/src/runtime.rs
+++ b/bridge/src/runtime.rs
@@ -1,13 +1,17 @@
+use crate::worker::Response;
 use std::sync::Arc;
+use std::sync::mpsc::{channel, Sender, Receiver};
 use tokio::runtime::{Builder, Runtime as TokioRuntime};
 
-#[derive(Clone)]
 pub struct Runtime {
-    pub tokio_runtime: Arc<TokioRuntime>
+    pub tokio_runtime: Arc<TokioRuntime>,
+    pub callback_tx: Sender<Response>,
+    pub callback_rx: Receiver<Response>,
 }
 
 impl Runtime {
     pub fn new(thread_count: u8) -> Self {
+        let (tx, rx): (Sender<Response>, Receiver<Response>) = channel();
         let tokio_runtime = Arc::new(
             Builder::new_multi_thread()
                 .worker_threads(thread_count.into())
@@ -17,6 +21,6 @@ impl Runtime {
                 .expect("Unable to start a runtime")
         );
 
-        Runtime { tokio_runtime }
+        Runtime { tokio_runtime, callback_tx: tx, callback_rx: rx }
     }
 }

--- a/bridge/src/worker.rs
+++ b/bridge/src/worker.rs
@@ -38,25 +38,6 @@ pub enum Response {
 pub type WorkerResult = Result<Vec<u8>, WorkerError>;
 type WorkerCallback = Box<dyn FnOnce(WorkerResult) + Send + 'static>;
 
-async fn poll_activity_task_async(worker: Worker, callback: WorkerCallback) {
-    let task = worker.core_worker.poll_activity_task().await;
-
-    let response = match task {
-        Ok(task) => {
-            let mut bytes: Vec<u8> = Vec::with_capacity(task.encoded_len());
-            task.encode(&mut bytes).expect("Unable to encode activity task protobuf");
-
-            Response::ActivityTask { bytes, callback }
-        },
-        Err(e) => {
-            Response::Error { error: WorkerError::UnableToPollActivityTask(e), callback }
-        }
-    };
-
-    worker.callback_tx.send(response).expect("Unable to send a callback");
-}
-
-#[derive(Clone)]
 pub struct Worker {
     core_worker: Arc<temporal_sdk_core::Worker>,
     tokio_runtime: Arc<TokioRuntime>,
@@ -83,9 +64,27 @@ impl Worker {
     }
 
     pub fn poll_activity_task<F>(&self, callback: F) -> Result<(), WorkerError> where F: FnOnce(WorkerResult) + Send + 'static {
-        self.tokio_runtime.spawn(
-            poll_activity_task_async(self.clone(), Box::new(callback))
-        );
+        let core_worker = self.core_worker.clone();
+        let callback_tx = self.callback_tx.clone();
+        let callback = Box::new(callback);
+
+        self.tokio_runtime.spawn(async move {
+            let task = core_worker.poll_activity_task().await;
+
+            let response = match task {
+                Ok(task) => {
+                    let mut bytes: Vec<u8> = Vec::with_capacity(task.encoded_len());
+                    task.encode(&mut bytes).expect("Unable to encode activity task protobuf");
+
+                    Response::ActivityTask { bytes, callback }
+                },
+                Err(e) => {
+                    Response::Error { error: WorkerError::UnableToPollActivityTask(e), callback }
+                }
+            };
+
+            callback_tx.send(response).expect("Unable to send a callback");
+        });
 
         Ok(())
     }

--- a/bridge/src/worker.rs
+++ b/bridge/src/worker.rs
@@ -55,10 +55,13 @@ impl Worker {
         let callback_tx = self.callback_tx.clone();
 
         self.tokio_runtime.spawn(async move {
-            let task = core_worker.poll_activity_task().await;
+            let result = core_worker.poll_activity_task().await;
 
-            let callback: Callback = match task {
-                Ok(task) => Box::new(move || callback(Ok(task.encode_to_vec()))),
+            let callback: Callback = match result {
+                Ok(task) => {
+                    let bytes = task.encode_to_vec();
+                    Box::new(move || callback(Ok(bytes)))
+                },
                 Err(e) => Box::new(move || callback(Err(WorkerError::UnableToPollActivityTask(e))))
             };
 

--- a/bridge/src/worker.rs
+++ b/bridge/src/worker.rs
@@ -65,7 +65,7 @@ pub struct Worker {
 
 impl Worker {
     // TODO: Extend this to include full worker config
-    pub fn create(runtime: &Runtime, client: &Client, namespace: &str, task_queue: &str) -> Result<Worker, WorkerError> {
+    pub fn new(runtime: &Runtime, client: &Client, namespace: &str, task_queue: &str) -> Result<Worker, WorkerError> {
         let config = WorkerConfigBuilder::default()
             .namespace(namespace)
             .task_queue(task_queue)

--- a/bridge/src/worker.rs
+++ b/bridge/src/worker.rs
@@ -58,12 +58,7 @@ impl Worker {
             let task = core_worker.poll_activity_task().await;
 
             let callback: Callback = match task {
-                Ok(task) => {
-                    let mut bytes: Vec<u8> = Vec::with_capacity(task.encoded_len());
-                    task.encode(&mut bytes).expect("Unable to encode activity task protobuf");
-
-                    Box::new(move || callback(Ok(bytes)))
-                },
+                Ok(task) => Box::new(move || callback(Ok(task.encode_to_vec()))),
                 Err(e) => Box::new(move || callback(Err(WorkerError::UnableToPollActivityTask(e))))
             };
 

--- a/lib/temporal/connection.rb
+++ b/lib/temporal/connection.rb
@@ -1,10 +1,12 @@
 require 'temporal/api/workflowservice/v1/request_response_pb'
 require 'temporal/bridge'
+require 'temporal/runtime'
 
 module Temporal
   class Connection
     def initialize(host)
-      @core_connection = Temporal::Bridge::Connection.connect(host)
+      runtime = Temporal::Runtime.instance
+      @core_connection = Temporal::Bridge::Connection.connect(runtime.core_runtime, host)
     end
 
     def register_namespace(request)

--- a/lib/temporal/connection.rb
+++ b/lib/temporal/connection.rb
@@ -4,6 +4,8 @@ require 'temporal/runtime'
 
 module Temporal
   class Connection
+    attr_reader :core_connection
+
     def initialize(host)
       runtime = Temporal::Runtime.instance
       @core_connection = Temporal::Bridge::Connection.connect(runtime.core_runtime, host)
@@ -288,9 +290,5 @@ module Temporal
 
       Temporal::Api::WorkflowService::V1::ListTaskQueuePartitionsResponse.decode(response)
     end
-
-    private
-
-    attr_reader :core_connection
   end
 end

--- a/lib/temporal/runtime.rb
+++ b/lib/temporal/runtime.rb
@@ -1,0 +1,14 @@
+require 'singleton'
+require 'temporal/bridge'
+
+module Temporal
+  class Runtime
+    include Singleton
+
+    attr_reader :core_runtime
+
+    def initialize
+      @core_runtime = Temporal::Bridge::Runtime.init
+    end
+  end
+end

--- a/lib/temporal/runtime.rb
+++ b/lib/temporal/runtime.rb
@@ -10,5 +10,13 @@ module Temporal
     def initialize
       @core_runtime = Temporal::Bridge::Runtime.init
     end
+
+    def ensure_callback_loop
+      return unless @thread
+
+      @thread = Thread.new do
+        core_runtime.run_callback_loop
+      end
+    end
   end
 end

--- a/lib/temporal/runtime.rb
+++ b/lib/temporal/runtime.rb
@@ -12,7 +12,7 @@ module Temporal
     end
 
     def ensure_callback_loop
-      return unless @thread
+      return if @thread
 
       @thread = Thread.new do
         core_runtime.run_callback_loop

--- a/sig/temporal/bridge.rbs
+++ b/sig/temporal/bridge.rbs
@@ -11,8 +11,12 @@ module Temporal
     end
 
     class Connection
-      def self.connect: (String) -> Temporal::Bridge::Connection
+      def self.connect: (Runtime, String) -> Temporal::Bridge::Connection
       def call: (Symbol, String) -> String
+    end
+
+    class Runtime
+      def self.init: () -> Temporal::Bridge::Runtime
     end
   end
 end

--- a/sig/temporal/bridge.rbs
+++ b/sig/temporal/bridge.rbs
@@ -17,6 +17,7 @@ module Temporal
 
     class Runtime
       def self.init: () -> Temporal::Bridge::Runtime
+      def run_callback_loop: () -> void
     end
   end
 end

--- a/sig/temporal/runtime.rbs
+++ b/sig/temporal/runtime.rbs
@@ -1,0 +1,8 @@
+module Temporal
+  class Runtime
+    attr_reader core_runtime: Temporal::Bridge::Runtime
+
+    def self.instance: () -> Runtime
+    def initialize: () -> void
+  end
+end

--- a/sig/temporal/runtime.rbs
+++ b/sig/temporal/runtime.rbs
@@ -4,5 +4,6 @@ module Temporal
 
     def self.instance: () -> Runtime
     def initialize: () -> void
+    def ensure_callback_loop: () -> void
   end
 end

--- a/sig/temporal/runtime.rbs
+++ b/sig/temporal/runtime.rbs
@@ -1,3 +1,6 @@
+module Singleton
+end
+
 module Temporal
   class Runtime
     attr_reader core_runtime: Temporal::Bridge::Runtime

--- a/spec/unit/temporal/runtime_spec.rb
+++ b/spec/unit/temporal/runtime_spec.rb
@@ -1,0 +1,25 @@
+require 'temporal/runtime'
+
+describe Temporal::Runtime do
+  subject { described_class.instance }
+
+  describe '#ensure_callback_loop' do
+    let(:mock_runtime) { double(Temporal::Bridge::Runtime, run_callback_loop: nil) }
+
+    before do
+      allow(subject).to receive(:core_runtime).and_return(mock_runtime)
+    end
+
+    it 'runs the callback loop' do
+      subject.ensure_callback_loop
+
+      expect(mock_runtime).to have_received(:run_callback_loop)
+    end
+
+    it 'does not run callback loop twice' do
+      subject.ensure_callback_loop
+
+      expect(mock_runtime).not_to have_received(:run_callback_loop)
+    end
+  end
+end


### PR DESCRIPTION
## What was changed

This PR is a refactor as suggested previously in #7. It consists of the following changes:

1. Removes all the global state from the Rust Bridge in favour of using a singleton in Ruby that represents the Runtime
2. Switches from using a channel with a loop for message processing to `tokio::runtime::spawn` for async tasks. This way it is much clearer what is going on

This PR is missing the logic to join on all the join handlers returned by the `spawn` to ensure no `panic`s are ignored. This will be implemented in a follow-up PR.

## Why?

This should make everything more readable and improve the code quality

## Checklist

1. Closes #31 

4. How was this tested:

Tested locally with a script. Proper tests will be added when a Ruby worker is implemented

5. Any docs updates needed?

No