### PR TITLE
[Feature] Improve `Worker#run`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,3 +75,6 @@ Metrics/PerceivedComplexity:
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
+
+Name/VariableNumber:
+  EnforcedStyle: snake_case

--- a/lib/temporalio.rb
+++ b/lib/temporalio.rb
@@ -1,8 +1,12 @@
 # Protoc wants all of its generated files on the LOAD_PATH
 $LOAD_PATH << File.expand_path('./gen', File.dirname(__FILE__))
 
+require 'temporalio/activity'
+require 'temporalio/bridge'
+require 'temporalio/client'
 require 'temporalio/connection'
 require 'temporalio/version'
+require 'temporalio/worker'
 
 module Temporalio
 end

--- a/lib/temporalio/errors.rb
+++ b/lib/temporalio/errors.rb
@@ -18,5 +18,10 @@ module Temporalio
         @status = status
       end
     end
+
+    # Superclass for internal errors
+    class Internal < Error; end
+
+    class WorkerShutdown < Internal; end
   end
 end

--- a/lib/temporalio/worker.rb
+++ b/lib/temporalio/worker.rb
@@ -3,10 +3,16 @@ require 'temporalio/bridge'
 require 'temporalio/data_converter'
 require 'temporalio/runtime'
 require 'temporalio/worker/activity_worker'
+require 'temporalio/worker/runner'
 require 'temporalio/worker/thread_pool_executor'
 
 module Temporalio
   class Worker
+    # TODO: Add signal handling
+    def self.run(*workers, &block)
+      Runner.new(*workers).run(&block)
+    end
+
     # TODO: Add worker interceptors
     def initialize(
       connection,
@@ -17,10 +23,11 @@ module Temporalio
       activity_executor: nil,
       max_concurrent_activities: 100
     )
-      @running = false
+      @started = false
+      @shutdown = false
       @mutex = Mutex.new
       @runtime = Temporalio::Runtime.instance
-      activity_executor ||= ThreadPoolExecutor.new(max_concurrent_activities)
+      @activity_executor = activity_executor || ThreadPoolExecutor.new(max_concurrent_activities)
       @core_worker = Temporalio::Bridge::Worker.create(
         @runtime.core_runtime,
         connection.core_connection,
@@ -32,7 +39,7 @@ module Temporalio
         @core_worker,
         activities,
         data_converter,
-        activity_executor,
+        @activity_executor,
       )
       @workflow_worker = nil
 
@@ -41,37 +48,66 @@ module Temporalio
       end
     end
 
-    def run
-      Async { |task| start(task) }
+    def run(&block)
+      Runner.new(self).run(&block)
     end
 
-    def start(reactor = nil)
+    def start(runner = nil)
       mutex.synchronize do
-        raise 'Worker is already running' if running?
+        raise 'Worker is already started' if started?
 
-        @running = true
+        @started = true
       end
 
+      @runner = runner
       runtime.ensure_callback_loop
-      reactor ||= runtime.reactor
-      reactor.async { |task| activity_worker.run(task) } if activity_worker
-      reactor.async { |task| workflow_worker.run(task) } if workflow_worker
+
+      runtime.reactor.async do |task|
+        if activity_worker
+          task.async do |task|
+            activity_worker.run(task)
+          rescue StandardError => e
+            shutdown(e) # initiate shutdown because of a fatal error
+          end
+        end
+
+        # TODO: Pending implementation
+        task.async { |task| workflow_worker.run(task) } if workflow_worker
+      end
     end
 
-    def shutdown
-      core_worker.initiate_shutdown
-      activity_worker&.shutdown
-      workflow_worker&.shutdown
-      core_worker.shutdown
+    def shutdown(exception = Temporalio::Error::WorkerShutdown.new('Manual shutdown'))
+      mutex.synchronize do
+        return unless running?
+
+        # First initiate Core shutdown, which will start dropping poll requests
+        core_worker.initiate_shutdown
+        # Then let the runner know we're shutting down, so it can stop other workers
+        runner&.shutdown(exception)
+        # Wait for workers to drain any outstanding tasks
+        activity_worker&.drain
+        workflow_worker&.drain
+        # Stop the executor (at this point there should already be nothing in it)
+        activity_executor.shutdown
+        # Finalize the shutdown by stopping the Core
+        core_worker.shutdown
+
+        @shutdown = true
+      end
+    end
+
+    def started?
+      @started
+    end
+
+    def running?
+      @started && !@shutdown
     end
 
     private
 
