### PR TITLE
Set client identity and build version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ different SDKs. A custom payload converter can be implemented to support these.
 Workers host workflows (coming soon) and/or activities. Here's how to run a worker:
 
 ```ruby
-require 'temporal'
+require 'temporalio'
 
 # Establish a gRPC connection to the server
-connection = Temporal::Connection.new('localhost:7233')
+connection = Temporalio::Connection.new('localhost:7233')
 
 # Initialize a new worker with your activities
-worker = Temporal::Worker.new(connection, 'my-namespace', 'my-task-queue', activities: [MyActivity])
+worker = Temporalio::Worker.new(connection, 'my-namespace', 'my-task-queue', activities: [MyActivity])
 
 # Occupy the thread by running the worker
 worker.run
@@ -125,7 +125,7 @@ which the worker will shut itself down:
 worker_1.run { sleep 5 }
 
 # Or shut the worker down when a workflow completes (very useful for running specs):
-client = Temporal::Client.new(connection, 'my-namespace')
+client = Temporalio::Client.new(connection, 'my-namespace')
 handle = client.start_workflow('MyWorkflow', 'some input', id: 'my-id', task_queue: 'my-task-queue')
 worker_2.run { handle.result }
 
@@ -135,34 +135,34 @@ Signal.trap('USR1') { stop_queue.close }
 worker_3.run { stop_queue.pop }
 ```
 
-You can also shut down a running worker by calling `Temporal::Worker#shutdown` from a separate
+You can also shut down a running worker by calling `Temporalio::Worker#shutdown` from a separate
 thread at any time.
 
 #### Running multiple workers
 
-In order to run multiple workers in the same thread you can use the `Temporal::Worker.run` method:
+In order to run multiple workers in the same thread you can use the `Temporalio::Worker.run` method:
 
 ```ruby
 # Initialize workers
-worker_1 = Temporal::Worker.new(connection, 'my-namespace-1', 'my-task-queue-1', activities: [MyActivity1, MyActivity2])
-worker_2 = Temporal::Worker.new(connection, 'my-namespace-2', 'my-task-queue-1', activities: [MyActivity3])
-worker_3 = Temporal::Worker.new(connection, 'my-namespace-1', 'my-task-queue-2', activities: [MyActivity4])
+worker_1 = Temporalio::Worker.new(connection, 'my-namespace-1', 'my-task-queue-1', activities: [MyActivity1, MyActivity2])
+worker_2 = Temporalio::Worker.new(connection, 'my-namespace-2', 'my-task-queue-1', activities: [MyActivity3])
+worker_3 = Temporalio::Worker.new(connection, 'my-namespace-1', 'my-task-queue-2', activities: [MyActivity4])
 
-Temporal::Worker.run(worker_1, worker_2, worker_3)
+Temporalio::Worker.run(worker_1, worker_2, worker_3)
 ```
 
-Please note that similar to `Temporal::Worker#run`, `Temporal::Worker.run` accepts a block that
+Please note that similar to `Temporalio::Worker#run`, `Temporalio::Worker.run` accepts a block that
 behaves the same way — the workers will be shut down when the block finishes.
 
 You can also configure your worker to listen on process signals to initiate a shutdown:
 
 ```ruby
-Temporal::Worker.run(worker_1, worker_2, worker_3, shutdown_signals: %w[INT TERM])
+Temporalio::Worker.run(worker_1, worker_2, worker_3, shutdown_signals: %w[INT TERM])
 ```
 
 #### Worker Shutdown
 
-The `Temporal::Worker#run` (as well as `Temporal::Worker#shutdown`) invocation will wait on all
+The `Temporalio::Worker#run` (as well as `Temporalio::Worker#shutdown`) invocation will wait on all
 activities to complete, so if a long-running activity does not at least respect cancellation, the
 shutdown may never complete.
 
