### PR TITLE
[Feature] Allow configuring payload converter, codecs and failure converter

### DIFF
--- a/lib/temporal/data_converter.rb
+++ b/lib/temporal/data_converter.rb
@@ -1,17 +1,11 @@
 require 'temporal/api/common/v1/message_pb'
 require 'temporal/errors'
-require 'temporal/payload_converter'
-require 'temporal/failure_converter'
 
 module Temporal
   class DataConverter
     class MissingPayload < Temporal::Error; end
 
-    def initialize(
-      payload_converter: Temporal::PayloadConverter::DEFAULT,
-      payload_codecs: [],
-      failure_converter: Temporal::FailureConverter::DEFAULT
-    )
+    def initialize(payload_converter:, payload_codecs:, failure_converter:)
       @payload_converter = payload_converter
       @payload_codecs = payload_codecs
       @failure_converter = failure_converter

--- a/sig/temporal/client.rbs
+++ b/sig/temporal/client.rbs
@@ -5,7 +5,10 @@ module Temporal
     def initialize: (
       Temporal::Connection connection,
       String | Symbol namespace,
-      ?interceptors: Array[Temporal::Interceptor::Client]
+      ?interceptors: Array[Temporal::Interceptor::Client],
+      ?payload_converter: Temporal::PayloadConverter::_PayloadConverter,
+      ?payload_codecs: Array[Temporal::PayloadCodec::_PayloadCodec],
+      ?failure_converter: Temporal::FailureConverter::_FailureConverter
     ) -> void
     def start_workflow: (
       String workflow,

--- a/sig/temporal/data_converter.rbs
+++ b/sig/temporal/data_converter.rbs
@@ -4,9 +4,9 @@ module Temporal
     end
 
     def initialize: (
-      ?payload_converter: Temporal::PayloadConverter::_PayloadConverter,
-      ?payload_codecs: Array[Temporal::PayloadCodec::_PayloadCodec],
-      ?failure_converter: Temporal::FailureConverter::_FailureConverter,
+      payload_converter: Temporal::PayloadConverter::_PayloadConverter,
+      payload_codecs: Array[Temporal::PayloadCodec::_PayloadCodec],
+      failure_converter: Temporal::FailureConverter::_FailureConverter,
     ) -> void
     def to_payloads: (Array[untyped]? data) -> Temporal::Api::Common::V1::Payloads?
     def to_payload_map: (Hash[String | Symbol, untyped] data) -> Hash[String, Temporal::Api::Common::V1::Payload]

--- a/spec/unit/temporal/client/implementation_spec.rb
+++ b/spec/unit/temporal/client/implementation_spec.rb
@@ -6,13 +6,21 @@ require 'temporal/client/workflow_handle'
 require 'temporal/connection'
 require 'temporal/data_converter'
 require 'temporal/errors'
+require 'temporal/failure_converter'
+require 'temporal/payload_converter'
 
 describe Temporal::Client::Implementation do
   subject { described_class.new(connection, namespace, converter, interceptors) }
 
   let(:connection) { instance_double(Temporal::Connection) }
   let(:namespace) { 'test-namespace' }
-  let(:converter) { Temporal::DataConverter.new }
+  let(:converter) do
+    Temporal::DataConverter.new(
+      payload_converter: Temporal::PayloadConverter::DEFAULT,
+      payload_codecs: [],
+      failure_converter: Temporal::FailureConverter::DEFAULT,
+    )
+  end
   let(:interceptors) { [] }
   let(:id) { SecureRandom.uuid }
   let(:run_id) { SecureRandom.uuid }

--- a/spec/unit/temporal/workflow/execution_info_spec.rb
+++ b/spec/unit/temporal/workflow/execution_info_spec.rb
@@ -1,13 +1,21 @@
 require 'securerandom'
 require 'temporal/api/workflowservice/v1/request_response_pb'
 require 'temporal/data_converter'
+require 'temporal/failure_converter'
+require 'temporal/payload_converter'
 require 'temporal/workflow/execution_info'
 require 'temporal/workflow/execution_status'
 
 describe Temporal::Workflow::ExecutionInfo do
   subject { described_class.from_raw(proto, converter) }
 
-  let(:converter) { Temporal::DataConverter.new }
+  let(:converter) do
+    Temporal::DataConverter.new(
+      payload_converter: Temporal::PayloadConverter::DEFAULT,
+      payload_codecs: [],
+      failure_converter: Temporal::FailureConverter::DEFAULT,
+    )
+  end
   let(:id) { SecureRandom.uuid }
   let(:run_id) { SecureRandom.uuid }
   let(:time_now) { Time.now }


### PR DESCRIPTION
## What was changed
This PR adds the option for the user to provide custom Payload Convert, Payload Codecs and Failure Converter to the Client.

## Checklist

1. Closes #58 

2. How was this tested:
Tests added/updated

3. Any docs updates needed?
Yes, inline docs updated
