### PR TITLE
chore(core): Update sdk-core and refactor shutdown process

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -53,17 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
-name = "async-channel"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,12 +238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
-
-[[package]]
 name = "cc"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,15 +270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -581,12 +555,6 @@ checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
@@ -2182,7 +2150,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "async-channel",
  "async-trait",
  "base64 0.21.0",
  "crossbeam",

--- a/bridge/src/connection.rs
+++ b/bridge/src/connection.rs
@@ -4,14 +4,14 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use temporal_client::{
-    ClientInitError, ClientOptionsBuilder, ClientOptionsBuilderError, WorkflowService, RetryClient,
-    ConfiguredClient, TemporalServiceClientWithMetrics, TestService
+    ClientInitError, ClientOptionsBuilder, ClientOptionsBuilderError, ConfiguredClient,
+    RetryClient, TemporalServiceClientWithMetrics, TestService, WorkflowService,
 };
 use thiserror::Error;
-use tokio::{select};
-use tokio::runtime::{Runtime};
+use tokio::runtime::Runtime;
+use tokio::select;
 use tokio_util::sync::CancellationToken;
-use tonic::metadata::{MetadataKey,MetadataValue};
+use tonic::metadata::{MetadataKey, MetadataValue};
 use url::Url;
 
 pub type Client = RetryClient<ConfiguredClient<TemporalServiceClientWithMetrics>>;

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -133,7 +133,7 @@ methods!(
                 service: service.clone(),
                 request: request.clone(),
                 metadata: metadata.clone(),
-            timeout_millis: timeout
+                timeout_millis: timeout
             };
             connection.call(params, token.clone())
         }, Some(|| { token.cancel() }));

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -10,12 +10,12 @@ mod worker;
 use connection::{Connection, RpcParams};
 use runtime::Runtime;
 use rutie::{
-    Module, Object, Symbol, RString, Encoding, AnyObject, AnyException, Exception, VM, Thread,
-    NilClass, Hash, Integer, Boolean, Array,
+    AnyException, AnyObject, Array, Boolean, Encoding, Exception, Hash, Integer, Module, NilClass,
+    Object, RString, Symbol, Thread, VM,
 };
 use std::collections::HashMap;
 use temporal_sdk_core_api::telemetry::{Logger, TelemetryOptionsBuilder};
-use test_server::{TestServer, TestServerConfig, TemporaliteConfig};
+use test_server::{TemporaliteConfig, TestServer, TestServerConfig};
 use tokio_util::sync::CancellationToken;
 use worker::{Worker, WorkerError, WorkerResult};
 
