### PR TITLE
[Feature] Activity Interceptors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
     - vendor/**/*
     - spec/support/grpc/**/*
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 Gemspec/RequireMFA:
   Enabled: false
 

--- a/lib/temporalio/interceptor/activity_inbound.rb
+++ b/lib/temporalio/interceptor/activity_inbound.rb
@@ -1,0 +1,20 @@
+module Temporalio
+  module Interceptor
+    # A mixin for implementing inbound Activity interceptors.
+    module ActivityInbound
+      class ExecuteActivityInput < Struct.new(
+        :activity,
+        :args,
+        :headers,
+        keyword_init: true,
+      ); end
+
+      # Interceptor for {Temporalio::Activity#execute}.
+      #
+      # @param input [ExecuteActivityInput]
+      def execute_activity(input)
+        yield(input)
+      end
+    end
+  end
+end

--- a/lib/temporalio/interceptor/activity_outbound.rb
+++ b/lib/temporalio/interceptor/activity_outbound.rb
@@ -1,0 +1,20 @@
+module Temporalio
+  module Interceptor
+    # A mixin for implementing outbound Activity interceptors.
+    module ActivityOutbound
+      # Interceptor for {Temporalio::Activity::Context#info}.
+      #
+      # @return [Temporalio::Activity::Info]
+      def info
+        yield
+      end
+
+      # Interceptor for {Temporalio::Activity::Context#heartbeat}.
+      #
+      # @param details [any] A list of details supplied with the heartbeat.
+      def heartbeat(*details)
+        yield(*details)
+      end
+    end
+  end
+end

--- a/lib/temporalio/interceptor/chain.rb
+++ b/lib/temporalio/interceptor/chain.rb
@@ -6,18 +6,18 @@ module Temporalio
         @interceptors = interceptors
       end
 
-      def invoke(method, input)
+      def invoke(method, *input)
         chain = interceptors.dup
 
-        traverse_chain = lambda do |i|
+        traverse_chain = lambda do |*i|
           if chain.empty?
-            yield(i)
+            yield(*i)
           else
-            chain.shift.public_send(method, i, &traverse_chain)
+            chain.shift.public_send(method, *i, &traverse_chain)
           end
         end
 
-        traverse_chain.call(input)
+        traverse_chain.call(*input)
       end
 
       private

--- a/lib/temporalio/interceptor/client.rb
+++ b/lib/temporalio/interceptor/client.rb
@@ -78,6 +78,8 @@ module Temporalio
       # Interceptor for {Temporalio::Client#start_workflow}.
       #
       # @param input [StartWorkflowInput]
+      #
+      # @return [Temporalio::Client::WorkflowHandle] A handle to interact with the workflow.
       def start_workflow(input)
         yield(input)
       end
@@ -85,6 +87,8 @@ module Temporalio
       # Interceptor for {Temporalio::Client::WorkflowHandle#describe}.
       #
       # @param input [DescribeWorkflowInput]
+      #
+      # @return [Temporalio::Workflow::ExecutionInfo] Information about the workflow.
       def describe_workflow(input)
         yield(input)
       end
@@ -92,6 +96,8 @@ module Temporalio
       # Interceptor for {Temporalio::Client::WorkflowHandle#query}.
       #
       # @param input [QueryWorkflowInput]
+      #
+      # @return [any] Query result
       def query_workflow(input)
         yield(input)
       end

--- a/lib/temporalio/interceptor/client.rb
+++ b/lib/temporalio/interceptor/client.rb
@@ -1,9 +1,7 @@
 module Temporalio
   module Interceptor
-    # Base class for implementing Client side interceptors.
-    #
-    # @abstract
-    class Client
+    # A mixin for implementing Client side interceptors.
+    module Client
       class StartWorkflowInput < Struct.new(
         :workflow,
         :args,

--- a/lib/temporalio/worker.rb
+++ b/lib/temporalio/worker.rb
@@ -50,6 +50,8 @@ module Temporalio
     #   to/from payloads.
     # @param activity_executor [ThreadPoolExecutor] Concurrent executor for all activities. Defaults
     #   to a {ThreadPoolExecutor} with `:max_concurrent_activities` available threads.
+    # @param interceptors [Array<Temporalio::Interceptor::ActivityInbound, Temporalio::Interceptor::ActivityOutbound>]
+    #   Collection of interceptors for this worker.
     # @param max_concurrent_activities [Integer] Number of concurrently running activities.
     # @param graceful_shutdown_timeout [Integer] Amount of time (in seconds) activities are given
     #   after a shutdown to complete before they are cancelled. A default value of `nil` means that
@@ -63,10 +65,10 @@ module Temporalio
       activities: [],
       data_converter: Temporalio::DataConverter.new,
       activity_executor: nil,
+      interceptors: [],
       max_concurrent_activities: 100,
       graceful_shutdown_timeout: nil
     )
