### PR TITLE
[Fix] Make Bridge Connection respond to Ruby interrupts

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "temporal-sdk-core-protos",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tonic",
  "url",
 ]

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -15,6 +15,7 @@ temporal-sdk-core-api = { version = "0.1.0", path = "./sdk-core/core-api" }
 temporal-sdk-core-protos = { version = "0.1.0", path = "./sdk-core/sdk-core-protos" }
 thiserror = "1.0.31"
 tokio = "1.15"
+tokio-util = "0.7.4"
 tonic = "0.8"
 url = "2.2"
 

--- a/bridge/src/connection.rs
+++ b/bridge/src/connection.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::mpsc;
 use std::time::Duration;
 use temporal_client::{
     ClientInitError, ClientOptionsBuilder, ClientOptionsBuilderError, WorkflowService, RetryClient,
@@ -42,13 +43,18 @@ pub enum ConnectionError {
 
     #[error(transparent)]
     RequestError(#[from] tonic::Status),
+
+    #[error("RPC call was cancelled")]
+    RequestCancelled,
 }
+
+pub type RpcResult = Result<Vec<u8>, ConnectionError>;
 
 fn rpc_req<P: prost::Message + Default>(params: RpcParams) -> Result<tonic::Request<P>, ConnectionError> {
     let proto = P::decode(&*params.request)?;
     let mut req = tonic::Request::new(proto);
 
-    for (k, v) in params.metadata {
+    for (k, v) in &params.metadata {
         req.metadata_mut().insert(
             MetadataKey::from_str(k.as_str())?,
             MetadataValue::try_from(v.as_str())?
@@ -62,14 +68,74 @@ fn rpc_req<P: prost::Message + Default>(params: RpcParams) -> Result<tonic::Requ
     Ok(req)
 }
 
-fn rpc_resp<P: prost::Message + Default>(res: Result<tonic::Response<P>, tonic::Status>) -> Result<Vec<u8>, ConnectionError> {
+fn rpc_resp<P: prost::Message + Default>(res: Result<tonic::Response<P>, tonic::Status>) -> RpcResult {
     Ok(res?.get_ref().encode_to_vec())
 }
 
 macro_rules! rpc_call {
-    ($client:expr, $runtime:expr, $rpc:ident, $params:expr) => {
-        rpc_resp($runtime.block_on($client.$rpc(rpc_req($params)?)))
+    ($client:expr, $rpc:ident, $params:expr) => {
+        rpc_resp($client.$rpc(rpc_req($params)?).await)
     };
+}
+
+async fn make_rpc_call(mut client: Client, params: RpcParams) -> RpcResult {
+    match params.rpc.as_str() {
+        "register_namespace" => rpc_call!(client, register_namespace, params),
+        "describe_namespace" => rpc_call!(client, describe_namespace, params),
+        "list_namespaces" => rpc_call!(client, list_namespaces, params),
+        "update_namespace" => rpc_call!(client, update_namespace, params),
+        "deprecate_namespace" => rpc_call!(client, deprecate_namespace, params),
+        "start_workflow_execution" => rpc_call!(client, start_workflow_execution, params),
+        "get_workflow_execution_history" => rpc_call!(client, get_workflow_execution_history, params),
+        // "get_workflow_execution_history_reverse" => rpc_call!(client, get_workflow_execution_history_reverse, params),
+        "poll_workflow_task_queue" => rpc_call!(client, poll_workflow_task_queue, params),
+        "respond_workflow_task_completed" => rpc_call!(client, respond_workflow_task_completed, params),
+        "respond_workflow_task_failed" => rpc_call!(client, respond_workflow_task_failed, params),
+        "poll_activity_task_queue" => rpc_call!(client, poll_activity_task_queue, params),
+        "record_activity_task_heartbeat" => rpc_call!(client, record_activity_task_heartbeat, params),
+        "record_activity_task_heartbeat_by_id" => rpc_call!(client, record_activity_task_heartbeat_by_id, params),
+        "respond_activity_task_completed" => rpc_call!(client, respond_activity_task_completed, params),
+        "respond_activity_task_completed_by_id" => rpc_call!(client, respond_activity_task_completed_by_id, params),
+        "respond_activity_task_failed" => rpc_call!(client, respond_activity_task_failed, params),
+        "respond_activity_task_failed_by_id" => rpc_call!(client, respond_activity_task_failed_by_id, params),
+        "respond_activity_task_canceled" => rpc_call!(client, respond_activity_task_canceled, params),
+        "respond_activity_task_canceled_by_id" => rpc_call!(client, respond_activity_task_canceled_by_id, params),
+        "request_cancel_workflow_execution" => rpc_call!(client, request_cancel_workflow_execution, params),
+        "signal_workflow_execution" => rpc_call!(client, signal_workflow_execution, params),
+        "signal_with_start_workflow_execution" => rpc_call!(client, signal_with_start_workflow_execution, params),
+        "reset_workflow_execution" => rpc_call!(client, reset_workflow_execution, params),
+        "terminate_workflow_execution" => rpc_call!(client, terminate_workflow_execution, params),
+        "list_open_workflow_executions" => rpc_call!(client, list_open_workflow_executions, params),
+        "list_closed_workflow_executions" => rpc_call!(client, list_closed_workflow_executions, params),
+        "list_workflow_executions" => rpc_call!(client, list_workflow_executions, params),
+        "list_archived_workflow_executions" => rpc_call!(client, list_archived_workflow_executions, params),
+        "scan_workflow_executions" => rpc_call!(client, scan_workflow_executions, params),
+        "count_workflow_executions" => rpc_call!(client, count_workflow_executions, params),
+        "get_search_attributes" => rpc_call!(client, get_search_attributes, params),
+        "respond_query_task_completed" => rpc_call!(client, respond_query_task_completed, params),
+        "reset_sticky_task_queue" => rpc_call!(client, reset_sticky_task_queue, params),
+        "query_workflow" => rpc_call!(client, query_workflow, params),
+        "describe_workflow_execution" => rpc_call!(client, describe_workflow_execution, params),
+        "describe_task_queue" => rpc_call!(client, describe_task_queue, params),
+        "get_cluster_info" => rpc_call!(client, get_cluster_info, params),
+        "get_system_info" => rpc_call!(client, get_system_info, params),
+        "list_task_queue_partitions" => rpc_call!(client, list_task_queue_partitions, params),
+        "create_schedule" => rpc_call!(client, create_schedule, params),
+        "describe_schedule" => rpc_call!(client, describe_schedule, params),
+        "update_schedule" => rpc_call!(client, update_schedule, params),
+        "patch_schedule" => rpc_call!(client, patch_schedule, params),
+        "list_schedule_matching_times" => rpc_call!(client, list_schedule_matching_times, params),
+        "delete_schedule" => rpc_call!(client, delete_schedule, params),
+        "list_schedules" => rpc_call!(client, list_schedules, params),
+        "update_worker_build_id_ordering" => rpc_call!(client, update_worker_build_id_ordering, params),
+        "get_worker_build_id_ordering" => rpc_call!(client, get_worker_build_id_ordering, params),
+        "update_workflow" => rpc_call!(client, update_workflow, params),
+        "start_batch_operation" => rpc_call!(client, start_batch_operation, params),
+        "stop_batch_operation" => rpc_call!(client, stop_batch_operation, params),
+        "describe_batch_operation" => rpc_call!(client, describe_batch_operation, params),
+        "list_batch_operations" => rpc_call!(client, list_batch_operations, params),
+        _ => Err(ConnectionError::InvalidRpc(params.rpc.to_string()))
+    }
 }
 
 // A Connection is a Client wrapper for making RPC calls
@@ -105,63 +171,12 @@ impl Connection {
         Ok(Connection { client, runtime })
     }
 
-    pub fn call(&mut self, params: RpcParams) -> Result<Vec<u8>, ConnectionError> {
-        match params.rpc.as_str() {
-            "register_namespace" => rpc_call!(self.client, self.runtime, register_namespace, params),
-            "describe_namespace" => rpc_call!(self.client, self.runtime, describe_namespace, params),
-            "list_namespaces" => rpc_call!(self.client, self.runtime, list_namespaces, params),
-            "update_namespace" => rpc_call!(self.client, self.runtime, update_namespace, params),
-            "deprecate_namespace" => rpc_call!(self.client, self.runtime, deprecate_namespace, params),
-            "start_workflow_execution" => rpc_call!(self.client, self.runtime, start_workflow_execution, params),
-            "get_workflow_execution_history" => rpc_call!(self.client, self.runtime, get_workflow_execution_history, params),
-            // "get_workflow_execution_history_reverse" => rpc_call!(self.client, self.runtime, get_workflow_execution_history_reverse, params),
-            "poll_workflow_task_queue" => rpc_call!(self.client, self.runtime, poll_workflow_task_queue, params),
-            "respond_workflow_task_completed" => rpc_call!(self.client, self.runtime, respond_workflow_task_completed, params),
-            "respond_workflow_task_failed" => rpc_call!(self.client, self.runtime, respond_workflow_task_failed, params),
-            "poll_activity_task_queue" => rpc_call!(self.client, self.runtime, poll_activity_task_queue, params),
-            "record_activity_task_heartbeat" => rpc_call!(self.client, self.runtime, record_activity_task_heartbeat, params),
-            "record_activity_task_heartbeat_by_id" => rpc_call!(self.client, self.runtime, record_activity_task_heartbeat_by_id, params),
-            "respond_activity_task_completed" => rpc_call!(self.client, self.runtime, respond_activity_task_completed, params),
-            "respond_activity_task_completed_by_id" => rpc_call!(self.client, self.runtime, respond_activity_task_completed_by_id, params),
-            "respond_activity_task_failed" => rpc_call!(self.client, self.runtime, respond_activity_task_failed, params),
-            "respond_activity_task_failed_by_id" => rpc_call!(self.client, self.runtime, respond_activity_task_failed_by_id, params),
-            "respond_activity_task_canceled" => rpc_call!(self.client, self.runtime, respond_activity_task_canceled, params),
-            "respond_activity_task_canceled_by_id" => rpc_call!(self.client, self.runtime, respond_activity_task_canceled_by_id, params),
-            "request_cancel_workflow_execution" => rpc_call!(self.client, self.runtime, request_cancel_workflow_execution, params),
-            "signal_workflow_execution" => rpc_call!(self.client, self.runtime, signal_workflow_execution, params),
-            "signal_with_start_workflow_execution" => rpc_call!(self.client, self.runtime, signal_with_start_workflow_execution, params),
-            "reset_workflow_execution" => rpc_call!(self.client, self.runtime, reset_workflow_execution, params),
-            "terminate_workflow_execution" => rpc_call!(self.client, self.runtime, terminate_workflow_execution, params),
-            "list_open_workflow_executions" => rpc_call!(self.client, self.runtime, list_open_workflow_executions, params),
-            "list_closed_workflow_executions" => rpc_call!(self.client, self.runtime, list_closed_workflow_executions, params),
-            "list_workflow_executions" => rpc_call!(self.client, self.runtime, list_workflow_executions, params),
-            "list_archived_workflow_executions" => rpc_call!(self.client, self.runtime, list_archived_workflow_executions, params),
-            "scan_workflow_executions" => rpc_call!(self.client, self.runtime, scan_workflow_executions, params),
-            "count_workflow_executions" => rpc_call!(self.client, self.runtime, count_workflow_executions, params),
-            "get_search_attributes" => rpc_call!(self.client, self.runtime, get_search_attributes, params),
-            "respond_query_task_completed" => rpc_call!(self.client, self.runtime, respond_query_task_completed, params),
-            "reset_sticky_task_queue" => rpc_call!(self.client, self.runtime, reset_sticky_task_queue, params),
-            "query_workflow" => rpc_call!(self.client, self.runtime, query_workflow, params),
-            "describe_workflow_execution" => rpc_call!(self.client, self.runtime, describe_workflow_execution, params),
-            "describe_task_queue" => rpc_call!(self.client, self.runtime, describe_task_queue, params),
-            "get_cluster_info" => rpc_call!(self.client, self.runtime, get_cluster_info, params),
-            "get_system_info" => rpc_call!(self.client, self.runtime, get_system_info, params),
-            "list_task_queue_partitions" => rpc_call!(self.client, self.runtime, list_task_queue_partitions, params),
-            "create_schedule" => rpc_call!(self.client, self.runtime, create_schedule, params),
-            "describe_schedule" => rpc_call!(self.client, self.runtime, describe_schedule, params),
-            "update_schedule" => rpc_call!(self.client, self.runtime, update_schedule, params),
-            "patch_schedule" => rpc_call!(self.client, self.runtime, patch_schedule, params),
-            "list_schedule_matching_times" => rpc_call!(self.client, self.runtime, list_schedule_matching_times, params),
-            "delete_schedule" => rpc_call!(self.client, self.runtime, delete_schedule, params),
-            "list_schedules" => rpc_call!(self.client, self.runtime, list_schedules, params),
-            "update_worker_build_id_ordering" => rpc_call!(self.client, self.runtime, update_worker_build_id_ordering, params),
-            "get_worker_build_id_ordering" => rpc_call!(self.client, self.runtime, get_worker_build_id_ordering, params),
-            "update_workflow" => rpc_call!(self.client, self.runtime, update_workflow, params),
-            "start_batch_operation" => rpc_call!(self.client, self.runtime, start_batch_operation, params),
-            "stop_batch_operation" => rpc_call!(self.client, self.runtime, stop_batch_operation, params),
-            "describe_batch_operation" => rpc_call!(self.client, self.runtime, describe_batch_operation, params),
-            "list_batch_operations" => rpc_call!(self.client, self.runtime, list_batch_operations, params),
-            _ => Err(ConnectionError::InvalidRpc(params.rpc.to_string()))
-        }
+    pub fn call(&self, params: RpcParams, tx: mpsc::Sender<RpcResult>) {
+        let core_client = self.client.clone();
+
+        self.runtime.spawn(async move {
+            let result = make_rpc_call(core_client, params).await;
+            tx.send(result).expect("Unable to send an RPC result");
+        });
     }
 }

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -56,8 +56,12 @@ fn to_hash_map(hash: Hash) -> HashMap<String, String> {
     result
 }
 
-fn ruby_nil() -> AnyObject {
-    NilClass::new().to_any_object()
+fn worker_result_to_proc_args(result: WorkerResult) -> [AnyObject; 2] {
+    let ruby_nil = NilClass::new().to_any_object();
+    match result {
+        Ok(bytes) => [wrap_bytes(bytes).to_any_object(), ruby_nil],
+        Err(e) => [ruby_nil, wrap_worker_error(&e).to_any_object()]
+    }
 }
 
 wrappable_struct!(Connection, ConnectionWrapper, CONNECTION_WRAPPER);
@@ -163,10 +167,7 @@ methods!(
 
         let ruby_callback = VM::block_proc();
         let callback = move |result: WorkerResult| {
-            match result {
-                Ok(bytes) => ruby_callback.call(&[wrap_bytes(bytes).to_any_object()]),
-                Err(e) => ruby_callback.call(&[ruby_nil(), wrap_worker_error(&e).to_any_object()])
-            };
+            ruby_callback.call(&worker_result_to_proc_args(result));
         };
 
         let worker = _rtself.get_data_mut(&*WORKER_WRAPPER);
@@ -185,10 +186,7 @@ methods!(
         let bytes = unwrap_bytes(proto.map_err(VM::raise_ex).unwrap());
         let ruby_callback = VM::block_proc();
         let callback = move |result: WorkerResult| {
-            match result {
-                Ok(_) => ruby_callback.call(&[ruby_nil()]),
-                Err(e) => ruby_callback.call(&[ruby_nil(), wrap_worker_error(&e).to_any_object()])
-            };
+            ruby_callback.call(&worker_result_to_proc_args(result));
         };
 
         let worker = _rtself.get_data_mut(&*WORKER_WRAPPER);

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -6,13 +6,14 @@ mod connection;
 mod runtime;
 mod worker;
 
-use connection::{Connection, RpcParams};
+use connection::{Connection, ConnectionError, RpcParams, RpcResult};
 use runtime::Runtime;
 use rutie::{
     Module, Object, Symbol, RString, Encoding, AnyObject, AnyException, Exception, VM, Thread,
     NilClass, Hash, Integer,
 };
 use std::collections::HashMap;
+use std::sync::mpsc;
 use temporal_sdk_core::{Logger, TelemetryOptionsBuilder};
 use worker::{Worker, WorkerError, WorkerResult};
 
@@ -91,8 +92,9 @@ methods!(
         let request = unwrap_bytes(request.map_err(VM::raise_ex).unwrap());
         let metadata = to_hash_map(metadata.map_err(VM::raise_ex).unwrap());
         let timeout = timeout.map_or(None, |v| Some(v.to_u64()));
+        let (tx, rx) = mpsc::channel::<RpcResult>();
 
-        let result = Thread::call_without_gvl(move || {
+        let result = Thread::call_without_gvl(|| {
             let connection = _rtself.get_data_mut(&*CONNECTION_WRAPPER);
             let params = RpcParams {
                 rpc: rpc.clone(),
@@ -100,8 +102,11 @@ methods!(
                 metadata: metadata.clone(),
                 timeout_millis: timeout
             };
-            connection.call(params)
-        }, Some(|| {}));
+            connection.call(params, tx.clone());
+            rx.recv().expect("RPC result channel closed")
+        }, Some(|| {
+            tx.send(Err(ConnectionError::RequestCancelled)).expect("Unable to close connection");
+        }));
 
         let response = result.map_err(|e| raise_bridge_exception(&e.to_string())).unwrap();
 


### PR DESCRIPTION
## What was changed
This PR addresses the issue of Connection unable to respond to Ruby interrupts. This can happen when `Thread#raise` is called explicitly or when a Ruby program gets terminated with Ctrl+C mid execution (and falls into an outside of GVL blocking call).

The new implementation waits on a channel rather than a blocking `Runtime::block_on` and then returns an error when Ruby interrupt was requested.

## Why?
This is required to make sure our Client plays well with Activity cancellations and propagating fatal Core error on shutdown.

## Checklist

1. Closes #96 

2. Closes #95 

3. How was this tested:
Integration spec that exposes the issue added

4. Any docs updates needed?
No