### PR TITLE
[Follow-up] Support RPC metadata and timeouts

### DIFF
--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -10,7 +10,7 @@ use connection::{Connection, RpcParams};
 use runtime::Runtime;
 use rutie::{
     Module, Object, Symbol, RString, Encoding, AnyObject, AnyException, Exception, VM, Thread,
-    NilClass
+    NilClass, Hash, Integer,
 };
 use std::collections::HashMap;
 use temporal_sdk_core::{Logger, TelemetryOptionsBuilder};
@@ -25,6 +25,19 @@ fn raise_bridge_exception(message: &str) {
 fn wrap_bytes(bytes: &Vec<u8>) -> AnyObject {
     let enc = Encoding::find("ASCII-8BIT").unwrap();
     RString::from_bytes(bytes, &enc).to_any_object()
+}
+
+fn to_hash_map(hash: Hash) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+
+    hash.each(|k, v| {
+        result.insert(
+            k.try_convert_to::<RString>().map_err(|e| VM::raise_ex(e)).unwrap().to_string(),
+            v.try_convert_to::<RString>().map_err(|e| VM::raise_ex(e)).unwrap().to_string()
+        );
+    });
+
+    return result
 }
 
 wrappable_struct!(Connection, ConnectionWrapper, CONNECTION_WRAPPER);
@@ -54,17 +67,19 @@ methods!(
             .wrap_data(connection, &*CONNECTION_WRAPPER)
     }
 
