### PR TITLE
[Feature] Activity worker shutdown

### DIFF
--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -28,7 +28,7 @@ fn wrap_worker_error(e: &WorkerError) -> AnyException {
         _ => "Temporal::Bridge::Error"
     };
 
-    AnyException::new(name, Some(&format!("[{:?}] {}", e, e.to_string())))
+    AnyException::new(name, Some(&format!("[{:?}] {}", e, e)))
 }
 
 fn wrap_bytes(bytes: Vec<u8>) -> RString {

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -207,6 +207,20 @@ methods!(
 
         NilClass::new()
     }
+
+    fn worker_initiate_shutdown() -> NilClass {
+        let worker = _rtself.get_data_mut(&*WORKER_WRAPPER);
+        worker.initiate_shutdown();
+
+        NilClass::new()
+    }
+
+    fn worker_shutdown() -> NilClass {
+        let worker = _rtself.get_data_mut(&*WORKER_WRAPPER);
+        worker.shutdown();
+
+        NilClass::new()
+    }
 );
 
 #[no_mangle]
@@ -229,6 +243,8 @@ pub extern "C" fn init_bridge() {
             klass.def("poll_activity_task", worker_poll_activity_task);
             klass.def("complete_activity_task", worker_complete_activity_task);
             klass.def("record_activity_heartbeat", worker_record_activity_heartbeat);
+            klass.def("initiate_shutdown", worker_initiate_shutdown);
+            klass.def("shutdown", worker_shutdown);
         });
     });
 }

--- a/bridge/src/worker.rs
+++ b/bridge/src/worker.rs
@@ -4,6 +4,7 @@ use prost::Message;
 use std::sync::Arc;
 use std::sync::mpsc::Sender;
 use temporal_sdk_core::api::{Worker as WorkerTrait};
+use temporal_sdk_core_api::errors::{PollActivityError};
 use temporal_sdk_core_api::worker::{WorkerConfigBuilder, WorkerConfigBuilderError};
 use temporal_sdk_core_protos::coresdk::{ActivityHeartbeat, ActivityTaskCompletion};
 use thiserror::Error;

--- a/lib/temporal/bridge.rb
+++ b/lib/temporal/bridge.rb
@@ -1,13 +1,11 @@
 require 'rutie'
+require 'temporal/bridge/error'
 
 # RBS: for some reason __dir__ has a type of (String | nil)
 BRIDGE_DIR = File.expand_path('..', __dir__ || '.')
 
 module Temporal
   module Bridge
-    # TODO: Expand this into more specific error types
-    class Error < StandardError; end
-
     Rutie
       .new(:bridge, lib_path: '', lib_suffix: 'so', lib_prefix: '')
       .init('init_bridge', BRIDGE_DIR)

--- a/lib/temporal/bridge/error.rb
+++ b/lib/temporal/bridge/error.rb
@@ -1,0 +1,7 @@
+module Temporal
+  module Bridge
+    class Error < StandardError
+      class WorkerShutdown < Error; end
+    end
+  end
+end

--- a/lib/temporal/worker/activity_worker.rb
+++ b/lib/temporal/worker/activity_worker.rb
@@ -17,6 +17,7 @@ module Temporal
       end
 
       def run(reactor)
+        # @type var async_tasks: Array[Async::Task]
         async_tasks = []
 
         loop do

--- a/lib/temporal/worker/activity_worker.rb
+++ b/lib/temporal/worker/activity_worker.rb
@@ -6,7 +6,6 @@ module Temporal
   class Worker
     class ActivityWorker
       def initialize(task_queue, core_worker, activities, converter, executor)
-        @running = false
         @task_queue = task_queue
         @worker = SyncWorker.new(core_worker)
         @activities = prepare_activities(activities)
@@ -14,36 +13,38 @@ module Temporal
         @executor = executor
         @running_activities = {}
         @cancellations = []
+        @shutdown_queue = Queue.new
       end
 
       def run(reactor)
-        @running = true
+        async_tasks = []
 
-        while running?
+        loop do
           activity_task = worker.poll_activity_task
-          reactor.async do
+          async_tasks << reactor.async do |async_task|
             if activity_task.start
               handle_start_activity(activity_task.task_token, activity_task.start)
             elsif activity_task.cancel
               handle_cancel_activity(activity_task.task_token, activity_task.cancel)
             end
+
+            async_tasks.delete(async_task)
           end
         end
+      rescue Temporal::Bridge::Error::WorkerShutdown
+        async_tasks.each(&:wait) # wait for all outstanding tasks to finish
+        shutdown_queue << nil
       end
 
       def shutdown
-        @running = false
+        shutdown_queue.pop
         executor.shutdown
-        # TODO: core worker shutdown implementation pending
       end
 
       private
 
-      attr_reader :task_queue, :worker, :activities, :converter, :executor, :running_activities, :cancellations
-
-      def running?
-        @running
-      end
+      attr_reader :task_queue, :worker, :activities, :converter, :executor, :running_activities,
+                  :cancellations, :shutdown_queue
 
       def prepare_activities(activities)
         activities.each_with_object({}) do |activity, result|