-    attr_reader :mutex, :runtime, :core_worker, :activity_worker, :workflow_worker
-
-    def running?
-      @running
-    end
+    attr_reader :mutex, :runtime, :activity_executor, :core_worker, :activity_worker,
+                :workflow_worker, :runner
 
     def init_activity_worker(task_queue, core_worker, activities, data_converter, executor)
       return if activities.empty?

--- a/lib/temporalio/worker/runner.rb
+++ b/lib/temporalio/worker/runner.rb
@@ -1,0 +1,58 @@
+module Temporalio
+  class Worker
+    class Runner
+      def initialize(*workers)
+        if workers.empty?
+          raise ArgumentError, 'Must be initialized with at least one worker'
+        end
+
+        @workers = workers
+        @mutex = Mutex.new
+        @started = false
+        @shutdown = false
+      end
+
+      def run(&block)
+        @thread = Thread.current
+        @started = true
+        workers.each { |worker| worker.start(self) }
+
+        block ? block.call : sleep
+      rescue Temporalio::Error::WorkerShutdown
+        # Explicit shutdown requested, no need to raise
+      ensure
+        @shutdown = true
+        shutdown_workers
+      end
+
+      def shutdown(exception = Temporalio::Error::WorkerShutdown.new('Manual shutdown'))
+        mutex.synchronize do
+          return unless running?
+
+          @shutdown = true
+        end
+
+        # propagate shutdown to the running thread
+        thread&.raise(exception)
+      end
+
+      private
+
+      attr_reader :workers, :mutex, :thread
+
+      def running?
+        @started && !@shutdown
+      end
+
+      def shutdown_workers
+        # Protect shutdown from any outside raises
+        Thread.handle_interrupt(StandardError => :never) do
+          workers.map do |worker|
+            # Shut down each worker (and wait for it) concurrently in separate threads
+            Thread.new { worker.shutdown }
+          end.each(&:join)
+        end
+      end
+    end
+  end
+end

--- a/sig/ruby.rbs
+++ b/sig/ruby.rbs
@@ -1,7 +1,11 @@
 # Missing signatures for Ruby's stdlib
 
-# https://rubyapi.org/3.1/o/thread#method-i-raise
 class Thread
+  # https://rubyapi.org/3.1/o/thread#method-c-handle_interrupt
+  def self.handle_interrupt: (Hash[singleton(Exception), Symbol]) { -> untyped } -> untyped
+                           | ...
+
+  # https://rubyapi.org/3.1/o/thread#method-i-raise
   def raise: () -> bot
            | (::String arg0) -> bot
            | (::_Exception arg0, ?untyped arg1, ?::Array[::String] arg2) -> bot

--- a/sig/temporalio/errors.rbs
+++ b/sig/temporalio/errors.rbs
@@ -17,5 +17,11 @@ module Temporalio
 
       def initialize: (Temporalio::Workflow::ExecutionStatus::values) -> void
     end
+
+    class Internal < Error
+    end
+
+    class WorkerShutdown < Internal
+    end
   end
 end

--- a/sig/temporalio/worker.rbs
+++ b/sig/temporalio/worker.rbs
@@ -1,6 +1,6 @@
 module Temporalio
   class Worker
-    @running: bool
+    def self.run: (*Temporalio::Worker workers) { -> void } -> void
 
     def initialize: (
       Temporalio::Connection connection,
@@ -11,19 +11,26 @@ module Temporalio
       ?activity_executor: Temporalio::Worker::_ActivityExecutor?,
       ?max_concurrent_activities: Integer
     ) -> void
-    def run: -> void
-    def start: (?Temporalio::Worker::_Reactor? reactor) -> void
-    def shutdown: -> void
+    def run: { -> void } -> void
+    def start: (?Temporalio::Worker::Runner? runner) -> void
+    def shutdown: (?Exception exception) -> void
+
+    def started?: -> bool
+    def running?: -> bool
 
     private
 
+    @started: bool
+    @shutdown: bool
+
     attr_reader mutex: Thread::Mutex
     attr_reader runtime: Temporalio::Runtime