@@ -175,10 +175,10 @@ Cancellation](#heartbeating-and-cancellation).
 
 #### Definition
 
-Activities are defined by subclassing `Temporal::Activity` class:
+Activities are defined by subclassing `Temporalio::Activity` class:
 
 ```ruby
-class SayHelloActivity < Temporal::Activity
+class SayHelloActivity < Temporalio::Activity
   # Optionally specify a custom activity name:
   #   (The class name `SayHelloActivity` will be used by default)
   activity_name 'say-hello'
@@ -197,7 +197,7 @@ Some things to note about activity definitions:
 
 #### Activity Context
 
-Activity classes have access to `Temporal::Activity::Context` via the `activity` method. Which
+Activity classes have access to `Temporalio::Activity::Context` via the `activity` method. Which
 itself provides access to useful methods, specifically:
 
 - `info` - Returns the immutable info of the currently running activity
@@ -217,12 +217,12 @@ persisted on the server for retrieval during activity retry. If an activity call
 return an array containing `123` and `456` on the next run.
 
 A cancellation is implemented using the `Thread#raise` method, which will raise a
-`Temporal::Error::ActivityCancelled` during the execution of an activity. This means that your code
+`Temporalio::Error::ActivityCancelled` during the execution of an activity. This means that your code
 might get interrupted at any point and never complete. In order to protect critical parts of your
 activities wrap them in `activity.shield`:
 
 ```ruby
-class ActivityWithCriticalLogic < Temporal::Activity
+class ActivityWithCriticalLogic < Temporalio::Activity
   def execute
     activity.shield do
       run_business_critical_logic_1
@@ -244,11 +244,11 @@ In case the entire activity is considered critical, you can mark it as `shielded
 cancellation requests altogether:
 
 ```ruby
-class CriticalActivity < Temporal::Activity
+class CriticalActivity < Temporalio::Activity
   shielded!
 
   def execute
-    ...
+    # ...
   end
 end
 ```

--- a/lib/temporalio.rb
+++ b/lib/temporalio.rb
@@ -9,4 +9,8 @@ require 'temporalio/version'
 require 'temporalio/worker'
 
 module Temporalio
+  def self.identity
+    # @type ivar @identity: String
+    @identity ||= "#{Process.pid}@#{Socket.gethostname} (Ruby SDK v#{VERSION})"
+  end
 end

--- a/lib/temporalio/client/implementation.rb
+++ b/lib/temporalio/client/implementation.rb
@@ -19,7 +19,7 @@ module Temporalio
         @namespace = namespace
         @converter = converter
         @interceptor_chain = Interceptor::Chain.new(interceptors)
-        @identity = "#{Process.pid}@#{Socket.gethostname} (Ruby SDK v#{VERSION})"
+        @identity = Temporalio.identity
       end
 
       def start_workflow(input)

--- a/lib/temporalio/connection.rb
+++ b/lib/temporalio/connection.rb
@@ -7,18 +7,21 @@ require 'uri'
 module Temporalio
   # A connection to the Temporal server.
   #
-  # This is used to instantiate a {Temporalio::Client}. But it also can be used for a direct
+  # This is used to instantiate a {Temporalio::Client} or a {Temporalio::Worker}. But it also can be used for a direct
   # interaction with the API.
   class Connection
+    CLIENT_NAME = 'temporal-ruby'.freeze
+
     # @api private
     attr_reader :core_connection
 
     # @param host [String] `host:port` for the Temporal server. For local development, this is
     #   often `"localhost:7233"`.
     def initialize(host)
-      url = parse_url(host)
       runtime = Temporalio::Runtime.instance
-      @core_connection = Temporalio::Bridge::Connection.connect(runtime.core_runtime, url)
+      @core_connection = Temporalio::Bridge::Connection.connect(
+        runtime.core_runtime, parse_url(host), Temporalio.identity, CLIENT_NAME, Temporalio::VERSION,
+      )
     end
 
     # @param request [Temporalio::Api::WorkflowService::V1::RegisterNamespaceRequest]

--- a/lib/temporalio/worker.rb
+++ b/lib/temporalio/worker.rb
@@ -64,7 +64,8 @@ module Temporalio
       data_converter: Temporalio::DataConverter.new,
       activity_executor: nil,
       max_concurrent_activities: 100,
-      graceful_shutdown_timeout: nil
+      graceful_shutdown_timeout: nil,
+      build_id: nil
     )
       # TODO: Add worker interceptors
       @started = false
