### PR TITLE
[CI] Enable matrix CI runs different Ruby versions and OSs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,21 @@ on: # rebuild any PRs and main branch changes
 jobs:
   # Lint and test the project
   build-lint-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby:
+          - 2.7.6
+          - 3.0.4
+          - 3.1.2
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
+      - name: Print build information
+        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}, ruby: ${{ matrix.ruby }}'
       - uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -21,7 +34,7 @@ jobs:
       - uses: arduino/setup-protoc@v1
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       # Needed to compile go test server and worker
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.19"
-      - uses: Swatinem/rust-cache@v1
-        with:
-          working-directory: bridge
+      # - uses: Swatinem/rust-cache@v1
+      #   with:
+      #     working-directory: bridge
       - name: Setup Golang test server caches
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   # Lint and test the project
   build-lint-test:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ruby:
           - 2.7.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           go-version: "1.19"
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: bridge
+          workspaces: bridge
       - name: Setup Golang test server caches
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.19"
-      # - uses: Swatinem/rust-cache@v1
-      #   with:
-      #     working-directory: bridge
+      - uses: Swatinem/rust-cache@v2
+        with:
+          working-directory: bridge
       - name: Setup Golang test server caches
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           toolchain: stable
       - uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Print build information

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: bridge
+          key: ${{ matrix.os }}-${{ matrix.ruby }}
       - name: Setup Golang test server caches
         uses: actions/cache@v3
         with:

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -204,7 +204,7 @@ describe Temporal::Client do
       input = { action_signal: 'test-signal' }
       handle = subject.start_workflow(workflow, input, id: id, task_queue: task_queue)
 
-      handle.signal('test-signal', { result: { value: 'test signal arg' } })
+      handle.signal('test-signal', { result: { value: 'test signal arg' } }, {})
 
       expect(handle.result).to eq('test signal arg')
     end

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -204,7 +204,8 @@ describe Temporal::Client do
       input = { action_signal: 'test-signal' }
       handle = subject.start_workflow(workflow, input, id: id, task_queue: task_queue)
 
-      handle.signal('test-signal', { result: { value: 'test signal arg' } }, {})
+      # Empty hash as the last arg is required in Ruby 2.7 to distinguish hash argument from kwargs
+      handle.signal('test-signal', { result: { value: 'test signal arg' } }, **{})
 
       expect(handle.result).to eq('test signal arg')
     end


### PR DESCRIPTION
## What was changed
Enable matrix CI runs for ruby 2.7, 3.0 and 3.1 on ubuntu and macos (windows will be added later)

## Why?
Preparing for the first public release of the Client
