### PR TITLE
[Feature] Implement Worker cancellation on signals and graceful shutdown timeout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,5 +76,5 @@ Metrics/PerceivedComplexity:
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
-Name/VariableNumber:
+Naming/VariableNumber:
   EnforcedStyle: snake_case

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Temporal::Worker.run(worker_1, worker_2, worker_3)
 Please note that similar to `Temporal::Worker#run`, `Temporal::Worker.run` accepts a block that
 behaves the same way — the workers will be shut down when the block finishes.
 
+You can also configure your worker to listen on process signals to initiate a shutdown:
+
+```ruby
+Temporal::Worker.run(worker_1, worker_2, worker_3, stop_on_signal: %w[INT TERM])
+```
+
 #### Worker Shutdown
 
 The `Temporal::Worker#run` (as well as `Temporal::Worker#shutdown`) invocation will wait on all

--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ The `Temporal::Worker#run` (as well as `Temporal::Worker#shutdown`) invocation w
 activities to complete, so if a long-running activity does not at least respect cancellation, the
 shutdown may never complete.
 
+If a worker was initialized with a `graceful_shutdown_timeout` option then a cancellation will be
+issued for every running activity after the set timeout. The bahaviour is mostly identical to a
+server requested cancellation and should be handled accordingly. More on this in [Heartbeating and
+Cancellation](#heartbeating-and-cancellation).
+
 ### Activities
 
 #### Definition
@@ -212,7 +217,7 @@ persisted on the server for retrieval during activity retry. If an activity call
 return an array containing `123` and `456` on the next run.
 
 A cancellation is implemented using the `Thread#raise` method, which will raise a
-`Temporal::Error::CancelledError` during the execution of an activity. This means that your code
+`Temporal::Error::ActivityCancelled` during the execution of an activity. This means that your code
 might get interrupted at any point and never complete. In order to protect critical parts of your
 activities wrap them in `activity.shield`:
 
@@ -250,6 +255,9 @@ end
 
 For any long-running activity using this approach it is recommended to periodically check
 `activity.cancelled?` flag and respond accordingly.
+
+Please note that your activities can also get cancelled during a worker shutdown process ([if
+configured accordingly](#worker-shutdown)).
 
 
 ## Dev Setup

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ behaves the same way — the workers will be shut down when the block finishes.
 You can also configure your worker to listen on process signals to initiate a shutdown:
 
 ```ruby
-Temporal::Worker.run(worker_1, worker_2, worker_3, stop_on_signal: %w[INT TERM])
+Temporal::Worker.run(worker_1, worker_2, worker_3, shutdown_signals: %w[INT TERM])
 ```
 
 #### Worker Shutdown

--- a/lib/temporalio/errors.rb
+++ b/lib/temporalio/errors.rb
@@ -23,5 +23,18 @@ module Temporalio
     class Internal < Error; end
 
     class WorkerShutdown < Internal; end
+
+    # This error is used within the SDK to communicate Activity cancellations
+    # (and whether it was requested by server or not)
+    class ActivityCancelled < Internal
+      def initialize(reason, by_request)
+        super(reason)
+        @by_request = by_request
+      end
+
+      def by_request?
+        @by_request
+      end
+    end
   end
 end

--- a/lib/temporalio/worker.rb
+++ b/lib/temporalio/worker.rb
@@ -17,11 +17,26 @@ module Temporalio
     # finished) and will raise if any of the workers raises a fatal error.
     #
     # @param workers [Array<Temporalio::Worker>] A list of the workers to be run.
+    # @param stop_on_signal [Array<String>] A list of process signals for the worker to stop on.
+    #   This argument can not be used with a custom block.
     #
     # @yield Optionally you can provide a block by the end of which all the workers will be shut
     #   down. Any errors raised from this block will be re-raised by this method.
-    def self.run(*workers, &block)
-      # TODO: Add signal handling
+    def self.run(*workers, stop_on_signal: [], &block)
+      unless stop_on_signal.empty?
+        if block
+          raise ArgumentError, 'Temporalio::Worker.run accepts stop_on_signal: or a block, but not both'
+        end
+
+        signal_queue = Queue.new
+
+        stop_on_signal.each do |signal|
+          Signal.trap(signal) { signal_queue.close }
+        end
+
+        block = -> { signal_queue.pop }
+      end
+
       Runner.new(*workers).run(&block)
     end
 

--- a/lib/temporalio/worker.rb
+++ b/lib/temporalio/worker.rb
@@ -17,20 +17,20 @@ module Temporalio
     # finished) and will raise if any of the workers raises a fatal error.
     #
     # @param workers [Array<Temporalio::Worker>] A list of the workers to be run.
-    # @param stop_on_signal [Array<String>] A list of process signals for the worker to stop on.
+    # @param shutdown_signals [Array<String>] A list of process signals for the worker to stop on.
     #   This argument can not be used with a custom block.
     #
     # @yield Optionally you can provide a block by the end of which all the workers will be shut
     #   down. Any errors raised from this block will be re-raised by this method.
-    def self.run(*workers, stop_on_signal: [], &block)
-      unless stop_on_signal.empty?
+    def self.run(*workers, shutdown_signals: [], &block)
+      unless shutdown_signals.empty?
         if block
-          raise ArgumentError, 'Temporalio::Worker.run accepts stop_on_signal: or a block, but not both'
+          raise ArgumentError, 'Temporalio::Worker.run accepts :shutdown_signals or a block, but not both'
         end
 
         signal_queue = Queue.new
 
-        stop_on_signal.each do |signal|
+        shutdown_signals.each do |signal|
           Signal.trap(signal) { signal_queue.close }
         end
 

--- a/lib/temporalio/worker/activity_worker.rb
+++ b/lib/temporalio/worker/activity_worker.rb
@@ -43,7 +43,9 @@ module Temporalio
             if graceful_timeout
               async_task.async do
                 sleep graceful_timeout
-                running_activities.each_value(&:cancel)
+                running_activities.each_value do |activity_runner|
+                  activity_runner.cancel('Worker is shutting down', by_request: false)
+                end
               end
             end
 
@@ -129,7 +131,7 @@ module Temporalio
         end
 
         cancellations << task_token
-        runner&.cancel
+        runner&.cancel('Activity cancellation requested', by_request: true)
       end
     end
   end

--- a/lib/temporalio/worker/activity_worker.rb
+++ b/lib/temporalio/worker/activity_worker.rb
@@ -7,12 +7,13 @@ module Temporalio
   class Worker
     # @api private
     class ActivityWorker
-      def initialize(task_queue, core_worker, activities, converter, executor)
+      def initialize(task_queue, core_worker, activities, converter, executor, graceful_timeout)
         @task_queue = task_queue
         @worker = SyncWorker.new(core_worker)
         @activities = prepare_activities(activities)
         @converter = converter
         @executor = executor
+        @graceful_timeout = graceful_timeout
         @running_activities = {}
         @cancellations = []
         @drain_queue = Queue.new
@@ -37,8 +38,17 @@ module Temporalio
       rescue Temporalio::Bridge::Error::WorkerShutdown
         # No need to re-raise this error, it's a part of a normal shutdown
       ensure
-        reactor.async do
+        reactor.async do |async_task|
+          cancelation_task =
+            if graceful_timeout
+              async_task.async do
+                sleep graceful_timeout
+                running_activities.each_value(&:cancel)
+              end
+            end
+
           outstanding_tasks.each(&:wait)
+          cancelation_task&.stop # all tasks completed, stop cancellations
           drain_queue.close
         end
       end
@@ -49,8 +59,8 @@ module Temporalio
 
       private
 
-      attr_reader :task_queue, :worker, :activities, :converter, :executor, :running_activities,
-                  :cancellations, :drain_queue
+      attr_reader :task_queue, :worker, :activities, :converter, :executor, :graceful_timeout,
+                  :running_activities, :cancellations, :drain_queue
 
       def prepare_activities(activities)
         activities.each_with_object({}) do |activity, result|

--- a/lib/temporalio/worker/runner.rb
+++ b/lib/temporalio/worker/runner.rb
@@ -1,3 +1,5 @@
+require 'temporalio/errors'
+
 module Temporalio
   class Worker
     # A class used to manage the lifecycle of running any number of workers.

--- a/sig/async.rbs
+++ b/sig/async.rbs
@@ -8,6 +8,7 @@ module Async
   class Task
     def async: { (Async::Task) -> void } -> Async::Task
     def wait: -> void
+    def stop: -> void
   end
 end
 

--- a/sig/temporalio/activity/context.rbs
+++ b/sig/temporalio/activity/context.rbs
@@ -7,12 +7,12 @@ module Temporalio
       def heartbeat: (*untyped details) -> void
       def shield: { -> untyped } -> untyped
       def cancelled?: -> bool
-      def cancel: -> void
+      def cancel: (String reason, ?by_request: bool) -> void
 
       private
 
       @shielded: bool
-      @cancelled: bool
+      @pending_cancellation: Exception?
 
       attr_reader thread: Thread
       attr_reader heartbeat_proc: ^(*untyped) -> void

--- a/sig/temporalio/errors.rbs
+++ b/sig/temporalio/errors.rbs
@@ -23,5 +23,14 @@ module Temporalio
 
     class WorkerShutdown < Internal
     end
+
+    class ActivityCancelled < Internal
+      def initialize: (String reason, bool by_request) -> void
+      def by_request?: -> bool
+
+      private
+
+      @by_request: bool
+    end
   end
 end

--- a/sig/temporalio/worker.rbs
+++ b/sig/temporalio/worker.rbs
@@ -2,7 +2,7 @@ module Temporalio
   class Worker
     def self.run: (
       *Temporalio::Worker workers,
-      ?stop_on_signal: Array[String]
+      ?shutdown_signals: Array[String]
     ) ?{ -> void } -> void
 
     def initialize: (

--- a/sig/temporalio/worker.rbs
+++ b/sig/temporalio/worker.rbs
@@ -12,7 +12,8 @@ module Temporalio
       ?activities: Array[singleton(Temporalio::Activity)],
       ?data_converter: Temporalio::DataConverter,
       ?activity_executor: Temporalio::Worker::_ActivityExecutor?,
-      ?max_concurrent_activities: Integer
+      ?max_concurrent_activities: Integer,
+      ?graceful_shutdown_timeout: Integer?
     ) -> void
     def run: ?{ -> void } -> void
     def start: (?Temporalio::Worker::Runner? runner) -> void
@@ -33,13 +34,5 @@ module Temporalio
     attr_reader activity_worker: Temporalio::Worker::ActivityWorker?
     attr_reader workflow_worker: untyped
     attr_reader runner: Temporalio::Worker::Runner?
-
-    def init_activity_worker: (
-      String task_queue,
-      Temporalio::Bridge::Worker core_worker,
-      Array[singleton(Temporalio::Activity)] activities,
-      Temporalio::DataConverter data_converter,
-      Temporalio::Worker::_ActivityExecutor executor
-    ) -> Temporalio::Worker::ActivityWorker?
   end
 end

--- a/sig/temporalio/worker.rbs
+++ b/sig/temporalio/worker.rbs
@@ -1,6 +1,9 @@
 module Temporalio
   class Worker
-    def self.run: (*Temporalio::Worker workers) { -> void } -> void
+    def self.run: (
+      *Temporalio::Worker workers,
+      ?stop_on_signal: Array[String]
+    ) ?{ -> void } -> void
 
     def initialize: (
       Temporalio::Connection connection,
@@ -11,7 +14,7 @@ module Temporalio
       ?activity_executor: Temporalio::Worker::_ActivityExecutor?,
       ?max_concurrent_activities: Integer
     ) -> void
-    def run: { -> void } -> void
+    def run: ?{ -> void } -> void
     def start: (?Temporalio::Worker::Runner? runner) -> void
     def shutdown: (?Exception exception) -> void
 

--- a/sig/temporalio/worker/activity_runner.rbs
+++ b/sig/temporalio/worker/activity_runner.rbs
@@ -10,7 +10,7 @@ module Temporalio
         Temporalio::DataConverter converter
       ) -> void
       def run: -> (Temporalio::Api::Common::V1::Payload | Temporalio::Api::Failure::V1::Failure)
-      def cancel: -> void
+      def cancel: (String reason, by_request: bool) -> void
 
       private
 

--- a/sig/temporalio/worker/activity_worker.rbs
+++ b/sig/temporalio/worker/activity_worker.rbs
@@ -8,7 +8,8 @@ module Temporalio
         Temporalio::Bridge::Worker core_worker,
         Array[singleton(Temporalio::Activity)] activities,
         Temporalio::DataConverter converter,
-        Temporalio::Worker::_ActivityExecutor executor
+        Temporalio::Worker::_ActivityExecutor executor,
+        Integer? graceful_timeout
       ) -> void
       def run: (Async::Task reactor) -> void
       def drain: -> void
@@ -20,6 +21,7 @@ module Temporalio
       attr_reader activities: Hash[String, singleton(Temporalio::Activity)]
       attr_reader converter: Temporalio::DataConverter
       attr_reader executor: Temporalio::Worker::_ActivityExecutor
+      attr_reader graceful_timeout: Integer?
       attr_reader running_activities: Hash[String, Temporalio::Worker::ActivityRunner]
       attr_reader cancellations: Array[String]
       attr_reader drain_queue: Thread::Queue

--- a/sig/temporalio/worker/runner.rbs
+++ b/sig/temporalio/worker/runner.rbs
@@ -5,7 +5,7 @@ module Temporalio
       @shutdown: bool
 
       def initialize: (*Temporalio::Worker workers) -> void
-      def run: { -> void } -> void
+      def run: ?{ -> void } -> void
       def shutdown: (?Exception exception) -> void
 
       private

--- a/spec/integration/activity_worker_spec.rb
+++ b/spec/integration/activity_worker_spec.rb
@@ -57,7 +57,7 @@ class TestCancellingActivityWithShield < Temporalio::Activity
       end
     end
     i += 1 # this line will not get executed
-  rescue Temporalio::Error::CancelledError
+  rescue Temporalio::Error::ActivityCancelled
     i.to_s # expected to eq '10'
   end
 end
@@ -98,7 +98,7 @@ class TestCancellationIgnoringActivity < Temporalio::Activity
       activity.heartbeat
       i += 1
     end
-  rescue Temporalio::Error::CancelledError
+  rescue Temporalio::Error::ActivityCancelled
     i.to_s # expected to be less than '10'
   end
 end

--- a/spec/integration/worker_runner_spec.rb
+++ b/spec/integration/worker_runner_spec.rb
@@ -212,13 +212,16 @@ describe Temporalio::Worker::Runner do
 
         subject.run
 
-        # TODO: finish this after figuring out why a cancellation isn't propagated
-        # expect { handle_1.result }.to raise_error do |error|
-        #   # TODO: Fill in error details
-        # end
-        # expect { handle_2.result }.to raise_error do |error|
-        #   # TODO: Fill in error details
-        # end
+        expect { handle_1.result }.to raise_error do |error|
+          expect(error).to be_a(Temporalio::Error::WorkflowFailure)
+          expect(error.cause).to be_a(Temporalio::Error::ActivityError)
+          expect(error.cause.message).to eq('activity error')
+        end
+        expect { handle_2.result }.to raise_error do |error|
+          expect(error).to be_a(Temporalio::Error::WorkflowFailure)
+          expect(error.cause).to be_a(Temporalio::Error::ActivityError)
+          expect(error.cause.message).to eq('activity error')
+        end
       end
     end
   end

--- a/spec/integration/worker_runner_spec.rb
+++ b/spec/integration/worker_runner_spec.rb
@@ -191,7 +191,7 @@ describe Temporalio::Worker::Runner do
         Process.kill('USR2', Process.pid)
       end
 
-      Temporalio::Worker.run(worker_1, worker_2, stop_on_signal: %w[USR2])
+      Temporalio::Worker.run(worker_1, worker_2, shutdown_signals: %w[USR2])
 
       expect(handle_1.result).to eq('1')
       expect(handle_2.result).to eq('2')

--- a/spec/support/go_worker/main.go
+++ b/spec/support/go_worker/main.go
@@ -29,7 +29,7 @@ func run(endpoint, namespace, taskQueue string) error {
 	defer cl.Close()
 
 	log.Printf("Creating worker")
-	w := worker.New(cl, taskQueue, worker.Options{})
+	w := worker.New(cl, taskQueue, worker.Options{MaxConcurrentWorkflowTaskPollers: 4})
 	w.RegisterWorkflowWithOptions(KitchenSinkWorkflow, workflow.RegisterOptions{Name: "kitchen_sink"})
 	defer log.Printf("Stopping worker")
 

--- a/spec/unit/temporalio/worker/activity_worker_spec.rb
+++ b/spec/unit/temporalio/worker/activity_worker_spec.rb
@@ -15,7 +15,7 @@ end
 class TestWrongSuperclassActivity < Object; end
 
 describe Temporalio::Worker::ActivityWorker do
-  subject { described_class.new(task_queue, core_worker, activities, converter, executor) }
+  subject { described_class.new(task_queue, core_worker, activities, converter, executor, graceful_timeout) }
 
   let(:task_queue) { 'test-task-queue' }
   let(:activities) { [TestActivity] }
@@ -23,6 +23,7 @@ describe Temporalio::Worker::ActivityWorker do
   let(:core_worker) { instance_double(Temporalio::Bridge::Worker) }
   let(:runner) { instance_double(Temporalio::Worker::ActivityRunner) }
   let(:executor) { Temporalio::Worker::ThreadPoolExecutor.new(1) }
+  let(:graceful_timeout) { nil }
   let(:converter) { Temporalio::DataConverter.new }
 
   describe '#initialize' do

--- a/spec/unit/temporalio/worker_spec.rb
+++ b/spec/unit/temporalio/worker_spec.rb
@@ -37,9 +37,9 @@ describe Temporalio::Worker do
       end
     end
 
-    context 'when stop_on_signal is provided' do
+    context 'when shutdown_signals is provided' do
       it 'initializes a Runner and runs it' do
-        described_class.run(worker_one, worker_two, stop_on_signal: %w[USR2])
+        described_class.run(worker_one, worker_two, shutdown_signals: %w[USR2])
 
         expect(Temporalio::Worker::Runner).to have_received(:new).with(worker_one, worker_two)
         expect(runner).to have_received(:run) do |&block|

--- a/spec/unit/temporalio/worker_spec.rb
+++ b/spec/unit/temporalio/worker_spec.rb
@@ -36,6 +36,17 @@ describe Temporalio::Worker do
         expect(block).to eq(run_block)
       end
     end
+
+    context 'when stop_on_signal is provided' do
+      it 'initializes a Runner and runs it' do
+        described_class.run(worker_one, worker_two, stop_on_signal: %w[USR2])
+
+        expect(Temporalio::Worker::Runner).to have_received(:new).with(worker_one, worker_two)
+        expect(runner).to have_received(:run) do |&block|
+          expect(block).to an_instance_of(Proc)
+        end
+      end
+    end
   end
 
   describe '#initialize' do


### PR DESCRIPTION
## What was changed
This PR adds 2 new features to the `Worker`:

1. Allow users to specify process signals to result in a worker shutdown procedure
2. Allow users to specify a graceful shutdown timeout after which running activities will get cancelled (but still waited on indefinitely)

P.S. This is not yet ready for a review because there's an issue — for some Temporal Server ignores failures of a type "cancelled_failure" when delivered outside of an activity cancellation request.

## Checklist

1. Closes #98 
2. Closes #92 

4. How was this tested:
Unit and integration specs added

5. Any docs updates needed?
README and YARD docs updated