-      # TODO: Add worker interceptors
       @started = false
       @shutdown = false
       @mutex = Mutex.new
@@ -85,6 +87,7 @@ module Temporalio
             @core_worker,
             activities,
             data_converter,
+            interceptors,
             @activity_executor,
             graceful_shutdown_timeout,
           )

--- a/sig/temporalio/activity/context.rbs
+++ b/sig/temporalio/activity/context.rbs
@@ -1,9 +1,13 @@
 module Temporalio
   class Activity
     class Context
-      attr_reader info: Temporalio::Activity::Info
-
-      def initialize: (Temporalio::Activity::Info info, ^(*untyped) -> void, ?shielded: bool) -> void
+      def initialize: (
+        Temporalio::Activity::Info info,
+        ^(*untyped) -> void,
+        Temporalio::Interceptor::Chain[Temporalio::Interceptor::ActivityOutbound],
+        ?shielded: bool
+      ) -> void
+      def info: -> Temporalio::Activity::Info
       def heartbeat: (*untyped details) -> void
       def shield: { -> untyped } -> untyped
       def cancelled?: -> bool
@@ -11,11 +15,13 @@ module Temporalio
 
       private
 
+      @info: Temporalio::Activity::Info
+      @heartbeat_proc: ^(*untyped) -> void
       @shielded: bool
       @pending_cancellation: Exception?
 
       attr_reader thread: Thread
-      attr_reader heartbeat_proc: ^(*untyped) -> void
+      attr_reader interceptors: Temporalio::Interceptor::Chain[Temporalio::Interceptor::ActivityOutbound]
       attr_reader mutex: Thread::Mutex
     end
   end

--- a/sig/temporalio/client.rbs
+++ b/sig/temporalio/client.rbs
@@ -5,7 +5,7 @@ module Temporalio
     def initialize: (
       Temporalio::Connection connection,
       String | Symbol namespace,
-      ?interceptors: Array[Temporalio::Interceptor::Client],
+      ?interceptors: Array[Temporalio::Interceptor::Client::_Interface],
       ?data_converter: Temporalio::DataConverter
     ) -> void
     def start_workflow: (

--- a/sig/temporalio/client.rbs
+++ b/sig/temporalio/client.rbs
@@ -5,7 +5,7 @@ module Temporalio
     def initialize: (
       Temporalio::Connection connection,
       String | Symbol namespace,
-      ?interceptors: Array[Temporalio::Interceptor::Client::_Interface],
+      ?interceptors: Array[Temporalio::Interceptor::Client],
       ?data_converter: Temporalio::DataConverter
     ) -> void
     def start_workflow: (

--- a/sig/temporalio/client/implementation.rbs
+++ b/sig/temporalio/client/implementation.rbs
@@ -5,7 +5,7 @@ module Temporalio
         Temporalio::Connection connection,
         Symbol | String namespace,
         Temporalio::DataConverter converter,
-        Array[Temporalio::Interceptor::Client] interceptors
+        Array[Temporalio::Interceptor::Client::_Interface] interceptors
       ) -> void
 
       def start_workflow: (Temporalio::Interceptor::Client::StartWorkflowInput input) -> Temporalio::Client::WorkflowHandle

--- a/sig/temporalio/client/implementation.rbs
+++ b/sig/temporalio/client/implementation.rbs
@@ -5,7 +5,7 @@ module Temporalio
         Temporalio::Connection connection,
         Symbol | String namespace,
         Temporalio::DataConverter converter,
-        Array[Temporalio::Interceptor::Client::_Interface] interceptors
+        Array[Temporalio::Interceptor::Client] interceptors
       ) -> void
 
       def start_workflow: (Temporalio::Interceptor::Client::StartWorkflowInput input) -> Temporalio::Client::WorkflowHandle

