### PR TITLE
[Fix] DataConverter improvements

### DIFF
--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -20,14 +20,8 @@ module Temporal
     # @param namespace [String] Namespace to use for client calls.
     # @param interceptors [Array<Temporal::Interceptor::Client>] List of interceptors for
     #   intercepting client calls. Executed in their original order.
-    # @param payload_converter [Temporal::PayloadConverter::Base] A custom payload converter for
-    #   converting Ruby values to/from protos. See {Temporal::PayloadConverter::Base} for the
-    #   interface definition.
-    # @param payload_codecs [Array<Temporal::PayloadCodec::Base>] A list of payload codecs to
-    #   transform payload protos. See {Temporal::PayloadCodec::Base} for the interface definition.
-    # @param failure_converter [Temporal::FailureConverter::Base] A custom failure converter for
-    #   converting Exceptions to/from protos. See {Temporal::FailureConverter::Base} for the
-    #   interface definition.
+    # @param data_converter [Temporal::DataConverter] Data converter to use for all data conversions
+    #   to/from payloads.
     #
     # @see https://docs.temporal.io/concepts/what-is-a-data-converter for more information on
     #   payload converters and codecs.
@@ -35,16 +29,9 @@ module Temporal
       connection,
       namespace,
       interceptors: [],
-      payload_converter: Temporal::PayloadConverter::DEFAULT,
-      payload_codecs: [],
-      failure_converter: Temporal::FailureConverter::DEFAULT
+      data_converter: Temporal::DataConverter.new
     )
       @namespace = namespace
-      data_converter = DataConverter.new(
-        payload_converter: payload_converter,
-        payload_codecs: payload_codecs,
-        failure_converter: failure_converter,
-      )
       @implementation = Client::Implementation.new(connection, namespace, data_converter, interceptors)
     end
 

--- a/lib/temporal/data_converter.rb
+++ b/lib/temporal/data_converter.rb
@@ -28,11 +28,7 @@ module Temporal
 
     def to_payload_map(data)
       data.to_h do |key, value|
-        payload = value_to_payload(value)
-        encoded_payload = encode([payload]).first
-        raise MissingPayload, 'Payload Codecs returned no payloads' unless encoded_payload
-
-        [key.to_s, encoded_payload]
+        [key.to_s, to_payload(value)]
       end
     end
 
@@ -59,14 +55,11 @@ module Temporal
       return unless payload_map
 
       # Protobuf's Hash isn't compatible with the native Hash, ignore rubocop here
-      # rubocop:disable Style/MapToHash
+      # rubocop:disable Style/MapToHash, Style/HashTransformValues
       payload_map.map do |key, payload|
-        decoded_payload = decode([payload]).first
-        raise MissingPayload, 'Payload Codecs returned no payloads' unless decoded_payload
-
-        [key, payload_to_value(decoded_payload)]
+        [key, from_payload(payload)]
       end.to_h
-      # rubocop:enable Style/MapToHash
+      # rubocop:enable Style/MapToHash, Style/HashTransformValues
     end
 
     def from_failure(failure)

--- a/lib/temporal/data_converter.rb
+++ b/lib/temporal/data_converter.rb
@@ -1,11 +1,30 @@
 require 'temporal/api/common/v1/message_pb'
 require 'temporal/errors'
+require 'temporal/failure_converter'
+require 'temporal/payload_converter'
 
 module Temporal
   class DataConverter
     class MissingPayload < Temporal::Error; end
 