--- a/sig/async.rbs
+++ b/sig/async.rbs
@@ -6,7 +6,8 @@ module Async
   end
 
   class Task
-    def async: { (Async::Task) -> void } -> void
+    def async: { (Async::Task) -> void } -> Async::Task
+    def wait: -> void
   end
 end
 

--- a/sig/temporal/bridge.rbs
+++ b/sig/temporal/bridge.rbs
@@ -32,6 +32,8 @@ module Temporal
       def poll_activity_task: { (String?, Exception?) -> void } -> void
       def complete_activity_task: (String) { (nil, Exception?) -> void } -> void
       def record_activity_heartbeat: (String) -> void
+      def initiate_shutdown: -> void
+      def shutdown: -> void
     end
   end
 end

--- a/sig/temporal/bridge.rbs
+++ b/sig/temporal/bridge.rbs
@@ -29,8 +29,8 @@ module Temporal
 
     class Worker
       def self.create: (Runtime, Connection, String, String) -> Temporal::Bridge::Worker
-      def poll_activity_task: { (String) -> void } -> void
-      def complete_activity_task: (String) { (nil) -> void } -> void
+      def poll_activity_task: { (String?, Exception?) -> void } -> void
+      def complete_activity_task: (String) { (nil, Exception?) -> void } -> void
       def record_activity_heartbeat: (String) -> void
     end
   end

--- a/sig/temporal/bridge/error.rbs
+++ b/sig/temporal/bridge/error.rbs
@@ -1,0 +1,8 @@
+module Temporal
+  module Bridge
+    class Error < StandardError
+      class WorkerShutdown < Error
+      end
+    end
+  end
+end

--- a/sig/temporal/worker.rbs
+++ b/sig/temporal/worker.rbs
@@ -19,6 +19,7 @@ module Temporal
 
     attr_reader mutex: Thread::Mutex
     attr_reader runtime: Temporal::Runtime
+    attr_reader core_worker: Temporal::Bridge::Worker
     attr_reader activity_worker: Temporal::Worker::ActivityWorker?
     attr_reader workflow_worker: untyped
 

--- a/sig/temporal/worker/activity_worker.rbs
+++ b/sig/temporal/worker/activity_worker.rbs
@@ -10,7 +10,7 @@ module Temporal
         Temporal::DataConverter converter,
         Temporal::Worker::_ActivityExecutor executor
       ) -> void
-      def run: (Temporal::Worker::_Reactor reactor) -> void
+      def run: (Async::Task reactor) -> void
       def shutdown: -> void
 
       private
@@ -22,6 +22,7 @@ module Temporal
       attr_reader executor: Temporal::Worker::_ActivityExecutor
       attr_reader running_activities: Hash[String, Temporal::Worker::ActivityRunner]
       attr_reader cancellations: Array[String]
+      attr_reader shutdown_queue: Thread::Queue
 
       def running?: -> bool
       def prepare_activities: (Array[singleton(Temporal::Activity)] activities)

--- a/sig/temporal/worker/sync_worker.rbs
+++ b/sig/temporal/worker/sync_worker.rbs
@@ -12,7 +12,7 @@ module Temporal
 
       attr_reader core_worker: Temporal::Bridge::Worker
 
-      def with_queue: { (^(?untyped) -> void) -> void } -> untyped
+      def with_queue: { (^(untyped?, Exception?) -> void) -> void } -> untyped
       def complete_activity_task: (String task_token, Coresdk::ActivityResult::ActivityExecutionResult result) -> void
     end
   end

--- a/spec/integration/activity_worker_spec.rb
+++ b/spec/integration/activity_worker_spec.rb
@@ -155,9 +155,6 @@ describe Temporal::Worker::ActivityWorker do
   after { subject.shutdown }
 
   describe 'running an activity' do