+    attr_reader activity_executor: Temporalio::Worker::_ActivityExecutor
     attr_reader core_worker: Temporalio::Bridge::Worker
     attr_reader activity_worker: Temporalio::Worker::ActivityWorker?
     attr_reader workflow_worker: untyped
+    attr_reader runner: Temporalio::Worker::Runner?
 
-    def running?: -> bool
     def init_activity_worker: (
       String task_queue,
       Temporalio::Bridge::Worker core_worker,

--- a/sig/temporalio/worker/activity_worker.rbs
+++ b/sig/temporalio/worker/activity_worker.rbs
@@ -11,7 +11,7 @@ module Temporalio
         Temporalio::Worker::_ActivityExecutor executor
       ) -> void
       def run: (Async::Task reactor) -> void
-      def shutdown: -> void
+      def drain: -> void
 
       private
 
@@ -22,7 +22,7 @@ module Temporalio
       attr_reader executor: Temporalio::Worker::_ActivityExecutor
       attr_reader running_activities: Hash[String, Temporalio::Worker::ActivityRunner]
       attr_reader cancellations: Array[String]
-      attr_reader shutdown_queue: Thread::Queue
+      attr_reader drain_queue: Thread::Queue
 
       def running?: -> bool
       def prepare_activities: (Array[singleton(Temporalio::Activity)] activities)

--- a/sig/temporalio/worker/runner.rbs
+++ b/sig/temporalio/worker/runner.rbs
@@ -1,0 +1,21 @@
+module Temporalio
+  class Worker
+    class Runner
+      @started: bool
+      @shutdown: bool
+
+      def initialize: (*Temporalio::Worker workers) -> void
+      def run: { -> void } -> void
+      def shutdown: (?Exception exception) -> void
+
+      private
+
+      attr_reader workers: Array[Temporalio::Worker]
+      attr_reader mutex: Thread::Mutex
+      attr_reader thread: Thread
+
+      def running?: -> bool
+      def shutdown_workers: -> void
+    end
+  end
+end