-    def initialize(payload_converter:, payload_codecs:, failure_converter:)
+    # Initialize a new data converter with optional payload converter, codecs and failure converter.
+    #
+    # @param payload_converter [Temporal::PayloadConverter::Base] A custom payload converter for
+    #   converting Ruby values to/from protos. See {Temporal::PayloadConverter::Base} for the
+    #   interface definition.
+    # @param payload_codecs [Array<Temporal::PayloadCodec::Base>] A list of payload codecs to
+    #   transform payload protos. See {Temporal::PayloadCodec::Base} for the interface definition.
+    # @param failure_converter [Temporal::FailureConverter::Base] A custom failure converter for
+    #   converting Exceptions to/from protos. See {Temporal::FailureConverter::Base} for the
+    #   interface definition.
+    #
+    # @see https://docs.temporal.io/concepts/what-is-a-data-converter for more information on
+    #   payload converters and codecs.
+    def initialize(
+      payload_converter: Temporal::PayloadConverter::DEFAULT,
+      payload_codecs: [],
+      failure_converter: Temporal::FailureConverter::DEFAULT
+    )
       @payload_converter = payload_converter
       @payload_codecs = payload_codecs
       @failure_converter = failure_converter

--- a/lib/temporal/data_converter.rb
+++ b/lib/temporal/data_converter.rb
@@ -12,7 +12,11 @@ module Temporal
     end
 
     def to_payload(value)
-      value_to_payload(value)
+      payload = value_to_payload(value)
+      encoded_payload = encode([payload]).first
+      raise MissingPayload, 'Payload Codecs returned no payloads' unless encoded_payload
+
+      encoded_payload
     end
 
     def to_payloads(data)
@@ -38,7 +42,10 @@ module Temporal
     end
 
     def from_payload(payload)
-      payload_to_value(payload)
+      decoded_payload = decode([payload]).first
+      raise MissingPayload, 'Payload Codecs returned no payloads' unless decoded_payload
+
+      payload_to_value(decoded_payload)
     end
 
     def from_payloads(payloads)

--- a/lib/temporal/failure_converter.rb
+++ b/lib/temporal/failure_converter.rb
@@ -1,5 +1,4 @@
 require 'temporal/failure_converter/basic'
-require 'temporal/payload_converter'
 
 module Temporal
   module FailureConverter

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -1,8 +1,6 @@
 require 'async'
 require 'temporal/bridge'
 require 'temporal/data_converter'
-require 'temporal/failure_converter'
-require 'temporal/payload_converter'
 require 'temporal/runtime'
 require 'temporal/worker/activity'
 require 'temporal/worker/thread_pool_executor'
@@ -14,9 +12,7 @@ module Temporal
       connection,
       namespace,
       task_queue,
-      payload_converter: Temporal::PayloadConverter::DEFAULT,
-      payload_codecs: [],
-      failure_converter: Temporal::FailureConverter::DEFAULT,
+      data_converter: Temporal::DataConverter.new,
       activity_executor: nil,
       max_concurrent_activities: 100
     )
@@ -24,11 +20,6 @@ module Temporal
       @mutex = Mutex.new
       @runtime = Temporal::Runtime.instance
       activity_executor ||= ThreadPoolExecutor.new(max_concurrent_activities)
