### PR TITLE
[Follow-up] Implement `follow_runs` for workflow results

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,7 +57,7 @@ Metrics/ClassLength:
   Max: 400
 
 Metrics/CyclomaticComplexity:
-  Max: 15
+  Max: 25
 
 Metrics/MethodLength:
   Max: 100
@@ -66,4 +66,4 @@ Metrics/ParameterLists:
   Max: 15
 
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 25

--- a/lib/temporal/client/workflow_handle.rb
+++ b/lib/temporal/client/workflow_handle.rb
@@ -14,9 +14,9 @@ module Temporal
         @first_execution_run_id = first_execution_run_id
       end
 
-      # TODO: Add timeout and follow_runs
-      def result
-        client_impl.await_workflow_result(id, result_run_id)
+      # TODO: Add timeout
+      def result(follow_runs: true)
+        client_impl.await_workflow_result(id, result_run_id, follow_runs)
       end
 
       def describe

--- a/sig/temporal/client/implementation.rbs
+++ b/sig/temporal/client/implementation.rbs
@@ -14,7 +14,7 @@ module Temporal
       def signal_workflow: (Temporal::Interceptor::Client::SignalWorkflowInput input) -> void
       def cancel_workflow: (Temporal::Interceptor::Client::CancelWorkflowInput input) -> void
       def terminate_workflow: (Temporal::Interceptor::Client::TerminateWorkflowInput input) -> void
-      def await_workflow_result: (String id, String? run_id) -> untyped
+      def await_workflow_result: (String id, String? run_id, bool follow_runs) -> untyped
 
       private
 
@@ -31,7 +31,8 @@ module Temporal
       def handle_signal_workflow: (Temporal::Interceptor::Client::SignalWorkflowInput input) -> nil
       def handle_cancel_workflow: (Temporal::Interceptor::Client::CancelWorkflowInput input) -> nil
       def handle_terminate_workflow: (Temporal::Interceptor::Client::TerminateWorkflowInput input) -> nil
-      def process_workflow_result_from: (Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse response) -> untyped
+      def process_workflow_result_from: (Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse response, bool follow_runs) -> untyped
+      def follow: (String?) -> void
     end
   end
 end

--- a/sig/temporal/client/workflow_handle.rbs
+++ b/sig/temporal/client/workflow_handle.rbs
@@ -13,7 +13,7 @@ module Temporal
         ?result_run_id: String?,
         ?first_execution_run_id: String?
       ) -> void
-      def result: -> untyped
+      def result: (?follow_runs: bool) -> untyped
       def describe: -> Temporal::Workflow::ExecutionInfo
       def cancel: (?String? reason) -> void
       def query: (String | Symbol query, *untyped args, ?reject_condition: Symbol) -> untyped

--- a/spec/unit/temporal/client/workflow_handle_spec.rb
+++ b/spec/unit/temporal/client/workflow_handle_spec.rb
@@ -27,7 +27,7 @@ describe Temporal::Client::WorkflowHandle do
       result = subject.result
 
       expect(result).to eq(42)
-      expect(client_impl).to have_received(:await_workflow_result).with(id, result_run_id)
+      expect(client_impl).to have_received(:await_workflow_result).with(id, result_run_id, true)
     end
   end
 


### PR DESCRIPTION
## What was changed
A follow up to #39 which implements a `follow_runs` option for the workflow handle