--- a/spec/integration/worker_runner_spec.rb
+++ b/spec/integration/worker_runner_spec.rb
@@ -1,0 +1,182 @@
+# rubocop:disable Style/GlobalVars
+require 'support/helpers/test_rpc'
+require 'temporalio/activity'
+require 'temporalio/client'
+require 'temporalio/connection'
+require 'temporalio/worker'
+require 'temporalio/worker/runner'
+
+# WARNING: This test is using a global queue to avoid timing of an activity start.
+#          It allows us to test worker shutdown down right after activities got started.
+$activity_start_queue = Queue.new
+
+class TestWorkerIntegrationActivity < Temporalio::Activity
+  def execute(num)
+    $activity_start_queue << "started #{num}"
+    sleep 0.2
+    num.to_s
+  end
+end
+
+describe Temporalio::Worker::Runner do
+  support_path = 'spec/support'.freeze
+  port = 5555
+  task_queue = 'test-worker'.freeze
+  namespace = 'ruby-samples'.freeze
+  url = "localhost:#{port}".freeze
+
+  subject { Temporalio::Worker::Runner.new(worker_1, worker_2) }
+  let(:worker_1) do
+    Temporalio::Worker.new(
+      connection,
+      namespace,
+      activity_task_queue_1,
+      activities: [TestWorkerIntegrationActivity],
+    )
+  end
+  let(:worker_2) do
+    Temporalio::Worker.new(
+      connection,
+      namespace,
+      activity_task_queue_2,
+      activities: [TestWorkerIntegrationActivity],
+    )
+  end
+  let(:activity_task_queue_1) { 'test-activity-worker-1' }
+  let(:activity_task_queue_2) { 'test-activity-worker-2' }
+  let(:client) { Temporalio::Client.new(connection, namespace) }
+  let(:connection) { Temporalio::Connection.new(url) }
+  let(:workflow) { 'kitchen_sink' }
+  let(:input_1) do
+    {
+      actions: [{
+        execute_activity: {
+          name: 'TestWorkerIntegrationActivity',
+          task_queue: activity_task_queue_1,
+          args: [1],
+        },
+      }],
+    }
+  end
+  let(:input_2) do
+    {
+      actions: [{
+        execute_activity: {
+          name: 'TestWorkerIntegrationActivity',
+          task_queue: activity_task_queue_2,
+          args: [2],
+        },
+      }],
+    }
+  end
+  let(:start) { Queue.new }
+
+  before(:all) do
+    @server_pid = fork { exec("#{support_path}/go_server/main #{port} #{namespace}") }
+    Helpers::TestRPC.wait(url, 10, 0.5)
+
+    @worker_pid = fork { exec("#{support_path}/go_worker/main #{url} #{namespace} #{task_queue}") }
+  end
+
+  after(:all) do
+    Process.kill('INT', @worker_pid)
+    Process.wait(@worker_pid)
+    Process.kill('INT', @server_pid)
+    Process.wait(@server_pid)
+  end
+
+  describe 'lifecycle' do
+    after { $activity_start_queue.clear }
+
+    it 'runs workers and shuts them down when finished' do
+      handle_1 = client.start_workflow(workflow, input_1, id: SecureRandom.uuid, task_queue: task_queue)
+      handle_2 = client.start_workflow(workflow, input_2, id: SecureRandom.uuid, task_queue: task_queue)
+
+      subject.run { handle_1.result && handle_2.result }
+
+      expect(handle_1.result).to eq('1')
+      expect(handle_2.result).to eq('2')
+    end
+
+    it 'stops when the block raises and waits for all the tasks to finish' do
+      handle_1 = client.start_workflow(workflow, input_1, id: SecureRandom.uuid, task_queue: task_queue)
+      handle_2 = client.start_workflow(workflow, input_2, id: SecureRandom.uuid, task_queue: task_queue)
+
+      expect do
+        subject.run do
+          $activity_start_queue.pop
+          $activity_start_queue.pop
+          raise 'test error'
+        end
+      end.to raise_error('test error')
+
+      expect(handle_1.result).to eq('1')
+      expect(handle_2.result).to eq('2')
+    end
+
+    it 'stops on explicit runner shutdown it waits for all the tasks to finish' do
+      handle_1 = client.start_workflow(workflow, input_1, id: SecureRandom.uuid, task_queue: task_queue)
+      handle_2 = client.start_workflow(workflow, input_2, id: SecureRandom.uuid, task_queue: task_queue)
+
+      Thread.new do
+        $activity_start_queue.pop
+        $activity_start_queue.pop
+        subject.shutdown
+      end
+
+      subject.run
+
+      expect(handle_1.result).to eq('1')
+      expect(handle_2.result).to eq('2')
+    end
+
+    it 'stops on explicit runner error it waits for all the tasks to finish' do
+      handle_1 = client.start_workflow(workflow, input_1, id: SecureRandom.uuid, task_queue: task_queue)
+      handle_2 = client.start_workflow(workflow, input_2, id: SecureRandom.uuid, task_queue: task_queue)
+
+      Thread.new do
+        $activity_start_queue.pop
+        $activity_start_queue.pop
+        subject.shutdown('runner test error')
+      end
+
+      expect { subject.run }.to raise_error('runner test error')
+
+      expect(handle_1.result).to eq('1')
+      expect(handle_2.result).to eq('2')
+    end
+
+    it 'stops on a single worker shutdown it waits for all the tasks to finish' do
+      handle_1 = client.start_workflow(workflow, input_1, id: SecureRandom.uuid, task_queue: task_queue)
+      handle_2 = client.start_workflow(workflow, input_2, id: SecureRandom.uuid, task_queue: task_queue)
+
+      Thread.new do
+        $activity_start_queue.pop
+        $activity_start_queue.pop
+        worker_2.shutdown
+      end
+
+      subject.run
+
+      expect(handle_1.result).to eq('1')
+      expect(handle_2.result).to eq('2')
+    end
+
+    it 'stops on a single worker error it waits for all the tasks to finish' do
+      handle_1 = client.start_workflow(workflow, input_1, id: SecureRandom.uuid, task_queue: task_queue)
+      handle_2 = client.start_workflow(workflow, input_2, id: SecureRandom.uuid, task_queue: task_queue)
+
+      Thread.new do
+        $activity_start_queue.pop
+        $activity_start_queue.pop
+        worker_2.shutdown('worker 2 test error')
+      end
+
+      expect { subject.run }.to raise_error('worker 2 test error')
+
+      expect(handle_1.result).to eq('1')
+      expect(handle_2.result).to eq('2')
+    end
+  end
+end
+# rubocop:enable Style/GlobalVars