-      data_converter = DataConverter.new(
-        payload_converter: payload_converter,
-        payload_codecs: payload_codecs,
-        failure_converter: failure_converter,
-      )
       core_worker = Temporal::Bridge::Worker.create(
         @runtime.core_runtime,
         connection.core_connection,

--- a/sig/temporal/client.rbs
+++ b/sig/temporal/client.rbs
@@ -6,9 +6,7 @@ module Temporal
       Temporal::Connection connection,
       String | Symbol namespace,
       ?interceptors: Array[Temporal::Interceptor::Client],
-      ?payload_converter: Temporal::PayloadConverter::_PayloadConverter,
-      ?payload_codecs: Array[Temporal::PayloadCodec::_PayloadCodec],
-      ?failure_converter: Temporal::FailureConverter::_FailureConverter
+      ?data_converter: Temporal::DataConverter
     ) -> void
     def start_workflow: (
       String workflow,

--- a/sig/temporal/data_converter.rbs
+++ b/sig/temporal/data_converter.rbs
@@ -23,6 +23,8 @@ module Temporal
     attr_reader payload_codecs: Array[Temporal::PayloadCodec::_PayloadCodec]
     attr_reader failure_converter: Temporal::FailureConverter::_FailureConverter
 
+    def value_to_payload: (untyped value) -> Temporal::Api::Common::V1::Payload
+    def payload_to_value: (Temporal::Api::Common::V1::Payload payload) -> untyped
     def encode: (Array[Temporal::Api::Common::V1::Payload]?) -> Array[Temporal::Api::Common::V1::Payload]
     def decode: (Array[Temporal::Api::Common::V1::Payload]?) -> Array[Temporal::Api::Common::V1::Payload]
     def encode_failure: (Temporal::Api::Failure::V1::Failure failure) -> Temporal::Api::Failure::V1::Failure

--- a/sig/temporal/data_converter.rbs
+++ b/sig/temporal/data_converter.rbs
@@ -4,9 +4,9 @@ module Temporal
     end
 
     def initialize: (
-      payload_converter: Temporal::PayloadConverter::_PayloadConverter,
-      payload_codecs: Array[Temporal::PayloadCodec::_PayloadCodec],
-      failure_converter: Temporal::FailureConverter::_FailureConverter,
+      ?payload_converter: Temporal::PayloadConverter::_PayloadConverter,
+      ?payload_codecs: Array[Temporal::PayloadCodec::_PayloadCodec],
+      ?failure_converter: Temporal::FailureConverter::_FailureConverter,
     ) -> void
     def to_payload: (untyped data) -> Temporal::Api::Common::V1::Payload
     def to_payloads: (Array[untyped]? data) -> Temporal::Api::Common::V1::Payloads?

--- a/sig/temporal/worker.rbs
+++ b/sig/temporal/worker.rbs
@@ -6,9 +6,7 @@ module Temporal
       Temporal::Connection connection,
       String namespace,
       String task_queue,
-      ?payload_converter: Temporal::PayloadConverter::_PayloadConverter,
-      ?payload_codecs: Array[Temporal::PayloadCodec::_PayloadCodec],
-      ?failure_converter: Temporal::FailureConverter::_FailureConverter,
+      ?data_converter: Temporal::DataConverter,
       ?activity_executor: Temporal::Worker::_ActivityExecutor?,
       ?max_concurrent_activities: Integer
     ) -> void

--- a/spec/unit/temporal/client_spec.rb
+++ b/spec/unit/temporal/client_spec.rb
@@ -4,9 +4,6 @@ require 'temporal/client/implementation'
 require 'temporal/client/workflow_handle'
 require 'temporal/connection'
 require 'temporal/data_converter'
-require 'temporal/failure_converter'
-require 'temporal/payload_codec/base'
-require 'temporal/payload_converter'
 require 'temporal/retry_policy'
 
 describe Temporal::Client do
@@ -25,57 +22,6 @@ describe Temporal::Client do
       .to receive(:new)
       .with(connection, namespace, an_instance_of(Temporal::DataConverter), interceptors)
       .and_return(client_impl)
-  end
-
-  describe '#initialize' do
-    before { allow(Temporal::DataConverter).to receive(:new).and_call_original }
-
-    context 'with a custom payload converter' do
-      let(:payload_converter) { instance_double(Temporal::PayloadConverter::Base) }
-
-      it 'passes it to a data converter' do
-        described_class.new(connection, namespace, payload_converter: payload_converter)
-
-        expect(Temporal::DataConverter).to have_received(:new).with(
-          payload_converter: payload_converter,
-          payload_codecs: [],
-          failure_converter: Temporal::FailureConverter::DEFAULT,
-        )
-      end
-    end
-
-    context 'with custom payload codecs' do
-      let(:payload_codecs) do
-        [
-          instance_double(Temporal::PayloadCodec::Base),
-          instance_double(Temporal::PayloadCodec::Base),
-        ]
-      end
-
-      it 'passes it to a data converter' do
-        described_class.new(connection, namespace, payload_codecs: payload_codecs)
-
-        expect(Temporal::DataConverter).to have_received(:new).with(
-          payload_converter: Temporal::PayloadConverter::DEFAULT,
-          payload_codecs: payload_codecs,
-          failure_converter: Temporal::FailureConverter::DEFAULT,
-        )
-      end
-    end
-
-    context 'with a custom failure converter' do
-      let(:failure_converter) { instance_double(Temporal::FailureConverter::Base) }
-
-      it 'passes it to a data converter' do
-        described_class.new(connection, namespace, failure_converter: failure_converter)
-
-        expect(Temporal::DataConverter).to have_received(:new).with(
-          payload_converter: Temporal::PayloadConverter::DEFAULT,
-          payload_codecs: [],
-          failure_converter: failure_converter,
-        )
-      end
-    end
   end
 
   describe '#start_workflow' do