-    # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-    let(:activity_task_queue) { 'test-activity-worker-1' }
-
     it 'runs an activity and returns a result' do
       input = {
         actions: [{
@@ -174,9 +171,6 @@ describe Temporal::Worker::ActivityWorker do
     end
 
     context 'when activity has a custom name' do
-      # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-      let(:activity_task_queue) { 'test-activity-worker-2' }
-
       it 'runs an activity and returns a result' do
         input = {
           actions: [{
@@ -194,9 +188,6 @@ describe Temporal::Worker::ActivityWorker do
     end
 
     context 'when activity fails' do
-      # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-      let(:activity_task_queue) { 'test-activity-worker-3' }
-
       it 'raises an application error' do
         input = {
           actions: [{
@@ -219,9 +210,6 @@ describe Temporal::Worker::ActivityWorker do
   end
 
   describe 'running a heartbeating activity' do
-    # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-    let(:activity_task_queue) { 'test-activity-worker-4' }
-
     it 'runs an activity and returns heartbeat details' do
       input = {
         actions: [{
@@ -257,8 +245,6 @@ describe Temporal::Worker::ActivityWorker do
 
     context 'when unhandled' do
       let(:activity_name) { 'TestCancellingActivity' }
-      # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-      let(:activity_task_queue) { 'test-activity-worker-5' }
 
       it 'raises from within an activity' do
         handle = client.start_workflow(workflow, input, id: id, task_queue: task_queue)
@@ -272,8 +258,6 @@ describe Temporal::Worker::ActivityWorker do
 
     context 'when protected by a shield' do
       let(:activity_name) { 'TestCancellingActivityWithShield' }
-      # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-      let(:activity_task_queue) { 'test-activity-worker-6' }
 
       it 'performs all cycles' do
         handle = client.start_workflow(workflow, input, id: id, task_queue: task_queue)
@@ -284,8 +268,6 @@ describe Temporal::Worker::ActivityWorker do
 
     context 'when handled manually in a shield' do
       let(:activity_name) { 'TestManuallyCancellingActivityWithShield' }
-      # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-      let(:activity_task_queue) { 'test-activity-worker-7' }
 
       it 'raises' do
         handle = client.start_workflow(workflow, input, id: id, task_queue: task_queue)
@@ -301,8 +283,6 @@ describe Temporal::Worker::ActivityWorker do
 
     context 'when unhandled by a shielded activity' do
       let(:activity_name) { 'TestCancellingShieldedActivity' }
-      # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-      let(:activity_task_queue) { 'test-activity-worker-8' }
 
       it 'does not affect activity' do
         handle = client.start_workflow(workflow, input, id: id, task_queue: task_queue)
@@ -313,8 +293,6 @@ describe Temporal::Worker::ActivityWorker do
 
     context 'when intentionally ignored' do
       let(:activity_name) { 'TestCancellationIgnoringActivity' }
-      # TODO: Use a different task queue due to an incomplete Worker#shutdown implementation
-      let(:activity_task_queue) { 'test-activity-worker-9' }
 
       it 'return a number of performed cycles' do
         handle = client.start_workflow(workflow, input, id: id, task_queue: task_queue)

--- a/spec/unit/temporal/worker/activity_worker_spec.rb
+++ b/spec/unit/temporal/worker/activity_worker_spec.rb
@@ -59,7 +59,7 @@ describe Temporal::Worker::ActivityWorker do
 
     before do
       allow(subject).to receive(:running?).and_return(true, false)
-      allow(core_worker).to receive(:complete_activity_task).and_yield(nil)
+      allow(core_worker).to receive(:complete_activity_task).and_yield(nil, nil)
       allow(core_worker).to receive(:poll_activity_task) do |&block|
         block.call(task.to_proto)
       end

--- a/spec/unit/temporal/worker/activity_worker_spec.rb
+++ b/spec/unit/temporal/worker/activity_worker_spec.rb
@@ -58,11 +58,11 @@ describe Temporal::Worker::ActivityWorker do
     let(:activity_name) { 'TestActivity' }
 
     before do
-      allow(subject).to receive(:running?).and_return(true, false)
       allow(core_worker).to receive(:complete_activity_task).and_yield(nil, nil)
-      allow(core_worker).to receive(:poll_activity_task) do |&block|
-        block.call(task.to_proto)
-      end
+      allow(core_worker).to receive(:poll_activity_task).and_invoke(
+        ->(&block) { block.call(task.to_proto) },
+        -> { raise(Temporal::Bridge::Error::WorkerShutdown) },
+      )
       allow(Temporal::Worker::ActivityRunner).to receive(:new).and_return(runner)
     end
 

--- a/spec/unit/temporal/worker_spec.rb
+++ b/spec/unit/temporal/worker_spec.rb
@@ -1,4 +1,5 @@
 require 'support/helpers/test_rpc'
+require 'temporal/activity'
 require 'temporal/bridge'
 require 'temporal/connection'
 require 'temporal/worker'
@@ -98,12 +99,18 @@ describe Temporal::Worker do
   describe '#shutdown' do
     let(:activity_worker) { instance_double(Temporal::Worker::ActivityWorker, shutdown: nil) }
 
-    before { allow(Temporal::Worker::ActivityWorker).to receive(:new).and_return(activity_worker) }
+    before do
+      allow(core_worker).to receive(:initiate_shutdown)
+      allow(core_worker).to receive(:shutdown)
+      allow(Temporal::Worker::ActivityWorker).to receive(:new).and_return(activity_worker)
+    end
 
     it 'calls shutdown on all workers' do
       subject.shutdown
 
-      expect(activity_worker).to have_received(:shutdown)
+      expect(core_worker).to have_received(:initiate_shutdown).ordered
+      expect(activity_worker).to have_received(:shutdown).ordered
+      expect(core_worker).to have_received(:shutdown).ordered
     end
   end
 end


### PR DESCRIPTION
## What was changed
This PR adds a proper shutdown procedure that interacts with the Core and waits for all the running tasks to finish.

Please bear in mind that this does not yet include the previously discussed changes to the `Worker#run` method (run until). These will be added after this PR.

## Checklist

1. Closes #87 

2. How was this tested:
Tested against a running Temporal Server. Unit and integration specs updated

3. Any docs updates needed?
README and YARD docs will be updated separately #88 