--- a/sig/temporalio/client/implementation.rbs
+++ b/sig/temporalio/client/implementation.rbs
@@ -21,7 +21,7 @@ module Temporalio
       attr_reader connection: Temporalio::Connection
       attr_reader namespace: Symbol | String
       attr_reader converter: Temporalio::DataConverter
-      attr_reader interceptor_chain: Interceptor::Chain
+      attr_reader interceptor_chain: Temporalio::Interceptor::Chain[Temporalio::Interceptor::Client]
       attr_reader identity: String
 
       def convert_headers: (Hash[Symbol | String, untyped]) -> Temporalio::Api::Common::V1::Header?

--- a/sig/temporalio/interceptor/activity_inbound.rbs
+++ b/sig/temporalio/interceptor/activity_inbound.rbs
@@ -1,0 +1,21 @@
+module Temporalio
+  module Interceptor
+    module ActivityInbound
+      type methods = (:execute_activity)
+
+      def execute_activity: (ExecuteActivityInput input) ?{ (ExecuteActivityInput) -> untyped } -> untyped
+
+      class ExecuteActivityInput < Struct[untyped]
+        attr_accessor activity: singleton(Temporalio::Activity)
+        attr_accessor args: Array[untyped]
+        attr_accessor headers: Hash[String, Temporalio::Api::Common::V1::Payload]
+
+        def self.new: (
+          activity: singleton(Temporalio::Activity),
+          args: Array[untyped],
+          headers: Hash[String, Temporalio::Api::Common::V1::Payload],
+        ) -> ExecuteActivityInput
+      end
+    end
+  end
+end

--- a/sig/temporalio/interceptor/activity_outbound.rbs
+++ b/sig/temporalio/interceptor/activity_outbound.rbs
@@ -1,0 +1,10 @@
+module Temporalio
+  module Interceptor
+    module ActivityOutbound
+      type methods = (:info | :heartbeat)
+
+      def info: ?{ () -> Temporalio::Activity::Info } -> Temporalio::Activity::Info
+      def heartbeat: (*untyped details) ?{ (*untyped) -> void } -> void
+    end
+  end
+end

--- a/sig/temporalio/interceptor/chain.rbs
+++ b/sig/temporalio/interceptor/chain.rbs
@@ -1,13 +1,13 @@
 module Temporalio
   module Interceptor
     class Chain
-      def initialize: (?Array[Temporalio::Interceptor::Client::_Interface]) -> void
+      def initialize: (?Array[Temporalio::Interceptor::Client]) -> void
       # TODO: RBS fails to interpret the inline block defined in #invoke
       def invoke: (Temporalio::Interceptor::Client::interface_method method, untyped input) { (untyped) -> untyped } -> untyped
 
       private
 
-      attr_reader interceptors: Array[Temporalio::Interceptor::Client::_Interface]
+      attr_reader interceptors: Array[Temporalio::Interceptor::Client]
     end
   end
 end

--- a/sig/temporalio/interceptor/chain.rbs
+++ b/sig/temporalio/interceptor/chain.rbs
@@ -1,13 +1,24 @@
 module Temporalio
   module Interceptor
-    class Chain
-      def initialize: (?Array[Temporalio::Interceptor::Client]) -> void
+    class Chain[T < _PublicSend]
+      type interceptor_methods =
+        Temporalio::Interceptor::Client::methods |
+        Temporalio::Interceptor::ActivityInbound::methods |
+        Temporalio::Interceptor::ActivityOutbound::methods
+
+      # NOTE: RBS is not smart enough to figure out which methods are callable per each interceptor
+      #       class, so we're just allowing any of them to be called on any interceptor.
+      interface _PublicSend
+        def public_send: (interceptor_methods, *untyped) { (*untyped) -> untyped } -> untyped
+      end
+
+      def initialize: (?Array[T]) -> void
       # TODO: RBS fails to interpret the inline block defined in #invoke
-      def invoke: (Temporalio::Interceptor::Client::interface_method method, untyped input) { (untyped) -> untyped } -> untyped
+      def invoke: (interceptor_methods, *untyped) { (*untyped) -> untyped } -> untyped
 
       private
 
-      attr_reader interceptors: Array[Temporalio::Interceptor::Client]
+      attr_reader interceptors: Array[T]
     end
   end
 end