--- a/spec/unit/temporal/data_converter_spec.rb
+++ b/spec/unit/temporal/data_converter_spec.rb
@@ -114,6 +114,17 @@ describe Temporal::DataConverter do
       expect(result).to be_a(Temporal::Api::Common::V1::Payload)
       expect(converter).to have_received(:to_payload).with('test')
     end
+
+    context 'with payload codecs' do
+      let(:codecs) { [test_codec] }
+
+      it 'encodes the payloads' do
+        result = subject.to_payload('test')
+
+        expect(result.metadata['encoding']).to eq(TestConcatenatingPayloadCodec::ENCODING)
+        expect(test_codec).to have_received(:encode).once
+      end
+    end
   end
 
   describe '#to_payloads' do
@@ -238,6 +249,19 @@ describe Temporal::DataConverter do
       expect(result).to eq('test')
       expect(converter).to have_received(:from_payload).with(json_payload)
     end
+
+    context 'with payload codecs' do
+      let(:codecs) { [test_codec] }
+
+      it 'decodes the payloads' do
+        payload = test_codec.encode([json_payload]).first
+
+        result = subject.from_payload(payload)
+
+        expect(result).to eq('test')
+        expect(test_codec).to have_received(:decode).once
+      end
+    end
   end
 
   describe '#from_payloads' do
@@ -257,7 +281,7 @@ describe Temporal::DataConverter do
     context 'with payload codecs' do
       let(:codecs) { [test_codec] }
 
-      it 'decodecs the payloads' do
+      it 'decodes the payloads' do
         mixed_payloads = test_codec.encode([json_payload, nil_payload])
         payloads = Temporal::Api::Common::V1::Payloads.new(payloads: mixed_payloads)
 
@@ -350,6 +374,11 @@ describe Temporal::DataConverter do
   end
 
   describe 'full circle' do
+    it 'converts a single value to payload and back' do
+      expect(subject.from_payload(subject.to_payload('test'))).to eq('test')
+      expect(subject.from_payload(subject.to_payload(nil))).to eq(nil)
+    end
+
     it 'converts values to payloads and back' do
       input = ['test', nil]
 
@@ -380,6 +409,11 @@ describe Temporal::DataConverter do
 
     context 'with payload codecs' do
       let(:codecs) { [test_codec, swap_codec] }
+
+      it 'converts a single value to payload and back' do
+        expect(subject.from_payload(subject.to_payload('test'))).to eq('test')
+        expect(subject.from_payload(subject.to_payload(nil))).to eq(nil)
+      end
 
       it 'converts values to payloads and back' do
         input = ['test', nil]

--- a/spec/unit/temporal/data_converter_spec.rb
+++ b/spec/unit/temporal/data_converter_spec.rb
@@ -124,6 +124,16 @@ describe Temporal::DataConverter do
         expect(result.metadata['encoding']).to eq(TestConcatenatingPayloadCodec::ENCODING)
         expect(test_codec).to have_received(:encode).once
       end
+
+      context 'with faulty codec' do
+        let(:codecs) { [faulty_codec] }
+
+        it 'raises' do
+          expect do
+            subject.to_payload('test')
+          end.to raise_error(described_class::MissingPayload, 'Payload Codecs returned no payloads')
+        end
+      end
     end
   end
 
@@ -251,15 +261,24 @@ describe Temporal::DataConverter do
     end
 
     context 'with payload codecs' do