-    fn call_rpc(rpc: Symbol, request: RString) -> RString {
+    fn call_rpc(rpc: Symbol, request: RString, metadata: Hash, timeout: Integer) -> RString {
         let rpc = rpc.map_err(|e| VM::raise_ex(e)).unwrap().to_string();
         let request = request.map_err(|e| VM::raise_ex(e)).unwrap().to_string().as_bytes().to_vec();
+        let metadata = to_hash_map(metadata.map_err(|e| VM::raise_ex(e)).unwrap());
+        let timeout = timeout.map_or(None, |v| Some(v.to_u64()));
 
         let result = Thread::call_without_gvl(move || {
             let connection = rtself.get_data_mut(&*CONNECTION_WRAPPER);
             let params = RpcParams {
                 rpc: rpc.clone(),
                 request: request.clone(),
-                metadata: HashMap::new(),
-                timeout_millis: None
+                metadata: metadata.clone(),
+                timeout_millis: timeout
             };
             connection.call(params)
         }, Some(|| {}));

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -18,7 +18,7 @@ module Temporal
       @implementation = Client::Implementation.new(connection, namespace, converter, interceptors)
     end
 
-    def start_workflow(
+    def start_workflow( # rubocop:disable Metrics/ParameterLists
       workflow,
       *args,
       id:,
@@ -32,7 +32,9 @@ module Temporal
       memo: nil,
       search_attributes: nil,
       start_signal: nil,
-      start_signal_args: []
+      start_signal_args: [],
+      rpc_metadata: {},
+      rpc_timeout: nil
     )
       input = Interceptor::Client::StartWorkflowInput.new(
         workflow: workflow,
@@ -50,6 +52,8 @@ module Temporal
         headers: {},
         start_signal: start_signal,
         start_signal_args: start_signal_args,
+        rpc_metadata: rpc_metadata,
+        rpc_timeout: rpc_timeout,
       )
 
       implementation.start_workflow(input)

--- a/lib/temporal/client/workflow_handle.rb
+++ b/lib/temporal/client/workflow_handle.rb
@@ -14,29 +14,41 @@ module Temporal
         @first_execution_run_id = first_execution_run_id
       end
 
-      # TODO: Add timeout
-      def result(follow_runs: true)
-        client_impl.await_workflow_result(id, result_run_id, follow_runs)
+      def result(follow_runs: true, rpc_metadata: {}, rpc_timeout: nil)
+        client_impl.await_workflow_result(id, result_run_id, follow_runs, rpc_metadata, rpc_timeout)
       end
 
-      def describe
-        input = Interceptor::Client::DescribeWorkflowInput.new(id: id, run_id: run_id)
+      def describe(rpc_metadata: {}, rpc_timeout: nil)
+        input = Interceptor::Client::DescribeWorkflowInput.new(
+          id: id,
+          run_id: run_id,
+          rpc_metadata: rpc_metadata,
+          rpc_timeout: rpc_timeout,
+        )
 
         client_impl.describe_workflow(input)
       end
 
-      def cancel(reason = nil)
+      def cancel(reason = nil, rpc_metadata: {}, rpc_timeout: nil)
         input = Interceptor::Client::CancelWorkflowInput.new(
           id: id,
           run_id: run_id,
           first_execution_run_id: first_execution_run_id,
           reason: reason,
+          rpc_metadata: rpc_metadata,
+          rpc_timeout: rpc_timeout,
         )
 
         client_impl.cancel_workflow(input)
       end
 
-      def query(query, *args, reject_condition: Workflow::QueryRejectCondition::NONE)
+      def query(
+        query,
+        *args,
+        reject_condition: Workflow::QueryRejectCondition::NONE,
+        rpc_metadata: {},
+        rpc_timeout: nil
+      )
         input = Interceptor::Client::QueryWorkflowInput.new(
           id: id,
           run_id: run_id,
@@ -44,30 +56,36 @@ module Temporal
           args: args,
           reject_condition: reject_condition,
           headers: {},
+          rpc_metadata: rpc_metadata,
+          rpc_timeout: rpc_timeout,
         )
 
         client_impl.query_workflow(input)
       end
 
-      def signal(signal, *args)
+      def signal(signal, *args, rpc_metadata: {}, rpc_timeout: nil)
         input = Interceptor::Client::SignalWorkflowInput.new(
           id: id,
           run_id: run_id,
           signal: signal,
           args: args,
           headers: {},
+          rpc_metadata: rpc_metadata,
+          rpc_timeout: rpc_timeout,
         )
 
         client_impl.signal_workflow(input)
       end
 
-      def terminate(reason = nil, args = nil)
+      def terminate(reason = nil, args = nil, rpc_metadata: {}, rpc_timeout: nil)
         input = Interceptor::Client::TerminateWorkflowInput.new(
           id: id,
           run_id: run_id,
           first_execution_run_id: first_execution_run_id,
           reason: reason,
           args: args,
+          rpc_metadata: rpc_metadata,
+          rpc_timeout: rpc_timeout,
         )
 
         client_impl.terminate_workflow(input)

--- a/lib/temporal/connection.rb
+++ b/lib/temporal/connection.rb
@@ -11,282 +11,282 @@ module Temporal
       @core_connection = Temporal::Bridge::Connection.connect(runtime.core_runtime, host)
     end
 
-    def register_namespace(request)
+    def register_namespace(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RegisterNamespaceRequest.encode(request)
-      response = core_connection.call(:register_namespace, encoded)
+      response = core_connection.call(:register_namespace, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RegisterNamespaceResponse.decode(response)
     end
 
-    def describe_namespace(request)
+    def describe_namespace(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::DescribeNamespaceRequest.encode(request)
-      response = core_connection.call(:describe_namespace, encoded)
+      response = core_connection.call(:describe_namespace, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::DescribeNamespaceResponse.decode(response)
     end
 
-    def list_namespaces(request)
+    def list_namespaces(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ListNamespacesRequest.encode(request)
-      response = core_connection.call(:list_namespaces, encoded)
+      response = core_connection.call(:list_namespaces, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ListNamespacesResponse.decode(response)
     end
 
-    def update_namespace(request)
+    def update_namespace(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::UpdateNamespaceRequest.encode(request)
-      response = core_connection.call(:update_namespace, encoded)
+      response = core_connection.call(:update_namespace, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::UpdateNamespaceResponse.decode(response)
     end
 
-    def deprecate_namespace(request)
+    def deprecate_namespace(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::DeprecateNamespaceRequest.encode(request)
-      response = core_connection.call(:deprecate_namespace, encoded)
+      response = core_connection.call(:deprecate_namespace, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::DeprecateNamespaceResponse.decode(response)
     end
 
-    def start_workflow_execution(request)
+    def start_workflow_execution(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::StartWorkflowExecutionRequest.encode(request)
-      response = core_connection.call(:start_workflow_execution, encoded)
+      response = core_connection.call(:start_workflow_execution, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::StartWorkflowExecutionResponse.decode(response)
     end
 
-    def get_workflow_execution_history(request)
+    def get_workflow_execution_history(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryRequest.encode(request)
-      response = core_connection.call(:get_workflow_execution_history, encoded)
+      response = core_connection.call(:get_workflow_execution_history, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse.decode(response)
     end
 
-    def get_workflow_execution_history_reverse(request)
+    def get_workflow_execution_history_reverse(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseRequest.encode(request)
-      response = core_connection.call(:get_workflow_execution_history_reverse, encoded)
+      response = core_connection.call(:get_workflow_execution_history_reverse, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseResponse.decode(response)
     end
 
-    def poll_workflow_task_queue(request)
+    def poll_workflow_task_queue(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::PollWorkflowTaskQueueRequest.encode(request)
-      response = core_connection.call(:poll_workflow_task_queue, encoded)
+      response = core_connection.call(:poll_workflow_task_queue, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::PollWorkflowTaskQueueResponse.decode(response)
     end
 
-    def respond_workflow_task_completed(request)
+    def respond_workflow_task_completed(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondWorkflowTaskCompletedRequest.encode(request)
-      response = core_connection.call(:respond_workflow_task_completed, encoded)
+      response = core_connection.call(:respond_workflow_task_completed, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondWorkflowTaskCompletedResponse.decode(response)
     end
 
-    def respond_workflow_task_failed(request)
+    def respond_workflow_task_failed(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondWorkflowTaskFailedRequest.encode(request)
-      response = core_connection.call(:respond_workflow_task_failed, encoded)
+      response = core_connection.call(:respond_workflow_task_failed, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondWorkflowTaskFailedResponse.decode(response)
     end
 
-    def poll_activity_task_queue(request)
+    def poll_activity_task_queue(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::PollActivityTaskQueueRequest.encode(request)
-      response = core_connection.call(:poll_activity_task_queue, encoded)
+      response = core_connection.call(:poll_activity_task_queue, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::PollActivityTaskQueueResponse.decode(response)
     end
 
-    def record_activity_task_heartbeat(request)
+    def record_activity_task_heartbeat(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatRequest.encode(request)
-      response = core_connection.call(:record_activity_task_heartbeat, encoded)
+      response = core_connection.call(:record_activity_task_heartbeat, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatResponse.decode(response)
     end
 
-    def record_activity_task_heartbeat_by_id(request)
+    def record_activity_task_heartbeat_by_id(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdRequest.encode(request)
-      response = core_connection.call(:record_activity_task_heartbeat_by_id, encoded)
+      response = core_connection.call(:record_activity_task_heartbeat_by_id, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdResponse.decode(response)
     end
 
-    def respond_activity_task_completed(request)
+    def respond_activity_task_completed(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedRequest.encode(request)
-      response = core_connection.call(:respond_activity_task_completed, encoded)
+      response = core_connection.call(:respond_activity_task_completed, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedResponse.decode(response)
     end
 
-    def respond_activity_task_completed_by_id(request)
+    def respond_activity_task_completed_by_id(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdRequest.encode(request)
-      response = core_connection.call(:respond_activity_task_completed_by_id, encoded)
+      response = core_connection.call(:respond_activity_task_completed_by_id, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdResponse.decode(response)
     end
 
-    def respond_activity_task_failed(request)
+    def respond_activity_task_failed(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedRequest.encode(request)
-      response = core_connection.call(:respond_activity_task_failed, encoded)
+      response = core_connection.call(:respond_activity_task_failed, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedResponse.decode(response)
     end
 
-    def respond_activity_task_failed_by_id(request)
+    def respond_activity_task_failed_by_id(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedByIdRequest.encode(request)
-      response = core_connection.call(:respond_activity_task_failed_by_id, encoded)
+      response = core_connection.call(:respond_activity_task_failed_by_id, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedByIdResponse.decode(response)
     end
 
-    def respond_activity_task_canceled(request)
+    def respond_activity_task_canceled(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledRequest.encode(request)
-      response = core_connection.call(:respond_activity_task_canceled, encoded)
+      response = core_connection.call(:respond_activity_task_canceled, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledResponse.decode(response)
     end
 
-    def respond_activity_task_canceled_by_id(request)
+    def respond_activity_task_canceled_by_id(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdRequest.encode(request)
-      response = core_connection.call(:respond_activity_task_canceled_by_id, encoded)
+      response = core_connection.call(:respond_activity_task_canceled_by_id, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdResponse.decode(response)
     end
 
-    def request_cancel_workflow_execution(request)
+    def request_cancel_workflow_execution(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionRequest.encode(request)
-      response = core_connection.call(:request_cancel_workflow_execution, encoded)
+      response = core_connection.call(:request_cancel_workflow_execution, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionResponse.decode(response)
     end
 
-    def signal_workflow_execution(request)
+    def signal_workflow_execution(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::SignalWorkflowExecutionRequest.encode(request)
-      response = core_connection.call(:signal_workflow_execution, encoded)
+      response = core_connection.call(:signal_workflow_execution, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::SignalWorkflowExecutionResponse.decode(response)
     end
 
-    def signal_with_start_workflow_execution(request)
+    def signal_with_start_workflow_execution(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionRequest.encode(request)
-      response = core_connection.call(:signal_with_start_workflow_execution, encoded)
+      response = core_connection.call(:signal_with_start_workflow_execution, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionResponse.decode(response)
     end
 
-    def reset_workflow_execution(request)
+    def reset_workflow_execution(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionRequest.encode(request)
-      response = core_connection.call(:reset_workflow_execution, encoded)
+      response = core_connection.call(:reset_workflow_execution, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionResponse.decode(response)
     end
 
-    def terminate_workflow_execution(request)
+    def terminate_workflow_execution(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionRequest.encode(request)
-      response = core_connection.call(:terminate_workflow_execution, encoded)
+      response = core_connection.call(:terminate_workflow_execution, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse.decode(response)
     end
 
-    def list_open_workflow_executions(request)
+    def list_open_workflow_executions(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ListOpenWorkflowExecutionsRequest.encode(request)
-      response = core_connection.call(:list_open_workflow_executions, encoded)
+      response = core_connection.call(:list_open_workflow_executions, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ListOpenWorkflowExecutionsResponse.decode(response)
     end
 
-    def list_closed_workflow_executions(request)
+    def list_closed_workflow_executions(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ListClosedWorkflowExecutionsRequest.encode(request)
-      response = core_connection.call(:list_closed_workflow_executions, encoded)
+      response = core_connection.call(:list_closed_workflow_executions, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ListClosedWorkflowExecutionsResponse.decode(response)
     end
 
-    def list_workflow_executions(request)
+    def list_workflow_executions(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ListWorkflowExecutionsRequest.encode(request)
-      response = core_connection.call(:list_workflow_executions, encoded)
+      response = core_connection.call(:list_workflow_executions, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ListWorkflowExecutionsResponse.decode(response)
     end
 
-    def list_archived_workflow_executions(request)
+    def list_archived_workflow_executions(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsRequest.encode(request)
-      response = core_connection.call(:list_archived_workflow_executions, encoded)
+      response = core_connection.call(:list_archived_workflow_executions, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsResponse.decode(response)
     end
 
-    def scan_workflow_executions(request)
+    def scan_workflow_executions(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ScanWorkflowExecutionsRequest.encode(request)
-      response = core_connection.call(:scan_workflow_executions, encoded)
+      response = core_connection.call(:scan_workflow_executions, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ScanWorkflowExecutionsResponse.decode(response)
     end
 
-    def count_workflow_executions(request)
+    def count_workflow_executions(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsRequest.encode(request)
-      response = core_connection.call(:count_workflow_executions, encoded)
+      response = core_connection.call(:count_workflow_executions, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsResponse.decode(response)
     end
 
-    def get_search_attributes(request)
+    def get_search_attributes(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::GetSearchAttributesRequest.encode(request)
-      response = core_connection.call(:get_search_attributes, encoded)
+      response = core_connection.call(:get_search_attributes, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::GetSearchAttributesResponse.decode(response)
     end
 
-    def respond_query_task_completed(request)
+    def respond_query_task_completed(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::RespondQueryTaskCompletedRequest.encode(request)
-      response = core_connection.call(:respond_query_task_completed, encoded)
+      response = core_connection.call(:respond_query_task_completed, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::RespondQueryTaskCompletedResponse.decode(response)
     end
 
-    def reset_sticky_task_queue(request)
+    def reset_sticky_task_queue(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ResetStickyTaskQueueRequest.encode(request)
-      response = core_connection.call(:reset_sticky_task_queue, encoded)
+      response = core_connection.call(:reset_sticky_task_queue, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ResetStickyTaskQueueResponse.decode(response)
     end
 
-    def query_workflow(request)
+    def query_workflow(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::QueryWorkflowRequest.encode(request)
-      response = core_connection.call(:query_workflow, encoded)
+      response = core_connection.call(:query_workflow, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::QueryWorkflowResponse.decode(response)
     end
 
-    def describe_workflow_execution(request)
+    def describe_workflow_execution(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionRequest.encode(request)
-      response = core_connection.call(:describe_workflow_execution, encoded)
+      response = core_connection.call(:describe_workflow_execution, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse.decode(response)
     end
 
-    def describe_task_queue(request)
+    def describe_task_queue(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::DescribeTaskQueueRequest.encode(request)
-      response = core_connection.call(:describe_task_queue, encoded)
+      response = core_connection.call(:describe_task_queue, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::DescribeTaskQueueResponse.decode(response)
     end
 
-    def get_cluster_info(request)
+    def get_cluster_info(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::GetClusterInfoRequest.encode(request)
-      response = core_connection.call(:get_cluster_info, encoded)
+      response = core_connection.call(:get_cluster_info, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::GetClusterInfoResponse.decode(response)
     end
 
-    def get_system_info(request)
+    def get_system_info(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::GetSystemInfoRequest.encode(request)
-      response = core_connection.call(:get_system_info, encoded)
+      response = core_connection.call(:get_system_info, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::GetSystemInfoResponse.decode(response)
     end
 
-    def list_task_queue_partitions(request)
+    def list_task_queue_partitions(request, metadata: {}, timeout: nil)
       encoded = Temporal::Api::WorkflowService::V1::ListTaskQueuePartitionsRequest.encode(request)
-      response = core_connection.call(:list_task_queue_partitions, encoded)
+      response = core_connection.call(:list_task_queue_partitions, encoded, metadata, timeout)
 
       Temporal::Api::WorkflowService::V1::ListTaskQueuePartitionsResponse.decode(response)
     end

--- a/lib/temporal/interceptor/client.rb
+++ b/lib/temporal/interceptor/client.rb
@@ -17,12 +17,16 @@ module Temporal
         :headers,
         :start_signal,
         :start_signal_args,
+        :rpc_metadata,
+        :rpc_timeout,
         keyword_init: true,
       ); end
 
       class DescribeWorkflowInput < Struct.new(
         :id,
         :run_id,
+        :rpc_metadata,
+        :rpc_timeout,
         keyword_init: true,
       ); end
 
@@ -33,6 +37,8 @@ module Temporal
         :args,
         :reject_condition,
         :headers,
+        :rpc_metadata,
+        :rpc_timeout,
         keyword_init: true,
       ); end
 
@@ -42,6 +48,8 @@ module Temporal
         :signal,
         :args,
         :headers,
+        :rpc_metadata,
+        :rpc_timeout,
         keyword_init: true,
       ); end
 
@@ -50,6 +58,8 @@ module Temporal
         :run_id,
         :first_execution_run_id,
         :reason,
+        :rpc_metadata,
+        :rpc_timeout,
         keyword_init: true,
       ); end
 
@@ -59,6 +69,8 @@ module Temporal
         :first_execution_run_id,
         :reason,
         :args,
+        :rpc_metadata,
+        :rpc_timeout,
         keyword_init: true,
       ); end
 

--- a/sig/temporal/bridge.rbs
+++ b/sig/temporal/bridge.rbs
@@ -12,7 +12,7 @@ module Temporal
 
     class Connection
       def self.connect: (Runtime, String) -> Temporal::Bridge::Connection
-      def call: (Symbol, String) -> String
+      def call: (Symbol, String, Hash[String, String], Integer?) -> String
     end
 
     class Runtime

--- a/sig/temporal/client.rbs
+++ b/sig/temporal/client.rbs
@@ -21,7 +21,9 @@ module Temporal
       ?memo: Hash[Symbol | String, untyped]?,
       ?search_attributes: Hash[Symbol | String, untyped]?,
       ?start_signal: Symbol | String?,
-      ?start_signal_args: Array[untyped]?
+      ?start_signal_args: Array[untyped]?,
+      ?rpc_metadata: Hash[String, String],
+      ?rpc_timeout: Integer?
     ) -> untyped
     def workflow_handle: (String id, ?run_id: String?, ?first_execution_run_id: String?) -> WorkflowHandle
 

--- a/sig/temporal/client/implementation.rbs
+++ b/sig/temporal/client/implementation.rbs
@@ -14,7 +14,7 @@ module Temporal
       def signal_workflow: (Temporal::Interceptor::Client::SignalWorkflowInput input) -> void
       def cancel_workflow: (Temporal::Interceptor::Client::CancelWorkflowInput input) -> void
       def terminate_workflow: (Temporal::Interceptor::Client::TerminateWorkflowInput input) -> void
-      def await_workflow_result: (String id, String? run_id, bool follow_runs) -> untyped
+      def await_workflow_result: (String id, String? run_id, bool follow_runs, Hash[String, String] rpc_metadata, Integer? rpc_timeout) -> untyped
 
       private
 

--- a/sig/temporal/client/workflow_handle.rbs
+++ b/sig/temporal/client/workflow_handle.rbs
@@ -13,12 +13,12 @@ module Temporal
         ?result_run_id: String?,
         ?first_execution_run_id: String?
       ) -> void
-      def result: (?follow_runs: bool) -> untyped
-      def describe: -> Temporal::Workflow::ExecutionInfo
-      def cancel: (?String? reason) -> void
-      def query: (String | Symbol query, *untyped args, ?reject_condition: Symbol) -> untyped
-      def signal: (String | Symbol signal, *untyped args) -> void
-      def terminate: (?String? reason, ?untyped args) -> void
+      def result: (?follow_runs: bool, ?rpc_metadata: Hash[String, String], ?rpc_timeout: Integer?) -> untyped
+      def describe: (?rpc_metadata: Hash[String, String], ?rpc_timeout: Integer?) -> Temporal::Workflow::ExecutionInfo
+      def cancel: (?String? reason, ?rpc_metadata: Hash[String, String], ?rpc_timeout: Integer?) -> void
+      def query: (String | Symbol query, *untyped args, ?reject_condition: Symbol, ?rpc_metadata: Hash[String, String], ?rpc_timeout: Integer?) -> untyped
+      def signal: (String | Symbol signal, *untyped args, ?rpc_metadata: Hash[String, String], ?rpc_timeout: Integer?) -> void
+      def terminate: (?String? reason, ?untyped args, ?rpc_metadata: Hash[String, String], ?rpc_timeout: Integer?) -> void
 
       private
 

--- a/sig/temporal/connection.rbs
+++ b/sig/temporal/connection.rbs
@@ -3,45 +3,45 @@ module Temporal
     attr_reader core_connection: Temporal::Bridge::Connection
 
     def initialize: (String) -> void
-    def register_namespace: (Temporal::Api::WorkflowService::V1::RegisterNamespaceRequest request) -> Temporal::Api::WorkflowService::V1::RegisterNamespaceResponse
-    def describe_namespace: (Temporal::Api::WorkflowService::V1::DescribeNamespaceRequest request) -> Temporal::Api::WorkflowService::V1::DescribeNamespaceResponse
-    def list_namespaces: (Temporal::Api::WorkflowService::V1::ListNamespacesRequest request) -> Temporal::Api::WorkflowService::V1::ListNamespacesResponse
-    def update_namespace: (Temporal::Api::WorkflowService::V1::UpdateNamespaceRequest request) -> Temporal::Api::WorkflowService::V1::UpdateNamespaceResponse
-    def deprecate_namespace: (Temporal::Api::WorkflowService::V1::DeprecateNamespaceRequest request) -> Temporal::Api::WorkflowService::V1::DeprecateNamespaceResponse
-    def start_workflow_execution: (Temporal::Api::WorkflowService::V1::StartWorkflowExecutionRequest request) -> Temporal::Api::WorkflowService::V1::StartWorkflowExecutionResponse
-    def get_workflow_execution_history: (Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryRequest request) -> Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse
-    def get_workflow_execution_history_reverse: (Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseRequest request) -> Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseResponse
-    def poll_workflow_task_queue: (Temporal::Api::WorkflowService::V1::PollWorkflowTaskQueueRequest request) -> Temporal::Api::WorkflowService::V1::PollWorkflowTaskQueueResponse
-    def respond_workflow_task_completed: (Temporal::Api::WorkflowService::V1::RespondWorkflowTaskCompletedRequest request) -> Temporal::Api::WorkflowService::V1::RespondWorkflowTaskCompletedResponse
-    def respond_workflow_task_failed: (Temporal::Api::WorkflowService::V1::RespondWorkflowTaskFailedRequest request) -> Temporal::Api::WorkflowService::V1::RespondWorkflowTaskFailedResponse
-    def poll_activity_task_queue: (Temporal::Api::WorkflowService::V1::PollActivityTaskQueueRequest request) -> Temporal::Api::WorkflowService::V1::PollActivityTaskQueueResponse
-    def record_activity_task_heartbeat: (Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatRequest request) -> Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatResponse
-    def record_activity_task_heartbeat_by_id: (Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdRequest request) -> Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdResponse
-    def respond_activity_task_completed: (Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedRequest request) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedResponse
-    def respond_activity_task_completed_by_id: (Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdRequest request) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdResponse
-    def respond_activity_task_failed: (Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedRequest request) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedResponse
-    def respond_activity_task_failed_by_id: (Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedByIdRequest request) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedByIdResponse
-    def respond_activity_task_canceled: (Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledRequest request) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledResponse
-    def respond_activity_task_canceled_by_id: (Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdRequest request) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdResponse
-    def request_cancel_workflow_execution: (Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionRequest request) -> Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionResponse
-    def signal_workflow_execution: (Temporal::Api::WorkflowService::V1::SignalWorkflowExecutionRequest request) -> Temporal::Api::WorkflowService::V1::SignalWorkflowExecutionResponse
-    def signal_with_start_workflow_execution: (Temporal::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionRequest request) -> Temporal::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionResponse
-    def reset_workflow_execution: (Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionRequest request) -> Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionResponse
-    def terminate_workflow_execution: (Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionRequest request) -> Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse
-    def list_open_workflow_executions: (Temporal::Api::WorkflowService::V1::ListOpenWorkflowExecutionsRequest request) -> Temporal::Api::WorkflowService::V1::ListOpenWorkflowExecutionsResponse
-    def list_closed_workflow_executions: (Temporal::Api::WorkflowService::V1::ListClosedWorkflowExecutionsRequest request) -> Temporal::Api::WorkflowService::V1::ListClosedWorkflowExecutionsResponse
-    def list_workflow_executions: (Temporal::Api::WorkflowService::V1::ListWorkflowExecutionsRequest request) -> Temporal::Api::WorkflowService::V1::ListWorkflowExecutionsResponse
-    def list_archived_workflow_executions: (Temporal::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsRequest request) -> Temporal::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsResponse
-    def scan_workflow_executions: (Temporal::Api::WorkflowService::V1::ScanWorkflowExecutionsRequest request) -> Temporal::Api::WorkflowService::V1::ScanWorkflowExecutionsResponse
-    def count_workflow_executions: (Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsRequest request) -> Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsResponse
-    def get_search_attributes: (Temporal::Api::WorkflowService::V1::GetSearchAttributesRequest request) -> Temporal::Api::WorkflowService::V1::GetSearchAttributesResponse
-    def respond_query_task_completed: (Temporal::Api::WorkflowService::V1::RespondQueryTaskCompletedRequest request) -> Temporal::Api::WorkflowService::V1::RespondQueryTaskCompletedResponse
-    def reset_sticky_task_queue: (Temporal::Api::WorkflowService::V1::ResetStickyTaskQueueRequest request) -> Temporal::Api::WorkflowService::V1::ResetStickyTaskQueueResponse
-    def query_workflow: (Temporal::Api::WorkflowService::V1::QueryWorkflowRequest request) -> Temporal::Api::WorkflowService::V1::QueryWorkflowResponse
-    def describe_workflow_execution: (Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionRequest request) -> Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse
-    def describe_task_queue: (Temporal::Api::WorkflowService::V1::DescribeTaskQueueRequest request) -> Temporal::Api::WorkflowService::V1::DescribeTaskQueueResponse
-    def get_cluster_info: (Temporal::Api::WorkflowService::V1::GetClusterInfoRequest request) -> Temporal::Api::WorkflowService::V1::GetClusterInfoResponse
-    def get_system_info: (Temporal::Api::WorkflowService::V1::GetSystemInfoRequest request) -> Temporal::Api::WorkflowService::V1::GetSystemInfoResponse
-    def list_task_queue_partitions: (Temporal::Api::WorkflowService::V1::ListTaskQueuePartitionsRequest request) -> Temporal::Api::WorkflowService::V1::ListTaskQueuePartitionsResponse
+    def register_namespace: (Temporal::Api::WorkflowService::V1::RegisterNamespaceRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RegisterNamespaceResponse
+    def describe_namespace: (Temporal::Api::WorkflowService::V1::DescribeNamespaceRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::DescribeNamespaceResponse
+    def list_namespaces: (Temporal::Api::WorkflowService::V1::ListNamespacesRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ListNamespacesResponse
+    def update_namespace: (Temporal::Api::WorkflowService::V1::UpdateNamespaceRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::UpdateNamespaceResponse
+    def deprecate_namespace: (Temporal::Api::WorkflowService::V1::DeprecateNamespaceRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::DeprecateNamespaceResponse
+    def start_workflow_execution: (Temporal::Api::WorkflowService::V1::StartWorkflowExecutionRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::StartWorkflowExecutionResponse
+    def get_workflow_execution_history: (Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse
+    def get_workflow_execution_history_reverse: (Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseResponse
+    def poll_workflow_task_queue: (Temporal::Api::WorkflowService::V1::PollWorkflowTaskQueueRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::PollWorkflowTaskQueueResponse
+    def respond_workflow_task_completed: (Temporal::Api::WorkflowService::V1::RespondWorkflowTaskCompletedRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondWorkflowTaskCompletedResponse
+    def respond_workflow_task_failed: (Temporal::Api::WorkflowService::V1::RespondWorkflowTaskFailedRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondWorkflowTaskFailedResponse
+    def poll_activity_task_queue: (Temporal::Api::WorkflowService::V1::PollActivityTaskQueueRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::PollActivityTaskQueueResponse
+    def record_activity_task_heartbeat: (Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatResponse
+    def record_activity_task_heartbeat_by_id: (Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdResponse
+    def respond_activity_task_completed: (Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedResponse
+    def respond_activity_task_completed_by_id: (Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdResponse
+    def respond_activity_task_failed: (Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedResponse
+    def respond_activity_task_failed_by_id: (Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedByIdRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedByIdResponse
+    def respond_activity_task_canceled: (Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledResponse
+    def respond_activity_task_canceled_by_id: (Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdResponse
+    def request_cancel_workflow_execution: (Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RequestCancelWorkflowExecutionResponse
+    def signal_workflow_execution: (Temporal::Api::WorkflowService::V1::SignalWorkflowExecutionRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::SignalWorkflowExecutionResponse
+    def signal_with_start_workflow_execution: (Temporal::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionResponse
+    def reset_workflow_execution: (Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionResponse
+    def terminate_workflow_execution: (Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse
+    def list_open_workflow_executions: (Temporal::Api::WorkflowService::V1::ListOpenWorkflowExecutionsRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ListOpenWorkflowExecutionsResponse
+    def list_closed_workflow_executions: (Temporal::Api::WorkflowService::V1::ListClosedWorkflowExecutionsRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ListClosedWorkflowExecutionsResponse
+    def list_workflow_executions: (Temporal::Api::WorkflowService::V1::ListWorkflowExecutionsRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ListWorkflowExecutionsResponse
+    def list_archived_workflow_executions: (Temporal::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsResponse
+    def scan_workflow_executions: (Temporal::Api::WorkflowService::V1::ScanWorkflowExecutionsRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ScanWorkflowExecutionsResponse
+    def count_workflow_executions: (Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsResponse
+    def get_search_attributes: (Temporal::Api::WorkflowService::V1::GetSearchAttributesRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::GetSearchAttributesResponse
+    def respond_query_task_completed: (Temporal::Api::WorkflowService::V1::RespondQueryTaskCompletedRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::RespondQueryTaskCompletedResponse
+    def reset_sticky_task_queue: (Temporal::Api::WorkflowService::V1::ResetStickyTaskQueueRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ResetStickyTaskQueueResponse
+    def query_workflow: (Temporal::Api::WorkflowService::V1::QueryWorkflowRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::QueryWorkflowResponse
+    def describe_workflow_execution: (Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse
+    def describe_task_queue: (Temporal::Api::WorkflowService::V1::DescribeTaskQueueRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::DescribeTaskQueueResponse
+    def get_cluster_info: (Temporal::Api::WorkflowService::V1::GetClusterInfoRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::GetClusterInfoResponse
+    def get_system_info: (Temporal::Api::WorkflowService::V1::GetSystemInfoRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::GetSystemInfoResponse
+    def list_task_queue_partitions: (Temporal::Api::WorkflowService::V1::ListTaskQueuePartitionsRequest request, ?metadata: Hash[String, String], ?timeout: Integer?) -> Temporal::Api::WorkflowService::V1::ListTaskQueuePartitionsResponse
   end
 end

--- a/sig/temporal/interceptor/client.rbs
+++ b/sig/temporal/interceptor/client.rbs
@@ -32,6 +32,8 @@ module Temporal
         attr_accessor headers(): Hash[Symbol | String, untyped]
         attr_accessor start_signal(): String? | Symbol?
         attr_accessor start_signal_args(): Array[untyped]?
+        attr_accessor rpc_metadata(): Hash[String, String]
+        attr_accessor rpc_timeout(): Integer?
 
         def self.new: (
           workflow: String,
@@ -48,15 +50,24 @@ module Temporal
           search_attributes: Hash[Symbol | String, untyped]?,
           headers: Hash[Symbol | String, untyped]?,
           start_signal: String | Symbol?,
-          start_signal_args: Array[untyped]?
+          start_signal_args: Array[untyped]?,
+          rpc_metadata: Hash[String, String],
+          rpc_timeout: Integer?
         ) -> StartWorkflowInput
       end
 
       class DescribeWorkflowInput < Struct[untyped]
         attr_accessor id(): String
         attr_accessor run_id(): String
+        attr_accessor rpc_metadata(): Hash[String, String]
+        attr_accessor rpc_timeout(): Integer?
 
-        def self.new: (id: String, run_id: String?) -> DescribeWorkflowInput
+        def self.new: (
+          id: String,
+          run_id: String?,
+          rpc_metadata: Hash[String, String],
+          rpc_timeout: Integer?
+        ) -> DescribeWorkflowInput
       end
 
       class QueryWorkflowInput < Struct[untyped]
@@ -66,6 +77,8 @@ module Temporal
         attr_accessor args(): Array[untyped]
         attr_accessor reject_condition(): Symbol
         attr_accessor headers(): Hash[Symbol | String, untyped]
+        attr_accessor rpc_metadata(): Hash[String, String]
+        attr_accessor rpc_timeout(): Integer?
 
         def self.new: (
           id: String,
@@ -73,7 +86,9 @@ module Temporal
           query: String | Symbol,
           args: Array[untyped]?,
           reject_condition: Symbol,
-          headers: Hash[Symbol | String, untyped]?
+          headers: Hash[Symbol | String, untyped]?,
+          rpc_metadata: Hash[String, String],
+          rpc_timeout: Integer?
         ) -> QueryWorkflowInput
       end
 
@@ -83,13 +98,17 @@ module Temporal
         attr_accessor signal(): String | Symbol
         attr_accessor args(): Array[untyped]
         attr_accessor headers(): Hash[Symbol | String, untyped]
+        attr_accessor rpc_metadata(): Hash[String, String]
+        attr_accessor rpc_timeout(): Integer?
 
         def self.new: (
           id: String,
           run_id: String?,
           signal: String | Symbol,
           args: Array[untyped]?,
-          headers: Hash[Symbol | String, untyped]?
+          headers: Hash[Symbol | String, untyped]?,
+          rpc_metadata: Hash[String, String],
+          rpc_timeout: Integer?
         ) -> SignalWorkflowInput
       end
 
@@ -98,12 +117,16 @@ module Temporal
         attr_accessor run_id(): String
         attr_accessor first_execution_run_id(): String
         attr_accessor reason(): String
+        attr_accessor rpc_metadata(): Hash[String, String]
+        attr_accessor rpc_timeout(): Integer?
 
         def self.new: (
           id: String,
           run_id: String?,
           first_execution_run_id: String?,
-          reason: String?
+          reason: String?,
+          rpc_metadata: Hash[String, String],
+          rpc_timeout: Integer?
         ) -> CancelWorkflowInput
       end
 
@@ -113,13 +136,17 @@ module Temporal
         attr_accessor first_execution_run_id(): String
         attr_accessor reason(): String
         attr_accessor args(): Array[untyped]
+        attr_accessor rpc_metadata(): Hash[String, String]
+        attr_accessor rpc_timeout(): Integer?
 
         def self.new: (
           id: String,
           run_id: String?,
           first_execution_run_id: String?,
           reason: String?,
-          args: Array[untyped]
+          args: Array[untyped],
+          rpc_metadata: Hash[String, String],
+          rpc_timeout: Integer?
         ) -> TerminateWorkflowInput
       end
     end

--- a/spec/integration/connection_spec.rb
+++ b/spec/integration/connection_spec.rb
@@ -25,6 +25,20 @@ describe Temporal::Connection do
       it 'makes an RPC call' do
         expect(subject.public_send(rpc, desc.input.new)).to be_an_instance_of(desc.output)
       end
+
+      context 'with metadata' do
+        it 'makes an RPC call' do
+          expect(subject.public_send(rpc, desc.input.new, metadata: { 'foo' => 'bar' }))
+            .to be_an_instance_of(desc.output)
+        end
+      end
+
+      context 'with timeout' do
+        it 'makes an RPC call' do
+          expect(subject.public_send(rpc, desc.input.new, timeout: 5_000))
+            .to be_an_instance_of(desc.output)
+        end
+      end
     end
   end
 

--- a/spec/unit/temporal/client/workflow_handle_spec.rb
+++ b/spec/unit/temporal/client/workflow_handle_spec.rb
@@ -19,6 +19,7 @@ describe Temporal::Client::WorkflowHandle do
   let(:run_id) { SecureRandom.uuid }
   let(:result_run_id) { SecureRandom.uuid }
   let(:first_execution_run_id) { SecureRandom.uuid }
+  let(:rpc_params) { { rpc_metadata: { 'foo' => 'bar' }, rpc_timeout: 5_000 } }
 
   describe '#result' do
     before { allow(client_impl).to receive(:await_workflow_result).and_return(42) }
@@ -27,7 +28,9 @@ describe Temporal::Client::WorkflowHandle do
       result = subject.result
 
       expect(result).to eq(42)
-      expect(client_impl).to have_received(:await_workflow_result).with(id, result_run_id, true)
+      expect(client_impl)
+        .to have_received(:await_workflow_result)
+        .with(id, result_run_id, true, {}, nil)
     end
   end
 
@@ -44,6 +47,19 @@ describe Temporal::Client::WorkflowHandle do
         expect(input).to be_a(Temporal::Interceptor::Client::DescribeWorkflowInput)
         expect(input.id).to eq(id)
         expect(input.run_id).to eq(run_id)
+        expect(input.rpc_metadata).to eq({})
+        expect(input.rpc_timeout).to eq(nil)
+      end
+    end
+
+    context 'with RPC params' do
+      it 'passes RPC params to the client implementation' do
+        subject.describe(**rpc_params)
+
+        expect(client_impl).to have_received(:describe_workflow) do |input|
+          expect(input.rpc_metadata).to eq(rpc_params[:rpc_metadata])
+          expect(input.rpc_timeout).to eq(rpc_params[:rpc_timeout])
+        end
       end
     end
   end
@@ -60,6 +76,8 @@ describe Temporal::Client::WorkflowHandle do
         expect(input.run_id).to eq(run_id)
         expect(input.first_execution_run_id).to eq(first_execution_run_id)
         expect(input.reason).to eq('test reason')
+        expect(input.rpc_metadata).to eq({})
+        expect(input.rpc_timeout).to eq(nil)
       end
     end
 
@@ -69,6 +87,17 @@ describe Temporal::Client::WorkflowHandle do
 
         expect(client_impl).to have_received(:cancel_workflow) do |input|
           expect(input.reason).to eq(nil)
+        end
+      end
+    end
+
+    context 'with RPC params' do
+      it 'passes RPC params to the client implementation' do
+        subject.cancel(**rpc_params)
+
+        expect(client_impl).to have_received(:cancel_workflow) do |input|
+          expect(input.rpc_metadata).to eq(rpc_params[:rpc_metadata])
+          expect(input.rpc_timeout).to eq(rpc_params[:rpc_timeout])
         end
       end
     end
@@ -89,6 +118,8 @@ describe Temporal::Client::WorkflowHandle do
         expect(input.args).to eq([1, 2, 3])
         expect(input.reject_condition).to eq(Temporal::Workflow::QueryRejectCondition::NONE)
         expect(input.headers).to eq({})
+        expect(input.rpc_metadata).to eq({})
+        expect(input.rpc_timeout).to eq(nil)
       end
     end
 
@@ -100,6 +131,8 @@ describe Temporal::Client::WorkflowHandle do
         expect(client_impl).to have_received(:query_workflow) do |input|
           expect(input.query).to eq('test query')
           expect(input.args).to eq([])
+          expect(input.rpc_metadata).to eq({})
+          expect(input.rpc_timeout).to eq(nil)
         end
       end
     end
@@ -116,6 +149,19 @@ describe Temporal::Client::WorkflowHandle do
           expect(input.query).to eq('test query')
           expect(input.args).to eq([])
           expect(input.reject_condition).to eq(Temporal::Workflow::QueryRejectCondition::NOT_OPEN)
+          expect(input.rpc_metadata).to eq({})
+          expect(input.rpc_timeout).to eq(nil)
+        end
+      end
+    end
+
+    context 'with RPC params' do
+      it 'passes RPC params to the client implementation' do
+        subject.query('test query', **rpc_params)
+
+        expect(client_impl).to have_received(:query_workflow) do |input|
+          expect(input.rpc_metadata).to eq(rpc_params[:rpc_metadata])
+          expect(input.rpc_timeout).to eq(rpc_params[:rpc_timeout])
         end
       end
     end
@@ -134,6 +180,8 @@ describe Temporal::Client::WorkflowHandle do
         expect(input.signal).to eq('test signal')
         expect(input.args).to eq([1, 2, 3])
         expect(input.headers).to eq({})
+        expect(input.rpc_metadata).to eq({})
+        expect(input.rpc_timeout).to eq(nil)
       end
     end
 
@@ -144,6 +192,19 @@ describe Temporal::Client::WorkflowHandle do
         expect(client_impl).to have_received(:signal_workflow) do |input|
           expect(input.signal).to eq('test signal')
           expect(input.args).to eq([])
+          expect(input.rpc_metadata).to eq({})
+          expect(input.rpc_timeout).to eq(nil)
+        end
+      end
+    end
+
+    context 'with RPC params' do
+      it 'passes RPC params to the client implementation' do
+        subject.signal('test signal', **rpc_params)
+
+        expect(client_impl).to have_received(:signal_workflow) do |input|
+          expect(input.rpc_metadata).to eq(rpc_params[:rpc_metadata])
+          expect(input.rpc_timeout).to eq(rpc_params[:rpc_timeout])
         end
       end
     end
@@ -162,6 +223,8 @@ describe Temporal::Client::WorkflowHandle do
         expect(input.first_execution_run_id).to eq(first_execution_run_id)
         expect(input.reason).to eq('test reason')
         expect(input.args).to eq([1, 2, 3])
+        expect(input.rpc_metadata).to eq({})
+        expect(input.rpc_timeout).to eq(nil)
       end
     end
 
@@ -172,6 +235,19 @@ describe Temporal::Client::WorkflowHandle do
         expect(client_impl).to have_received(:terminate_workflow) do |input|
           expect(input.reason).to eq(nil)
           expect(input.args).to eq(nil)
+          expect(input.rpc_metadata).to eq({})
+          expect(input.rpc_timeout).to eq(nil)
+        end
+      end
+    end
+
+    context 'with RPC params' do
+      it 'passes RPC params to the client implementation' do
+        subject.terminate(**rpc_params)
+
+        expect(client_impl).to have_received(:terminate_workflow) do |input|
+          expect(input.rpc_metadata).to eq(rpc_params[:rpc_metadata])
+          expect(input.rpc_timeout).to eq(rpc_params[:rpc_timeout])
         end
       end
     end

--- a/spec/unit/temporal/client_spec.rb
+++ b/spec/unit/temporal/client_spec.rb
@@ -62,6 +62,8 @@ describe Temporal::Client do
         expect(input.headers).to eq({})
         expect(input.start_signal).to eq(nil)
         expect(input.start_signal_args).to eq([])
+        expect(input.rpc_metadata).to eq({})
+        expect(input.rpc_timeout).to eq(nil)
       end
     end
 
@@ -83,6 +85,8 @@ describe Temporal::Client do
         search_attributes: { 'search_attributes' => 'test' },
         start_signal: 'test-signal',
         start_signal_args: [42],
+        rpc_metadata: { 'foo' => 'bar' },
+        rpc_timeout: 5_000,
       )
 
       expect(result).to eq(handle)
@@ -103,6 +107,8 @@ describe Temporal::Client do
         expect(input.headers).to eq({})
         expect(input.start_signal).to eq('test-signal')
         expect(input.start_signal_args).to eq([42])
+        expect(input.rpc_metadata).to eq({ 'foo' => 'bar' })
+        expect(input.rpc_timeout).to eq(5_000)
       end
     end
   end


### PR DESCRIPTION
## What was changed
This is a follow up to the #39 adding support for RPC metadata and timeouts to be passed via `Client` and `WorkflowHandle`