--- a/sig/temporalio/interceptor/client.rbs
+++ b/sig/temporalio/interceptor/client.rbs
@@ -3,15 +3,13 @@ module Temporalio
     module Client
       type interface_method = (:start_workflow | :describe_workflow | :query_workflow | :signal_workflow | :cancel_workflow | :terminate_workflow)
 
-      interface _Interface
-        def public_send: (interface_method, untyped input) { (untyped) -> untyped } -> untyped
-        def start_workflow: (StartWorkflowInput input) ?{ (StartWorkflowInput) -> Temporalio::Client::WorkflowHandle } -> Temporalio::Client::WorkflowHandle
-        def describe_workflow: (DescribeWorkflowInput input) ?{ (DescribeWorkflowInput) -> Temporalio::Workflow::ExecutionInfo } -> Temporalio::Workflow::ExecutionInfo
-        def query_workflow: (QueryWorkflowInput input) ?{ (QueryWorkflowInput) -> untyped } -> untyped
-        def signal_workflow: (SignalWorkflowInput input) ?{ (SignalWorkflowInput) -> void } -> void
-        def cancel_workflow: (CancelWorkflowInput input) ?{ (CancelWorkflowInput) -> void } -> void
-        def terminate_workflow: (TerminateWorkflowInput input) ?{ (TerminateWorkflowInput) -> void } -> void
-      end
+      def public_send: (interface_method, untyped input) { (untyped) -> untyped } -> untyped
+      def start_workflow: (StartWorkflowInput input) ?{ (StartWorkflowInput) -> Temporalio::Client::WorkflowHandle } -> Temporalio::Client::WorkflowHandle
+      def describe_workflow: (DescribeWorkflowInput input) ?{ (DescribeWorkflowInput) -> Temporalio::Workflow::ExecutionInfo } -> Temporalio::Workflow::ExecutionInfo
+      def query_workflow: (QueryWorkflowInput input) ?{ (QueryWorkflowInput) -> untyped } -> untyped
+      def signal_workflow: (SignalWorkflowInput input) ?{ (SignalWorkflowInput) -> void } -> void
+      def cancel_workflow: (CancelWorkflowInput input) ?{ (CancelWorkflowInput) -> void } -> void
+      def terminate_workflow: (TerminateWorkflowInput input) ?{ (TerminateWorkflowInput) -> void } -> void
 
       class StartWorkflowInput < Struct[untyped]
         attr_accessor workflow(): String

--- a/sig/temporalio/interceptor/client.rbs
+++ b/sig/temporalio/interceptor/client.rbs
@@ -1,6 +1,6 @@
 module Temporalio
   module Interceptor
-    class Client
+    module Client
       type interface_method = (:start_workflow | :describe_workflow | :query_workflow | :signal_workflow | :cancel_workflow | :terminate_workflow)
 
       interface _Interface
@@ -12,9 +12,6 @@ module Temporalio
         def cancel_workflow: (CancelWorkflowInput input) ?{ (CancelWorkflowInput) -> void } -> void
         def terminate_workflow: (TerminateWorkflowInput input) ?{ (TerminateWorkflowInput) -> void } -> void
       end
-
-      # Client implements its own interface
-      include _Interface
 
       class StartWorkflowInput < Struct[untyped]
         attr_accessor workflow(): String

--- a/sig/temporalio/interceptor/client.rbs
+++ b/sig/temporalio/interceptor/client.rbs
@@ -1,9 +1,8 @@
 module Temporalio
   module Interceptor
     module Client
-      type interface_method = (:start_workflow | :describe_workflow | :query_workflow | :signal_workflow | :cancel_workflow | :terminate_workflow)
+      type methods = (:start_workflow | :describe_workflow | :query_workflow | :signal_workflow | :cancel_workflow | :terminate_workflow)
 
-      def public_send: (interface_method, untyped input) { (untyped) -> untyped } -> untyped
       def start_workflow: (StartWorkflowInput input) ?{ (StartWorkflowInput) -> Temporalio::Client::WorkflowHandle } -> Temporalio::Client::WorkflowHandle
       def describe_workflow: (DescribeWorkflowInput input) ?{ (DescribeWorkflowInput) -> Temporalio::Workflow::ExecutionInfo } -> Temporalio::Workflow::ExecutionInfo
       def query_workflow: (QueryWorkflowInput input) ?{ (QueryWorkflowInput) -> untyped } -> untyped