--- a/spec/unit/temporalio/worker/runner_spec.rb
+++ b/spec/unit/temporalio/worker/runner_spec.rb
@@ -1,0 +1,103 @@
+require 'temporalio/worker'
+require 'temporalio/worker/runner'
+
+describe Temporalio::Worker::Runner do
+  subject { described_class.new(worker_one, worker_two) }
+  let(:worker_one) { instance_double(Temporalio::Worker, start: nil, shutdown: nil) }
+  let(:worker_two) { instance_double(Temporalio::Worker, start: nil, shutdown: nil) }
+
+  describe '#initialize' do
+    it 'raises when initialized without workers' do
+      expect do
+        described_class.new
+      end.to raise_error(ArgumentError, 'Must be initialized with at least one worker')
+    end
+  end
+
+  describe '#run' do
+    it 'starts each worker and then shuts them down' do
+      Thread.new do
+        sleep 0.1
+        subject.shutdown
+      end
+
+      subject.run
+
+      expect(worker_one).to have_received(:start).with(subject)
+      expect(worker_two).to have_received(:start).with(subject)
+      expect(worker_two).to have_received(:shutdown)
+      expect(worker_two).to have_received(:shutdown)
+    end
+
+    it 'calls the provided block and the shuts down' do
+      expect { |b| subject.run(&b) }.to yield_control
+
+      expect(worker_one).to have_received(:start).with(subject)
+      expect(worker_two).to have_received(:start).with(subject)
+      expect(worker_two).to have_received(:shutdown)
+      expect(worker_two).to have_received(:shutdown)
+    end
+
+    it 're-raises when block raises and performs shutdown' do
+      expect do
+        subject.run { raise 'test error' }
+      end.to raise_error('test error')
+
+      expect(worker_two).to have_received(:shutdown)
+      expect(worker_two).to have_received(:shutdown)
+    end
+
+    it 'does not re-raise when a shutdown error was raised' do
+      subject.run { raise Temporalio::Error::WorkerShutdown }
+
+      expect(worker_two).to have_received(:shutdown)
+      expect(worker_two).to have_received(:shutdown)
+    end
+  end
+
+  describe '#shutdown' do
+    let(:start) { Queue.new }
+
+    it 'does nothing if worker is not running' do
+      subject.shutdown
+
+      expect(worker_two).not_to have_received(:shutdown)
+      expect(worker_two).not_to have_received(:shutdown)
+    end
+
+    it 'shuts each worker down' do
+      thread = Thread.new do
+        subject.run do
+          start.close # let the main thread know the workers are running
+          sleep
+        end
+      end
+
+      start.pop
+      subject.shutdown
+
+      thread.join # wait for runner to stop
+
+      expect(worker_two).to have_received(:shutdown)
+      expect(worker_two).to have_received(:shutdown)
+    end
+
+    it 'raises a given exception' do
+      thread = Thread.new do
+        subject.run do
+          start.close # let the main thread know the workers are running
+          sleep
+        end
+      end
+
+      start.pop
+      subject.shutdown(RuntimeError.new('test error'))
+
+      thread.report_on_exception = false
+      expect { thread.join }.to raise_error(RuntimeError, 'test error')
+
+      expect(worker_two).to have_received(:shutdown)
+      expect(worker_two).to have_received(:shutdown)
+    end
+  end
+end


### PR DESCRIPTION
## What was changed
As discussed previously this PR improves the `Worker#run` interface and allows the users to run multiple workers at the same time without having to manage Threads themselves.

The new interface the following:

```ruby
worker_1 = Temporal::Worker.new(...)
worker_1.run # run a single worker indefinitely while waiting for a manual shutdown or a fatal error

# run a single worker until the block has finished (or manual shutdown or fatal error)
# this form is useful for running tests, which now make a proper use of it (see diff)
worker_1.run do
  sleep 10
end

worker_2 = Temporal::Worker.new(...)
# run multiple workers indefinitely until manual shutdown or fatal error
Temporal::Worker.run(worker_1, worker_2) 

# run multiple workers until the block has finished (or manual shutdown or fatal error)
Temporal::Worker.run(worker_1, worker_2) do
  sleep 10
end
```

What is not yet implemented is shutting down workers based on an external signal #98

## Checklist

1. Closes #86 

2. How was this tested:
Both unit tests and integration test added/updated

3. Any docs updates needed?
Will be addressed separate before the release — #88 
