### PR TITLE
[Fix] Specs failing to shutdown the mock server properly

### DIFF
--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -4,6 +4,7 @@ require 'temporal/connection'
 require 'temporal/error/failure'
 require 'temporal/error/workflow_failure'
 require 'temporal/interceptor/client'
+require 'support/helpers/test_rpc'
 
 class TestInterceptor < Temporal::Interceptor::Client
   attr_reader :results
@@ -57,18 +58,9 @@ describe Temporal::Client do
   let(:id) { SecureRandom.uuid }
   let(:workflow) { 'kitchen_sink' }
 
-  def wait_for_server(url)
-    10.times do
-      Temporal::Connection.new("http://#{url}")
-      break
-    rescue Temporal::Bridge::Error
-      sleep(0.5) # delay before retrying
-    end
-  end
-
   before(:all) do
     @server_pid = fork { exec("#{support_path}/go_server/main #{port} #{namespace}") }
-    wait_for_server(url)
+    Helpers::TestRPC.wait("http://#{url}", 10, 0.5)
 
     @worker_pid = fork { exec("#{support_path}/go_worker/main #{url} #{namespace} #{task_queue}") }
   end

--- a/spec/integration/connection_spec.rb
+++ b/spec/integration/connection_spec.rb
@@ -11,7 +11,7 @@ describe Temporal::Connection do
   # TODO: For some reason the Bridge doesn't play well with the server in the same
   #       process throwing SegFaults in cases. Needs further investigation
   before(:all) do
-    @pid = fork { exec("bundle exec ruby spec/support/mock_server.rb") }
+    @pid = fork { exec('bundle exec ruby spec/support/mock_server.rb') }
     Helpers::TestRPC.wait("http://#{mock_address}", 10)
   end
   after(:all) { Process.kill('QUIT', @pid) }

--- a/spec/integration/connection_spec.rb
+++ b/spec/integration/connection_spec.rb
@@ -11,7 +11,7 @@ describe Temporal::Connection do
   # TODO: For some reason the Bridge doesn't play well with the server in the same
   #       process throwing SegFaults in cases. Needs further investigation
   before(:all) do
-    @pid = fork { MockServer.run(mock_address) }
+    @pid = fork { exec("bundle exec ruby spec/support/mock_server.rb") }
     Helpers::TestRPC.wait("http://#{mock_address}", 10)
   end
   after(:all) { Process.kill('QUIT', @pid) }

--- a/spec/support/helpers/test_rpc.rb
+++ b/spec/support/helpers/test_rpc.rb
@@ -1,0 +1,19 @@
+require 'temporal/connection'
+
+module Helpers
+  module TestRPC
+    def self.wait(address, max_attempts, interval = 1)
+      request = Temporal::Api::WorkflowService::V1::GetSystemInfoRequest.new
+      max_attempts.times do |i|
+        connection = Temporal::Connection.new(address)
+        connection.get_system_info(request)
+        break
+      rescue StandardError => e
+        puts "Error connecting to a server: #{e}. Attempt #{i + 1} / #{max_attempts}"
+        raise if i + 1 == max_attempts # re-raise upon exhausting attempts
+
+        sleep interval
+      end
+    end
+  end
+end

--- a/spec/support/mock_server.rb
+++ b/spec/support/mock_server.rb
@@ -1,4 +1,4 @@
-if __FILE__ == $0
+if __FILE__ == $PROGRAM_NAME
   $LOAD_PATH << File.expand_path('..', File.dirname(__FILE__))
   $LOAD_PATH << File.expand_path('../../lib/gen', File.dirname(__FILE__))
 end
@@ -22,6 +22,6 @@ class MockServer < Temporal::Api::WorkflowService::V1::WorkflowService::Service
   end
 end
 
-if __FILE__ == $0
+if __FILE__ == $PROGRAM_NAME
   MockServer.run('0.0.0.0:4444')
 end

--- a/spec/support/mock_server.rb
+++ b/spec/support/mock_server.rb
@@ -1,3 +1,8 @@
+if __FILE__ == $0
+  $LOAD_PATH << File.expand_path('..', File.dirname(__FILE__))
+  $LOAD_PATH << File.expand_path('../../lib/gen', File.dirname(__FILE__))
+end
+
 require 'grpc'
 require 'support/grpc/temporal/api/workflowservice/v1/service_services_pb'
 
@@ -15,4 +20,8 @@ class MockServer < Temporal::Api::WorkflowService::V1::WorkflowService::Service
       desc.output.new # return an empty response
     end
   end
+end
+
+if __FILE__ == $0
+  MockServer.run('0.0.0.0:4444')
 end


### PR DESCRIPTION
## What was changed
This is a fix that spawns the mock server independently of the spec process. For some reason forking a mock server creates some resource contention in `tokio` that often leads to failing specs