--- a/sig/temporalio/worker.rbs
+++ b/sig/temporalio/worker.rbs
@@ -1,5 +1,9 @@
 module Temporalio
   class Worker
+    type worker_interceptor =
+      Temporalio::Interceptor::ActivityInbound |
+      Temporalio::Interceptor::ActivityOutbound
+
     def self.run: (
       *Temporalio::Worker workers,
       ?shutdown_signals: Array[String]

--- a/sig/temporalio/worker.rbs
+++ b/sig/temporalio/worker.rbs
@@ -16,6 +16,7 @@ module Temporalio
       ?activities: Array[singleton(Temporalio::Activity)],
       ?data_converter: Temporalio::DataConverter,
       ?activity_executor: Temporalio::Worker::_ActivityExecutor?,
+      ?interceptors: Array[worker_interceptor],
       ?max_concurrent_activities: Integer,
       ?graceful_shutdown_timeout: Integer?
     ) -> void

--- a/sig/temporalio/worker/activity_runner.rbs
+++ b/sig/temporalio/worker/activity_runner.rbs
@@ -7,7 +7,9 @@ module Temporalio
         String task_queue,
         String task_token,
         Temporalio::Worker::SyncWorker worker,
-        Temporalio::DataConverter converter
+        Temporalio::DataConverter converter,
+        Temporalio::Interceptor::Chain[Temporalio::Interceptor::ActivityInbound] inbound_interceptors,
+        Temporalio::Interceptor::Chain[Temporalio::Interceptor::ActivityOutbound] outbound_interceptors
       ) -> void
       def run: -> (Temporalio::Api::Common::V1::Payload | Temporalio::Api::Failure::V1::Failure)
       def cancel: (String reason, by_request: bool) -> void
@@ -22,6 +24,8 @@ module Temporalio
       attr_reader task_token: String
       attr_reader worker: Temporalio::Worker::SyncWorker
       attr_reader converter: Temporalio::DataConverter
+      attr_reader inbound_interceptors: Temporalio::Interceptor::Chain[Temporalio::Interceptor::ActivityInbound]
+      attr_reader outbound_interceptors: Temporalio::Interceptor::Chain[Temporalio::Interceptor::ActivityOutbound]
 
       def context: -> Temporalio::Activity::Context
       def generate_activity_info: -> Temporalio::Activity::Info

--- a/sig/temporalio/worker/activity_worker.rbs
+++ b/sig/temporalio/worker/activity_worker.rbs
@@ -8,6 +8,7 @@ module Temporalio
         Temporalio::Bridge::Worker core_worker,
         Array[singleton(Temporalio::Activity)] activities,
         Temporalio::DataConverter converter,
+        Array[Temporalio::Worker::worker_interceptor] interceptors,
         Temporalio::Worker::_ActivityExecutor executor,
         Integer? graceful_timeout
       ) -> void
@@ -20,6 +21,8 @@ module Temporalio
       attr_reader worker: SyncWorker
       attr_reader activities: Hash[String, singleton(Temporalio::Activity)]
       attr_reader converter: Temporalio::DataConverter
+      attr_reader inbound_interceptors: Temporalio::Interceptor::Chain[Temporalio::Interceptor::ActivityInbound]
+      attr_reader outbound_interceptors: Temporalio::Interceptor::Chain[Temporalio::Interceptor::ActivityOutbound]
       attr_reader executor: Temporalio::Worker::_ActivityExecutor
       attr_reader graceful_timeout: Integer?
       attr_reader running_activities: Hash[String, Temporalio::Worker::ActivityRunner]
@@ -34,6 +37,10 @@ module Temporalio
         -> (Temporalio::Api::Common::V1::Payload | Temporalio::Api::Failure::V1::Failure)
       def handle_start_activity: (String task_token, Coresdk::ActivityTask::Start task) -> void
       def handle_cancel_activity: (String task_token, Coresdk::ActivityTask::Cancel task) -> void