@@ -77,6 +78,7 @@ module Temporalio
         connection.core_connection,
         namespace,
         task_queue,
+        build_id || Temporalio::VERSION, # TODO: Implement me
       )
       @activity_worker =
         unless activities.empty?

--- a/sig/temporalio.rbs
+++ b/sig/temporalio.rbs
@@ -1,2 +1,3 @@
 module Temporalio
+  def self.identity: () -> String
 end

--- a/sig/temporalio/bridge.rbs
+++ b/sig/temporalio/bridge.rbs
@@ -16,7 +16,7 @@ module Temporalio
     end
 
     class Connection
-      def self.connect: (Runtime, String) -> Temporalio::Bridge::Connection
+      def self.connect: (Runtime, String, String, String, String) -> Temporalio::Bridge::Connection
       def call: (Symbol, String, Hash[String, String], Integer?) -> String
     end
 
@@ -26,7 +26,7 @@ module Temporalio
     end
 
     class Worker
-      def self.create: (Runtime, Connection, String, String) -> Temporalio::Bridge::Worker
+      def self.create: (Runtime, Connection, String, String, String) -> Temporalio::Bridge::Worker
       def poll_activity_task: { (String?, Exception?) -> void } -> void
       def complete_activity_task: (String) { (nil, Exception?) -> void } -> void
       def record_activity_heartbeat: (String) -> void

--- a/sig/temporalio/connection.rbs
+++ b/sig/temporalio/connection.rbs
@@ -1,5 +1,6 @@
 module Temporalio
   class Connection
+    CLIENT_NAME: String
     attr_reader core_connection: Temporalio::Bridge::Connection
 
     def initialize: (String) -> void

--- a/sig/temporalio/worker.rbs
+++ b/sig/temporalio/worker.rbs
@@ -13,7 +13,8 @@ module Temporalio
       ?data_converter: Temporalio::DataConverter,
       ?activity_executor: Temporalio::Worker::_ActivityExecutor?,
       ?max_concurrent_activities: Integer,
-      ?graceful_shutdown_timeout: Integer?
+      ?graceful_shutdown_timeout: Integer?,
+      ?build_id: String?
     ) -> void
     def run: ?{ -> void } -> void
     def start: (?Temporalio::Worker::Runner? runner) -> void

--- a/spec/unit/temporalio/client/implementation_spec.rb
+++ b/spec/unit/temporalio/client/implementation_spec.rb
@@ -13,6 +13,7 @@ describe Temporalio::Client::Implementation do
   subject { described_class.new(connection, namespace, converter, interceptors) }
 
   let(:connection) { instance_double(Temporalio::Connection) }