@@ -127,15 +127,15 @@ methods!(
         let token = CancellationToken::new();
 
         let result = Thread::call_without_gvl(|| {
-            let connection = _rtself.get_data_mut(&*CONNECTION_WRAPPER);
-            let params = RpcParams {
-                rpc: rpc.clone(),
-                service: service.clone(),
-                request: request.clone(),
-                metadata: metadata.clone(),
+                let connection = _rtself.get_data_mut(&*CONNECTION_WRAPPER);
+                let params = RpcParams {
+                    rpc: rpc.clone(),
+                    service: service.clone(),
+                    request: request.clone(),
+                    metadata: metadata.clone(),
                 timeout_millis: timeout
-            };
-            connection.call(params, token.clone())
+                };
+                connection.call(params, token.clone())
         }, Some(|| { token.cancel() }));
 
         let response = result.map_err(|e| raise_bridge_exception(&e.to_string())).unwrap();
@@ -269,14 +269,14 @@ methods!(
 
     fn worker_initiate_shutdown() -> NilClass {
         let worker = _rtself.get_data_mut(&*WORKER_WRAPPER);
-        worker.initiate_shutdown();
+        worker.initiate_shutdown().map_err(|e| raise_bridge_exception(&e.to_string())).unwrap();
 
         NilClass::new()
     }
 
-    fn worker_shutdown() -> NilClass {
+    fn worker_finalize_shutdown() -> NilClass {
         let worker = _rtself.get_data_mut(&*WORKER_WRAPPER);
-        worker.shutdown();
+        worker.finalize_shutdown().map_err(|e| raise_bridge_exception(&e.to_string())).unwrap();
 
         NilClass::new()
     }
@@ -420,7 +420,7 @@ pub extern "C" fn init_bridge() {
             klass.def("poll_workflow_activation", worker_poll_workflow_activation);
             klass.def("complete_workflow_activation", worker_complete_workflow_activation);
             klass.def("initiate_shutdown", worker_initiate_shutdown);
-            klass.def("shutdown", worker_shutdown);
+            klass.def("finalize_shutdown", worker_finalize_shutdown);
         });
 
         module.define_nested_class("TestServer", None).define(|klass| {

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -127,15 +127,15 @@ methods!(
         let token = CancellationToken::new();
 
         let result = Thread::call_without_gvl(|| {
-                let connection = _rtself.get_data_mut(&*CONNECTION_WRAPPER);
-                let params = RpcParams {
-                    rpc: rpc.clone(),
-                    service: service.clone(),
-                    request: request.clone(),
-                    metadata: metadata.clone(),
-                timeout_millis: timeout
-                };
-                connection.call(params, token.clone())
+            let connection = _rtself.get_data_mut(&*CONNECTION_WRAPPER);
+            let params = RpcParams {
+                rpc: rpc.clone(),
+                service: service.clone(),
+                request: request.clone(),
+                metadata: metadata.clone(),
+            timeout_millis: timeout
+            };
+            connection.call(params, token.clone())
         }, Some(|| { token.cancel() }));
 
         let response = result.map_err(|e| raise_bridge_exception(&e.to_string())).unwrap();

--- a/bridge/src/runtime.rs
+++ b/bridge/src/runtime.rs
@@ -1,6 +1,6 @@
 use rutie::Thread;
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
-use std::sync::mpsc::{channel, Sender, Receiver};
 use temporal_sdk_core::CoreRuntime;
 use temporal_sdk_core_api::telemetry::TelemetryOptions;
 use tokio::runtime::{Builder, Runtime as TokioRuntime};

--- a/bridge/src/test_server.rs
+++ b/bridge/src/test_server.rs
@@ -102,7 +102,7 @@ fn ephemeral_exe(
     } else {
         let version =
             if download_version == "default" {
-                    ephemeral_server::EphemeralExeVersion::SDKDefault { sdk_name, sdk_version }
+                ephemeral_server::EphemeralExeVersion::SDKDefault { sdk_name, sdk_version }
             } else {
                 ephemeral_server::EphemeralExeVersion::Fixed(download_version)
             };

--- a/bridge/src/test_server.rs
+++ b/bridge/src/test_server.rs
@@ -102,10 +102,10 @@ fn ephemeral_exe(
     } else {
         let version =
             if download_version == "default" {
-                ephemeral_server::EphemeralExeVersion::SDKDefault { sdk_name, sdk_version }
-        } else {
-            ephemeral_server::EphemeralExeVersion::Fixed(download_version)
-        };
+                    ephemeral_server::EphemeralExeVersion::SDKDefault { sdk_name, sdk_version }
+            } else {
+                ephemeral_server::EphemeralExeVersion::Fixed(download_version)
+            };
 
         ephemeral_server::EphemeralExe::CachedDownload { version, dest_dir: download_dir }
     }

--- a/bridge/src/test_server.rs
+++ b/bridge/src/test_server.rs
@@ -1,8 +1,8 @@
-use crate::runtime::{Runtime};
+use crate::runtime::Runtime;
 use std::sync::Arc;
 use temporal_sdk_core::ephemeral_server;
 use thiserror::Error;
-use tokio::runtime::{Runtime as TokioRuntime};
+use tokio::runtime::Runtime as TokioRuntime;
 
 #[derive(Error, Debug)]
 pub enum TestServerError {
@@ -103,9 +103,9 @@ fn ephemeral_exe(
         let version =
             if download_version == "default" {
                 ephemeral_server::EphemeralExeVersion::SDKDefault { sdk_name, sdk_version }
-            } else {
-                ephemeral_server::EphemeralExeVersion::Fixed(download_version)
-            };
+        } else {
+            ephemeral_server::EphemeralExeVersion::Fixed(download_version)
+        };
 
         ephemeral_server::EphemeralExe::CachedDownload { version, dest_dir: download_dir }
     }

--- a/bridge/src/worker.rs
+++ b/bridge/src/worker.rs
@@ -67,8 +67,8 @@ impl Worker {
             .build()?;
 
         let core_worker = runtime.tokio_runtime.block_on(async move {
-                temporal_sdk_core::init_worker(&runtime.core_runtime, config, client.clone())
-            }).expect("Failed to initialize Core Worker");
+            temporal_sdk_core::init_worker(&runtime.core_runtime, config, client.clone())
+        }).expect("Failed to initialize Core Worker");
 
         Ok(Worker {
             core_worker: Some(Arc::new(core_worker)),

--- a/bridge/src/worker.rs
+++ b/bridge/src/worker.rs
@@ -180,10 +180,11 @@ impl Worker {
         // Take the worker out of the option and leave None
         let core_worker = self.core_worker.take().ok_or(WorkerError::WorkerHasBeenShutdown())?;
 
-        // This should be the only reference remaining to the worker so try_unwrap will work.
+        // By design, there should be no more task using the worker by the time the Ruby code calls finalize_shutdown.
+        // This should therefore be the very last reference remaining to the worker. This is a condition for try_unwrap to work.
         let core_worker = Arc::try_unwrap(core_worker).map_err(|arc| {
             WorkerError::UnexpectedError(format!(
-                "Cannot finalize, expected 1 reference, got {}",
+                "Can't finalize worker's shutdown because there are still active references to it (expected exactly 1 reference, but got {})",
                 Arc::strong_count(&arc)
             ))
         })?;

--- a/bridge/src/worker.rs
+++ b/bridge/src/worker.rs
@@ -1,15 +1,15 @@
 use crate::connection::Client;
 use crate::runtime::{Callback, Command, Runtime};
 use prost::Message;
-use std::sync::Arc;
 use std::sync::mpsc::Sender;
-use temporal_sdk_core::api::{Worker as WorkerTrait};
+use std::sync::Arc;
+use temporal_sdk_core::api::Worker as WorkerTrait;
 use temporal_sdk_core_api::errors::{PollActivityError, PollWfError};
 use temporal_sdk_core_api::worker::{WorkerConfigBuilder, WorkerConfigBuilderError};
+use temporal_sdk_core_protos::coresdk::workflow_completion::WorkflowActivationCompletion;
 use temporal_sdk_core_protos::coresdk::{ActivityHeartbeat, ActivityTaskCompletion};
-use temporal_sdk_core_protos::coresdk::workflow_completion::{WorkflowActivationCompletion};
 use thiserror::Error;
-use tokio::runtime::{Runtime as TokioRuntime};
+use tokio::runtime::Runtime as TokioRuntime;
 
 #[derive(Error, Debug)]
 pub enum WorkerError {
@@ -37,6 +37,12 @@ pub enum WorkerError {
     #[error("Unable to send a request. Channel is closed")]
     ChannelClosed(),
 
+    #[error("Worker has already been shutdown")]
+    WorkerHasBeenShutdown(),
+
+    #[error("Unexpected error: {0}")]
+    UnexpectedError(String),
+
     #[error("Core worker is shutting down")]
     Shutdown(),
 }
@@ -44,7 +50,7 @@ pub enum WorkerError {
 pub type WorkerResult = Result<Vec<u8>, WorkerError>;
 
 pub struct Worker {
-    core_worker: Arc<temporal_sdk_core::Worker>,
+    core_worker: Option<Arc<temporal_sdk_core::Worker>>,
     tokio_runtime: Arc<TokioRuntime>,
     callback_tx: Sender<Command>,
 }
@@ -61,18 +67,18 @@ impl Worker {
             .build()?;
 
         let core_worker = runtime.tokio_runtime.block_on(async move {
-            temporal_sdk_core::init_worker(&runtime.core_runtime, config, client.clone())
-        }).expect("Failed to initialize Core Worker");
+                temporal_sdk_core::init_worker(&runtime.core_runtime, config, client.clone())
+            }).expect("Failed to initialize Core Worker");
 
         Ok(Worker {
-            core_worker: Arc::new(core_worker),
+            core_worker: Some(Arc::new(core_worker)),
             tokio_runtime: runtime.tokio_runtime.clone(),
             callback_tx: runtime.callback_tx.clone(),
         })
     }
 
     pub fn poll_activity_task<F>(&self, callback: F) -> Result<(), WorkerError> where F: FnOnce(WorkerResult) + Send + 'static {
-        let core_worker = self.core_worker.clone();
+        let core_worker = Arc::clone(self.core_worker.as_ref().ok_or(WorkerError::WorkerHasBeenShutdown())?);
         let callback_tx = self.callback_tx.clone();
 
         self.tokio_runtime.spawn(async move {
@@ -94,7 +100,7 @@ impl Worker {
     }
 
     pub fn complete_activity_task<F>(&self, bytes: Vec<u8>, callback: F) -> Result<(), WorkerError> where F: FnOnce(WorkerResult) + Send + 'static {
-        let core_worker = self.core_worker.clone();
+        let core_worker = Arc::clone(self.core_worker.as_ref().ok_or(WorkerError::WorkerHasBeenShutdown())?);
         let callback_tx = self.callback_tx.clone();
         let proto = ActivityTaskCompletion::decode(&*bytes)?;
 
@@ -113,14 +119,16 @@ impl Worker {
     }
 
     pub fn record_activity_heartbeat(&self, bytes: Vec<u8>) -> Result<(), WorkerError> {
+        let core_worker = Arc::clone(self.core_worker.as_ref().ok_or(WorkerError::WorkerHasBeenShutdown())?);
         let proto = ActivityHeartbeat::decode(&*bytes)?;
-        self.core_worker.record_activity_heartbeat(proto);
+
+        core_worker.record_activity_heartbeat(proto);
 
         Ok(())
     }
 
     pub fn poll_workflow_activation<F>(&self, callback: F) -> Result<(), WorkerError> where F: FnOnce(WorkerResult) + Send + 'static {
-        let core_worker = self.core_worker.clone();
+        let core_worker = Arc::clone(self.core_worker.as_ref().ok_or(WorkerError::WorkerHasBeenShutdown())?);
         let callback_tx = self.callback_tx.clone();
 
         self.tokio_runtime.spawn(async move {
@@ -142,7 +150,7 @@ impl Worker {
     }
 
     pub fn complete_workflow_activation<F>(&self, bytes: Vec<u8>, callback: F) -> Result<(), WorkerError> where F: FnOnce(WorkerResult) + Send + 'static {
-        let core_worker = self.core_worker.clone();
+        let core_worker = Arc::clone(self.core_worker.as_ref().ok_or(WorkerError::WorkerHasBeenShutdown())?);
         let callback_tx = self.callback_tx.clone();
         let proto = WorkflowActivationCompletion::decode(&*bytes)?;
 
@@ -160,16 +168,29 @@ impl Worker {
         Ok(())
     }
 
-    pub fn initiate_shutdown(&self) {
-        self.core_worker.initiate_shutdown();
+    pub fn initiate_shutdown(&self) -> Result<(), WorkerError> {
+        let core_worker = Arc::clone(self.core_worker.as_ref().ok_or(WorkerError::WorkerHasBeenShutdown())?);
+
+        core_worker.initiate_shutdown();
+
+        Ok(())
     }
 
-    // FIXME: Replace with finalize_shutdown()
-    pub fn shutdown(&self) {
-        let core_worker = self.core_worker.clone();
+    pub fn finalize_shutdown(&mut self) -> Result<(), WorkerError> {
+        // Take the worker out of the option and leave None
+        let core_worker = self.core_worker.take().ok_or(WorkerError::WorkerHasBeenShutdown())?;
+
+        // This should be the only reference remaining to the worker so try_unwrap will work.
+        let core_worker = Arc::try_unwrap(core_worker).map_err(|arc| {
+            WorkerError::UnexpectedError(format!(
+                "Cannot finalize, expected 1 reference, got {}",
+                Arc::strong_count(&arc)
+            ))
+        })?;
 
         self.tokio_runtime.block_on(async move {
-            core_worker.shutdown().await;
-        });
+            core_worker.finalize_shutdown().await;
+            Ok(())
+        })
     }
 }

--- a/lib/gen/temporal/api/common/v1/message_pb.rb
+++ b/lib/gen/temporal/api/common/v1/message_pb.rb
@@ -46,6 +46,9 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :maximum_attempts, :int32, 4
       repeated :non_retryable_error_types, :string, 5
     end
+    add_message "temporal.api.common.v1.MeteringMetadata" do
+      optional :nonfirst_local_activity_execution_attempts, :uint32, 13
+    end
   end
 end
 
@@ -63,6 +66,7 @@ module Temporalio
         WorkflowType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("temporal.api.common.v1.WorkflowType").msgclass
         ActivityType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("temporal.api.common.v1.ActivityType").msgclass
         RetryPolicy = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("temporal.api.common.v1.RetryPolicy").msgclass
+        MeteringMetadata = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("temporal.api.common.v1.MeteringMetadata").msgclass
       end
     end
   end

--- a/lib/gen/temporal/api/history/v1/message_pb.rb
+++ b/lib/gen/temporal/api/history/v1/message_pb.rb
@@ -97,6 +97,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :binary_checksum, :string, 4
       optional :worker_versioning_id, :message, 5, "temporal.api.taskqueue.v1.VersionId"
       optional :sdk_metadata, :message, 6, "temporal.api.sdk.v1.WorkflowTaskCompletedMetadata"
+      optional :metering_metadata, :message, 13, "temporal.api.common.v1.MeteringMetadata"
     end
     add_message "temporal.api.history.v1.WorkflowTaskTimedOutEventAttributes" do
       optional :scheduled_event_id, :int64, 1

--- a/lib/gen/temporal/api/workflowservice/v1/request_response_pb.rb
+++ b/lib/gen/temporal/api/workflowservice/v1/request_response_pb.rb
@@ -180,6 +180,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :worker_versioning_id, :message, 10, "temporal.api.taskqueue.v1.VersionId"
       repeated :messages, :message, 11, "temporal.api.protocol.v1.Message"
       optional :sdk_metadata, :message, 12, "temporal.api.sdk.v1.WorkflowTaskCompletedMetadata"
+      optional :metering_metadata, :message, 13, "temporal.api.common.v1.MeteringMetadata"
     end
     add_message "temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedResponse" do
       optional :workflow_task, :message, 1, "temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse"

--- a/lib/temporalio/worker.rb
+++ b/lib/temporalio/worker.rb
@@ -85,6 +85,7 @@ module Temporalio
         namespace,
         task_queue,
         max_cached_workflows,
+        # FIXME: expose enable_non_local_activities
         activities.empty?,
       )
       sync_worker = Worker::SyncWorker.new(@core_worker)

--- a/lib/temporalio/worker.rb
+++ b/lib/temporalio/worker.rb
@@ -178,17 +178,21 @@ module Temporalio
       mutex.synchronize do
         return unless running?
 
-        # First initiate Core shutdown, which will start dropping poll requests
-        core_worker.initiate_shutdown
-        # Then let the runner know we're shutting down, so it can stop other workers
+        # Let the runner know we're shutting down, so it can stop other workers.
+        # This will cause a reentrant call to this method, but the mutex above will block that call.
         runner&.shutdown(exception)
+
+        # Initiate Core shutdown, which will start dropping poll requests
+        core_worker.initiate_shutdown
+        # Start the graceful activity shutdown timer, which will cancel activities after the timeout
+        activity_worker&.setup_graceful_shutdown_timer(runtime.reactor)
         # Wait for workers to drain any outstanding tasks
         activity_worker&.drain
         workflow_worker&.drain
         # Stop the executor (at this point there should already be nothing in it)
         activity_executor.shutdown
         # Finalize the shutdown by stopping the Core
-        core_worker.shutdown
+        core_worker.finalize_shutdown
 
         @shutdown = true
       end

--- a/sig/protos/temporal/api/common/v1/message.rbs
+++ b/sig/protos/temporal/api/common/v1/message.rbs
@@ -478,6 +478,50 @@ module Temporalio
 
           type hash[KEY] = ::Hash[KEY, RetryPolicy | _ToProto]
         end
+
+        # Metadata relevant for metering purposes
+        #
+        class MeteringMetadata < ::Protobuf::Message
+          # Encode the message to a binary string
+          #
+          def self.encode: (MeteringMetadata) -> String
+
+          # Count of local activities which have begun an execution attempt during this workflow task,
+          #  and whose first attempt occurred in some previous task. This is used for metering
+          #  purposes, and does not affect workflow state.
+          #
+          #  (-- api-linter: core::0141::forbidden-types=disabled
+          #      aip.dev/not-precedent: Negative values make no sense to represent. --)
+          #
+          attr_accessor nonfirst_local_activity_execution_attempts(): ::Integer
+
+          def nonfirst_local_activity_execution_attempts!: () -> ::Integer?
+
+          def initialize: (?nonfirst_local_activity_execution_attempts: ::Integer) -> void
+
+          def []: (:nonfirst_local_activity_execution_attempts) -> ::Integer
+                | (::Symbol) -> untyped
+
+          def []=: (:nonfirst_local_activity_execution_attempts, ::Integer) -> ::Integer
+                 | (::Symbol, untyped) -> untyped
+
+          interface _ToProto
+            def to_proto: () -> MeteringMetadata
+          end
+
+          # The type of `#initialize` parameter.
+          type init = MeteringMetadata | _ToProto
+
+          # The type of `repeated` field.
+          type field_array = ::Protobuf::Field::FieldArray[MeteringMetadata, MeteringMetadata | _ToProto]
+
+          # The type of `map` field.
+          type field_hash[KEY] = ::Protobuf::Field::FieldHash[KEY, MeteringMetadata, MeteringMetadata | _ToProto]
+
+          type array = ::Array[MeteringMetadata | _ToProto]
+
+          type hash[KEY] = ::Hash[KEY, MeteringMetadata | _ToProto]
+        end
       end
     end
   end

--- a/sig/protos/temporal/api/history/v1/message.rbs
+++ b/sig/protos/temporal/api/history/v1/message.rbs
@@ -887,7 +887,18 @@ module Temporalio
 
           def sdk_metadata!: () -> ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata?
 
-          def initialize: (?scheduled_event_id: ::Integer, ?started_event_id: ::Integer, ?identity: ::String, ?binary_checksum: ::String, ?worker_versioning_id: ::Temporalio::Api::TaskQueue::V1::VersionId::init?, ?sdk_metadata: ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata::init?) -> void
+          # Local usage data sent during workflow task completion and recorded here for posterity
+          #
+          attr_accessor metering_metadata(): ::Temporalio::Api::Common::V1::MeteringMetadata?
+
+          # Local usage data sent during workflow task completion and recorded here for posterity
+          #
+          def metering_metadata=: [M < ::Temporalio::Api::Common::V1::MeteringMetadata::_ToProto] (M?) -> M?
+                                | ...
+
+          def metering_metadata!: () -> ::Temporalio::Api::Common::V1::MeteringMetadata?
+
+          def initialize: (?scheduled_event_id: ::Integer, ?started_event_id: ::Integer, ?identity: ::String, ?binary_checksum: ::String, ?worker_versioning_id: ::Temporalio::Api::TaskQueue::V1::VersionId::init?, ?sdk_metadata: ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata::init?, ?metering_metadata: ::Temporalio::Api::Common::V1::MeteringMetadata::init?) -> void
 
           def []: (:scheduled_event_id) -> ::Integer
                 | (:started_event_id) -> ::Integer
@@ -895,6 +906,7 @@ module Temporalio
                 | (:binary_checksum) -> ::String
                 | (:worker_versioning_id) -> ::Temporalio::Api::TaskQueue::V1::VersionId?
                 | (:sdk_metadata) -> ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata?
+                | (:metering_metadata) -> ::Temporalio::Api::Common::V1::MeteringMetadata?
                 | (::Symbol) -> untyped
 
           def []=: (:scheduled_event_id, ::Integer) -> ::Integer
@@ -905,6 +917,8 @@ module Temporalio
                  | [M < ::Temporalio::Api::TaskQueue::V1::VersionId::_ToProto] (:worker_versioning_id, M?) -> M?
                  | (:sdk_metadata, ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata?) -> ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata?
                  | [M < ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata::_ToProto] (:sdk_metadata, M?) -> M?
+                 | (:metering_metadata, ::Temporalio::Api::Common::V1::MeteringMetadata?) -> ::Temporalio::Api::Common::V1::MeteringMetadata?
+                 | [M < ::Temporalio::Api::Common::V1::MeteringMetadata::_ToProto] (:metering_metadata, M?) -> M?
                  | (::Symbol, untyped) -> untyped
 
           interface _ToProto

--- a/sig/protos/temporal/api/workflowservice/v1/request_response.rbs
+++ b/sig/protos/temporal/api/workflowservice/v1/request_response.rbs
@@ -1610,7 +1610,18 @@ module Temporalio
 
           def sdk_metadata!: () -> ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata?
 
-          def initialize: (?task_token: ::String, ?commands: ::Temporalio::Api::Command::V1::Command::array, ?identity: ::String, ?sticky_attributes: ::Temporalio::Api::TaskQueue::V1::StickyExecutionAttributes::init?, ?return_new_workflow_task: bool, ?force_create_new_workflow_task: bool, ?binary_checksum: ::String, ?query_results: ::Temporalio::Api::Query::V1::WorkflowQueryResult::hash[::String], ?namespace: ::String, ?worker_versioning_id: ::Temporalio::Api::TaskQueue::V1::VersionId::init?, ?messages: ::Temporalio::Api::Protocol::V1::Message::array, ?sdk_metadata: ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata::init?) -> void
+          # Local usage data collected for metering
+          #
+          attr_accessor metering_metadata(): ::Temporalio::Api::Common::V1::MeteringMetadata?
+
+          # Local usage data collected for metering
+          #
+          def metering_metadata=: [M < ::Temporalio::Api::Common::V1::MeteringMetadata::_ToProto] (M?) -> M?
+                                | ...
+
+          def metering_metadata!: () -> ::Temporalio::Api::Common::V1::MeteringMetadata?
+
+          def initialize: (?task_token: ::String, ?commands: ::Temporalio::Api::Command::V1::Command::array, ?identity: ::String, ?sticky_attributes: ::Temporalio::Api::TaskQueue::V1::StickyExecutionAttributes::init?, ?return_new_workflow_task: bool, ?force_create_new_workflow_task: bool, ?binary_checksum: ::String, ?query_results: ::Temporalio::Api::Query::V1::WorkflowQueryResult::hash[::String], ?namespace: ::String, ?worker_versioning_id: ::Temporalio::Api::TaskQueue::V1::VersionId::init?, ?messages: ::Temporalio::Api::Protocol::V1::Message::array, ?sdk_metadata: ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata::init?, ?metering_metadata: ::Temporalio::Api::Common::V1::MeteringMetadata::init?) -> void
 
           def []: (:task_token) -> ::String
                 | (:commands) -> ::Temporalio::Api::Command::V1::Command::field_array
@@ -1624,6 +1635,7 @@ module Temporalio
                 | (:worker_versioning_id) -> ::Temporalio::Api::TaskQueue::V1::VersionId?
                 | (:messages) -> ::Temporalio::Api::Protocol::V1::Message::field_array
                 | (:sdk_metadata) -> ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata?
+                | (:metering_metadata) -> ::Temporalio::Api::Common::V1::MeteringMetadata?
                 | (::Symbol) -> untyped
 
           def []=: (:task_token, ::String) -> ::String
@@ -1644,6 +1656,8 @@ module Temporalio
                  | (:messages, ::Temporalio::Api::Protocol::V1::Message::array) -> ::Temporalio::Api::Protocol::V1::Message::array
                  | (:sdk_metadata, ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata?) -> ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata?
                  | [M < ::Temporalio::Api::Sdk::V1::WorkflowTaskCompletedMetadata::_ToProto] (:sdk_metadata, M?) -> M?
+                 | (:metering_metadata, ::Temporalio::Api::Common::V1::MeteringMetadata?) -> ::Temporalio::Api::Common::V1::MeteringMetadata?
+                 | [M < ::Temporalio::Api::Common::V1::MeteringMetadata::_ToProto] (:metering_metadata, M?) -> M?
                  | (::Symbol, untyped) -> untyped
 
           def return_new_workflow_task?: () -> bool

--- a/sig/temporalio/bridge.rbs
+++ b/sig/temporalio/bridge.rbs
@@ -33,7 +33,7 @@ module Temporalio
       def poll_workflow_activation: { (String?, Exception?) -> void } -> void
       def complete_workflow_activation: (String) { (nil, Exception?) -> void } -> void
       def initiate_shutdown: -> void
-      def shutdown: -> void
+      def finalize_shutdown: -> void
     end
 
     class TestServer

--- a/sig/temporalio/worker/activity_worker.rbs
+++ b/sig/temporalio/worker/activity_worker.rbs
@@ -1,6 +1,7 @@
 module Temporalio
   class Worker
     class ActivityWorker
+      @cancelation_task: Async::Task?
       @running: bool
 
       def initialize: (
@@ -14,6 +15,7 @@ module Temporalio
       ) -> void
       def run: (Async::Task reactor) -> void
       def drain: -> void
+      def setup_graceful_shutdown_timer: (Temporalio::Worker::Reactor reactor) -> void
 
       private
 

--- a/spec/unit/temporalio/worker_spec.rb
+++ b/spec/unit/temporalio/worker_spec.rb
@@ -116,7 +116,7 @@ describe Temporalio::Worker do
         .and_raise(Temporalio::Bridge::Error::WorkerShutdown)
 
       allow(core_worker).to receive(:initiate_shutdown)
-      allow(core_worker).to receive(:shutdown)
+      allow(core_worker).to receive(:finalize_shutdown)
 
       allow(reactor).to receive(:async).and_call_original
     end
@@ -145,8 +145,9 @@ describe Temporalio::Worker do
 
     before do
       allow(core_worker).to receive(:initiate_shutdown)
-      allow(core_worker).to receive(:shutdown)
+      allow(core_worker).to receive(:finalize_shutdown)
       allow(Temporalio::Worker::ActivityWorker).to receive(:new).and_return(activity_worker)
+      allow(activity_worker).to receive(:setup_graceful_shutdown_timer).and_return(nil)
       allow(activity_worker).to receive(:run).and_return(nil)
       allow(Temporalio::Worker::ThreadPoolExecutor).to receive(:new).and_return(activity_executor)
       allow(activity_executor).to receive(:shutdown).and_call_original
@@ -158,9 +159,10 @@ describe Temporalio::Worker do
       subject.shutdown
 
       expect(core_worker).to have_received(:initiate_shutdown).ordered
+      expect(activity_worker).to have_received(:setup_graceful_shutdown_timer).ordered
       expect(activity_worker).to have_received(:drain).ordered
       expect(activity_executor).to have_received(:shutdown).ordered
-      expect(core_worker).to have_received(:shutdown).ordered
+      expect(core_worker).to have_received(:finalize_shutdown).ordered
     end
   end
 


### PR DESCRIPTION
## What changed

- Update sdk-core to [09a2e4](https://github.com/temporalio/sdk-core/commit/09a2e4fc2198a8906bdb3f5051531578d9c46973)
- Refactor worker shutdown process as required by latest sdk-core