+      def filter_inbound: (Array[Temporalio::Worker::worker_interceptor] interceptors)
+        -> Array[Temporalio::Interceptor::ActivityInbound]
+      def filter_outbound: (Array[Temporalio::Worker::worker_interceptor] interceptors)
+        -> Array[Temporalio::Interceptor::ActivityOutbound]
     end
   end
 end

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -6,7 +6,9 @@ require 'temporalio/error/workflow_failure'
 require 'temporalio/interceptor/client'
 require 'support/helpers/test_rpc'
 
-class TestInterceptor < Temporalio::Interceptor::Client
+class TestInterceptor
+  include Temporalio::Interceptor::Client
+
   attr_reader :results
 
   def initialize

--- a/spec/support/helpers/test_capture_interceptor.rb
+++ b/spec/support/helpers/test_capture_interceptor.rb
@@ -1,8 +1,12 @@
+require 'temporalio/interceptor/activity_inbound'
+require 'temporalio/interceptor/activity_outbound'
 require 'temporalio/interceptor/client'
 
 module Helpers
   class TestCaptureInterceptor
     include Temporalio::Interceptor::Client
+    include Temporalio::Interceptor::ActivityInbound
+    include Temporalio::Interceptor::ActivityOutbound
 
     attr_reader :called_methods
 
@@ -38,6 +42,21 @@ module Helpers
 
     def terminate_workflow(input)
       @called_methods << :terminate_workflow
+      super
+    end
+
+    def execute_activity(input)
+      @called_methods << :execute_activity
+      super
+    end
+
+    def info
+      @called_methods << :info
+      super
+    end
+
+    def heartbeat(*details)
+      @called_methods << :heartbeat
       super
     end
   end

--- a/spec/support/helpers/test_capture_interceptor.rb
+++ b/spec/support/helpers/test_capture_interceptor.rb
@@ -1,7 +1,9 @@
 require 'temporalio/interceptor/client'
 
 module Helpers
-  class TestCaptureInterceptor < Temporalio::Interceptor::Client
+  class TestCaptureInterceptor
+    include Temporalio::Interceptor::Client
+
     attr_reader :called_methods
 
     def initialize

--- a/spec/support/helpers/test_simple_interceptor.rb
+++ b/spec/support/helpers/test_simple_interceptor.rb
@@ -1,8 +1,10 @@
 require 'temporalio/interceptor/client'
+require 'temporalio/interceptor/activity_outbound'
 
 module Helpers
   class TestSimpleInterceptor
     include Temporalio::Interceptor::Client
+    include Temporalio::Interceptor::ActivityOutbound
 
     def initialize(name)
       @name = name
@@ -14,6 +16,12 @@ module Helpers
       result = yield(input)
       result << "after_#{@name}"
       result
+    end
+
+    def info
+      info = yield
+      info.heartbeat_details << @name
+      info
     end
   end
 end

--- a/spec/support/helpers/test_simple_interceptor.rb
+++ b/spec/support/helpers/test_simple_interceptor.rb
@@ -1,7 +1,9 @@
 require 'temporalio/interceptor/client'
 
 module Helpers
-  class TestSimpleInterceptor < Temporalio::Interceptor::Client
+  class TestSimpleInterceptor
+    include Temporalio::Interceptor::Client
+
     def initialize(name)
       @name = name
       super()

--- a/spec/unit/temporalio/interceptor/activity_inbound_spec.rb
+++ b/spec/unit/temporalio/interceptor/activity_inbound_spec.rb
@@ -1,0 +1,17 @@
+require 'temporalio/interceptor/activity_inbound'
+
+class TestActivityInboundInterceptor
+  include Temporalio::Interceptor::ActivityInbound
+end
+
+describe Temporalio::Interceptor::ActivityInbound do
+  subject { TestActivityInboundInterceptor.new }
+
+  describe '#execute_activity' do
+    let(:input) { Temporalio::Interceptor::ActivityInbound::ExecuteActivityInput.new }
+
+    it 'yields' do
+      expect { |b| subject.execute_activity(input, &b) }.to yield_with_args(input)
+    end
+  end
+end