+      let(:payload) { test_codec.encode([json_payload]).first }
       let(:codecs) { [test_codec] }
 
       it 'decodes the payloads' do
-        payload = test_codec.encode([json_payload]).first
-
         result = subject.from_payload(payload)
 
         expect(result).to eq('test')
         expect(test_codec).to have_received(:decode).once
+      end
+
+      context 'with faulty codec' do
+        let(:codecs) { [faulty_codec] }
+
+        it 'raises' do
+          expect do
+            subject.from_payload(payload)
+          end.to raise_error(described_class::MissingPayload, 'Payload Codecs returned no payloads')
+        end
       end
     end
   end

--- a/spec/unit/temporal/worker_spec.rb
+++ b/spec/unit/temporal/worker_spec.rb
@@ -1,10 +1,6 @@
 require 'support/helpers/test_rpc'
 require 'temporal/bridge'
 require 'temporal/connection'
-require 'temporal/data_converter'
-require 'temporal/failure_converter/base'
-require 'temporal/payload_codec/base'
-require 'temporal/payload_converter/base'
 require 'temporal/worker'
 require 'temporal/worker/activity'
 require 'temporal/worker/thread_pool_executor'
@@ -22,7 +18,6 @@ describe Temporal::Worker do
   describe '#initialize' do
     before do
       allow(Temporal::Worker::ThreadPoolExecutor).to receive(:new).and_call_original
-      allow(Temporal::DataConverter).to receive(:new).and_call_original
     end
 
     it 'initializes the core worker' do
@@ -44,53 +39,6 @@ describe Temporal::Worker do
         described_class.new(connection, namespace, task_queue, max_concurrent_activities: 42)
 
         expect(Temporal::Worker::ThreadPoolExecutor).to have_received(:new).with(42)
-      end
-    end
-
-    context 'with a custom payload converter' do
-      let(:payload_converter) { instance_double(Temporal::PayloadConverter::Base) }
-
-      it 'passes it to a data converter' do
-        described_class.new(connection, namespace, task_queue, payload_converter: payload_converter)
-
-        expect(Temporal::DataConverter).to have_received(:new).with(
-          payload_converter: payload_converter,
-          payload_codecs: [],
-          failure_converter: Temporal::FailureConverter::DEFAULT,
-        )
-      end
-    end
-
-    context 'with custom payload codecs' do
-      let(:payload_codecs) do
-        [
-          instance_double(Temporal::PayloadCodec::Base),
-          instance_double(Temporal::PayloadCodec::Base),
-        ]
-      end
-
-      it 'passes it to a data converter' do
-        described_class.new(connection, namespace, task_queue, payload_codecs: payload_codecs)
-
-        expect(Temporal::DataConverter).to have_received(:new).with(
-          payload_converter: Temporal::PayloadConverter::DEFAULT,
-          payload_codecs: payload_codecs,
-          failure_converter: Temporal::FailureConverter::DEFAULT,
-        )
-      end
-    end
-
-    context 'with a custom failure converter' do
-      let(:failure_converter) { instance_double(Temporal::FailureConverter::Base) }
-
-      it 'passes it to a data converter' do
-        described_class.new(connection, namespace, task_queue, failure_converter: failure_converter)
-
-        expect(Temporal::DataConverter).to have_received(:new).with(
-          payload_converter: Temporal::PayloadConverter::DEFAULT,
-          payload_codecs: [],
-          failure_converter: failure_converter,
-        )
       end
     end
   end


### PR DESCRIPTION
## What was changed
This PR modifies `Client` and `Worker` interfaces to accept a single `DataConverter` as an argument instead of individual pieces(payload converter, codecs and failure converter).

It also includes a bug fix for the `DataConverter#to_payload` and `DataConverter#from_payload` to use codecs.

## Why?
This is one of the follow-ups to #74 

## Checklist

1. Closes 
#75 
#77 

2. How was this tested:
Specs and RBS updated

3. Any docs updates needed?
Inline documentation has been updated