+  let(:identity) { 'RSpec Ruby SDK Identity' }
   let(:namespace) { 'test-namespace' }
   let(:converter) do
     Temporalio::DataConverter.new(
@@ -32,6 +33,10 @@ describe Temporalio::Client::Implementation do
   end
   let(:metadata) { { 'foo' => 'bar' } }
   let(:timeout) { 5_000 }
+
+  before do
+    allow(Temporalio).to receive(:identity).and_return(identity)
+  end
 
   describe '#start_workflow' do
     let(:input) do
@@ -77,7 +82,7 @@ describe Temporalio::Client::Implementation do
 
       expect(connection).to have_received(:start_workflow_execution) do |request|
         expect(request).to be_a(Temporalio::Api::WorkflowService::V1::StartWorkflowExecutionRequest)
-        expect(request.identity).to include("(Ruby SDK v#{Temporalio::VERSION})")
+        expect(request.identity).to eq identity
         expect(request.request_id).to be_a(String)
         expect(request.workflow_type.name).to eq('TestWorkflow')
         expect(request.workflow_id).to eq(id)
@@ -448,7 +453,7 @@ describe Temporalio::Client::Implementation do
         expect(request.input.payloads[0].data).to eq('1')
         expect(request.input.payloads[1].data).to eq('2')
         expect(request.input.payloads[2].data).to eq('3')
-        expect(request.identity).to include("(Ruby SDK v#{Temporalio::VERSION})")
+        expect(request.identity).to eq identity
         expect(request.request_id).to be_a(String)
         expect(request.control).to eq('')
         expect(request.header).to eq(nil)
@@ -522,7 +527,7 @@ describe Temporalio::Client::Implementation do
         expect(request.namespace).to eq(namespace)
         expect(request.workflow_execution.workflow_id).to eq(id)
         expect(request.workflow_execution.run_id).to eq(run_id)
-        expect(request.identity).to include("(Ruby SDK v#{Temporalio::VERSION})")
+        expect(request.identity).to eq identity
         expect(request.request_id).to be_a(String)
         expect(request.first_execution_run_id).to eq(run_id)
         expect(request.reason).to eq('test reason')
@@ -587,7 +592,7 @@ describe Temporalio::Client::Implementation do
         expect(request.workflow_execution.run_id).to eq(run_id)
         expect(request.reason).to eq('test reason')
         expect(request.details).to eq(nil)
-        expect(request.identity).to include("(Ruby SDK v#{Temporalio::VERSION})")
+        expect(request.identity).to eq identity
         expect(request.first_execution_run_id).to eq(run_id)
       end
     end

--- a/spec/unit/temporalio/connection_spec.rb
+++ b/spec/unit/temporalio/connection_spec.rb
@@ -1,0 +1,25 @@
+require 'temporalio/connection'
+
+module Temporalio
+  RSpec.describe Connection do
+    let(:address) { 'localhost:1234' }
+    let(:core_connection) { instance_double(Bridge::Connection) }
+    subject { described_class.new(address) }
+
+    before do
+      allow(Bridge::Connection).to receive(:connect).with(
+        Runtime.instance.core_runtime, 'http://localhost:1234', Temporalio.identity, 'temporal-ruby', VERSION
+      ).and_return(core_connection)
+    end
+
+    it 'initializes correctly' do
+      expect(subject.core_connection).to eq core_connection
+    end
+
+    context 'when address format is not valid' do
+      let(:address) { 'https://localhost:1234' }
+
+      it { expect { subject }.to raise_error(Temporalio::Error, /Target host .* not supported/) }
+    end
+  end
+end

--- a/spec/unit/temporalio/worker_spec.rb
+++ b/spec/unit/temporalio/worker_spec.rb
@@ -59,7 +59,7 @@ describe Temporalio::Worker do
 
       expect(Temporalio::Bridge::Worker)
         .to have_received(:create)
-        .with(an_instance_of(Temporalio::Bridge::Runtime), core_connection, namespace, task_queue)
+        .with(an_instance_of(Temporalio::Bridge::Runtime), core_connection, namespace, task_queue, Temporalio::VERSION)
     end
 
     it 'uses a default executor with a default size' do
@@ -87,6 +87,25 @@ describe Temporalio::Worker do
         )
 
         expect(Temporalio::Worker::ThreadPoolExecutor).to have_received(:new).with(42)
+      end
+    end
+
+    context 'with build id' do
+      let(:build_id) { 'custom-build-id' }
+
+      it 'initializes the core worker' do
+        described_class.new(
+          connection,
+          namespace,
+          task_queue,
+          activities: activities,
+          build_id: build_id
+        )
+
+        expect(Temporalio::Bridge::Worker).to have_received(:create).with(
+          an_instance_of(Temporalio::Bridge::Runtime), core_connection,
+          namespace, task_queue, 'custom-build-id'
+        )
       end
     end
   end

--- a/spec/unit/temporalio_spec.rb
+++ b/spec/unit/temporalio_spec.rb
@@ -1,7 +1,8 @@
 require 'temporalio'
 
 describe Temporalio do
-  it 'is awesome!' do
-    Temporalio
+  describe 'identity' do
+    let(:expected) { "#{Process.pid}@#{Socket.gethostname} (Ruby SDK v#{Temporalio::VERSION})" }
+    it { expect(described_class.identity).to eq(expected) }
   end
 end


### PR DESCRIPTION
Extract identity, build id and client information from bridge to Ruby scope. 

NOTE: It would be great if we could pass the rust `xConfig` object directly but it looks like Rutie does not support it out of the box unless you implement a couple of interfaces. Other option would be to add https://github.com/deliveroo/rutie-serde but that would be another dependency on top.  