--- a/spec/unit/temporalio/interceptor/activity_outbound_spec.rb
+++ b/spec/unit/temporalio/interceptor/activity_outbound_spec.rb
@@ -1,0 +1,23 @@
+require 'temporalio/interceptor/activity_outbound'
+
+class TestActivityOutboundInterceptor
+  include Temporalio::Interceptor::ActivityOutbound
+end
+
+describe Temporalio::Interceptor::ActivityOutbound do
+  subject { TestActivityOutboundInterceptor.new }
+
+  describe '#info' do
+    it 'yields' do
+      expect { |b| subject.info(&b) }.to yield_control
+    end
+  end
+
+  describe '#heartbeat' do
+    let(:input) { ['foo', 'bar', 42] }
+
+    it 'yields' do
+      expect { |b| subject.heartbeat(*input, &b) }.to yield_with_args(*input)
+    end
+  end
+end

--- a/spec/unit/temporalio/interceptor/chain_spec.rb
+++ b/spec/unit/temporalio/interceptor/chain_spec.rb
@@ -1,6 +1,6 @@
 require 'support/helpers/test_simple_interceptor'
+require 'temporalio/activity/info'
 require 'temporalio/interceptor/chain'
-require 'temporalio/interceptor/client'
 
 describe Temporalio::Interceptor::Chain do
   subject { described_class.new(interceptors) }
@@ -22,6 +22,15 @@ describe Temporalio::Interceptor::Chain do
       expect(result).to eq(%w[before_a before_b main after_b after_a])
     end
 
+    it 'works for methods that take no arguments' do
+      result = subject.invoke(:info) do
+        Temporalio::Activity::Info.new(heartbeat_details: ['main'])
+      end
+
+      expect(result).to be_a(Temporalio::Activity::Info)
+      expect(result.heartbeat_details).to eq(%w[main b a])
+    end
+
     context 'without interceptors' do
       let(:interceptors) { [] }
 
@@ -32,6 +41,15 @@ describe Temporalio::Interceptor::Chain do
         end
 
         expect(result).to eq(%w[main])
+      end
+
+      it 'works for methods that take no arguments' do
+        result = subject.invoke(:info) do
+          Temporalio::Activity::Info.new(heartbeat_details: ['main'])
+        end
+
+        expect(result).to be_a(Temporalio::Activity::Info)
+        expect(result.heartbeat_details).to eq(%w[main])
       end
     end
   end

--- a/spec/unit/temporalio/interceptor/client_spec.rb
+++ b/spec/unit/temporalio/interceptor/client_spec.rb
@@ -1,7 +1,11 @@
 require 'temporalio/interceptor/client'
 
+class TestClientInterceptor
+  include Temporalio::Interceptor::Client
+end
+
 describe Temporalio::Interceptor::Client do
-  subject { described_class.new }
+  subject { TestClientInterceptor.new }
 
   describe '#start_workflow' do
     let(:input) { Temporalio::Interceptor::Client::StartWorkflowInput.new }

--- a/spec/unit/temporalio/worker/activity_worker_spec.rb
+++ b/spec/unit/temporalio/worker/activity_worker_spec.rb
@@ -15,7 +15,17 @@ end
 class TestWrongSuperclassActivity < Object; end
 
 describe Temporalio::Worker::ActivityWorker do
-  subject { described_class.new(task_queue, core_worker, activities, converter, executor, graceful_timeout) }
+  subject do
+    described_class.new(
+      task_queue,
+      core_worker,
+      activities,
+      converter,
+      interceptors,
+      executor,
+      graceful_timeout,
+    )
+  end
 
   let(:task_queue) { 'test-task-queue' }
   let(:activities) { [TestActivity] }
@@ -25,6 +35,7 @@ describe Temporalio::Worker::ActivityWorker do
   let(:executor) { Temporalio::Worker::ThreadPoolExecutor.new(1) }
   let(:graceful_timeout) { nil }
   let(:converter) { Temporalio::DataConverter.new }
+  let(:interceptors) { [] }
 
   describe '#initialize' do
     context 'when initialized with an incorrect activity class' do


### PR DESCRIPTION
## What was changed
This PR introduces inbound and outbound interceptors for activities. It also modifies the interceptor interface (from a superclass to a mixin), allowing a single class to implement multiple interceptors:

```ruby
class MyInterceptor
  include Temporalio::Interceptor::ActivityInbound
  include Temporalio::Interceptor::Client

  def execute_activity(input)
    ...
    super
  end

  def start_workflow(input)
    ...
    super
  end
end
```

## Checklist

1. Closes #85 

2. How was this tested:
Both unit tests and integration tests added

3. Any docs updates needed?
Inline docs were updated