### PR TITLE
Fix multiple build/release issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ _yardoc/
 /spec/reports/
 /tmp/
 
+*.gem
+
 # Thermite artefacts
 mkmf.log
 lib/bridge.so

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ _yardoc/
 
 # Thermite artefacts
 mkmf.log
-lib/bridge.so
+lib/temporal_sdk_ruby_bridge.*
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    temporalio (0.1.0)
+    temporalio (0.1.1)
       async
       google-protobuf (~> 3.21.1)
       rexml (~> 3.2.5)
@@ -31,9 +31,17 @@ GEM
     fiber-local (1.0.0)
     fileutils (1.7.0)
     google-protobuf (3.21.12)
+    google-protobuf (3.21.12-x86_64-darwin)
+    google-protobuf (3.21.12-x86_64-linux)
     googleapis-common-protos-types (1.5.0)
       google-protobuf (~> 3.14)
     grpc (1.52.0)
+      google-protobuf (~> 3.21)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.52.0-x86_64-darwin)
+      google-protobuf (~> 3.21)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.52.0-x86_64-linux)
       google-protobuf (~> 3.21)
       googleapis-common-protos-types (~> 1.0)
     grpc-tools (1.52.0)

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -180,26 +180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bridge"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "lazy_static",
- "parking_lot",
- "prost",
- "rutie",
- "temporal-client",
- "temporal-sdk-core",
- "temporal-sdk-core-api",
- "temporal-sdk-core-protos",
- "thiserror",
- "tokio",
- "tokio-util",
- "tonic",
- "url",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2221,26 @@ dependencies = [
  "tonic",
  "tonic-build",
  "uuid",
+]
+
+[[package]]
+name = "temporal-sdk-ruby-bridge"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "parking_lot",
+ "prost",
+ "rutie",
+ "temporal-client",
+ "temporal-sdk-core",
+ "temporal-sdk-core-api",
+ "temporal-sdk-core-protos",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "url",
 ]
 
 [[package]]

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "bridge"
-version = "0.1.0"
+name = "temporal-sdk-ruby-bridge"
+version = "0.1.1"
 authors = ["Anthony D <anthony@temporal.io>"]
 edition = "2021"
 repository = "https://github.com/temporalio/sdk-ruby"
@@ -22,7 +22,7 @@ tonic = "0.8"
 url = "2.2"
 
 [lib]
-name = "bridge"
+name = "temporal_sdk_ruby_bridge"
 crate-type = ["dylib"]
 
 [package.metadata.thermite]

--- a/lib/temporalio/bridge.rb
+++ b/lib/temporalio/bridge.rb
@@ -8,7 +8,7 @@ module Temporalio
   # @api private
   module Bridge
     Rutie
-      .new(:bridge, lib_path: '', lib_suffix: 'so', lib_prefix: '')
+      .new(:temporal_sdk_ruby_bridge, lib_path: '', lib_suffix: 'so', lib_prefix: '')
       .init('init_bridge', BRIDGE_DIR)
   end
 end

--- a/lib/temporalio/version.rb
+++ b/lib/temporalio/version.rb
@@ -1,3 +1,3 @@
 module Temporalio
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end

--- a/lib/thermite_patch.rb
+++ b/lib/thermite_patch.rb
@@ -19,5 +19,15 @@ module Thermite
       target_base = ENV.fetch('CARGO_TARGET_DIR', File.join(rust_toplevel_dir, 'target'))
       File.join(target_base, ENV.fetch('CARGO_BUILD_TARGET', ''), profile, *path_components)
     end
+
+    def dynamic_linker_flags
+      @dynamic_linker_flags ||= begin
+        default_flags = RbConfig::CONFIG['DLDFLAGS'].strip
+        if target_os == 'darwin' && !default_flags.include?('-Wl,-undefined,dynamic_lookup')
+          default_flags += ' -Wl,-undefined,dynamic_lookup'
+        end
+        default_flags
+      end
+    end
   end
 end

--- a/sig/thermite_patch.rbs
+++ b/sig/thermite_patch.rbs
@@ -4,10 +4,12 @@ module Thermite
     def target_os: -> String
     def cargo_target_path: (String, *String) -> String
     def rust_toplevel_dir: -> String
+    def dynamic_linker_flags: -> String
 
     private
 
     @target_arch: String?
     @target_os: String?
+    @dynamic_linker_flags: String?
   end
 end

--- a/temporalio.gemspec
+++ b/temporalio.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |spec|
   spec.extensions    = ['ext/Rakefile']
 
   spec.files =
-    Dir['lib/**/*.*'] +
+    Dir['lib/**/*.rb'] +
+    Dir['sig/**/*.rbs'] +
     Dir['bridge/**/*.*'].reject { |x| x.include?('/target/') } +
     %w[ext/Rakefile temporalio.gemspec Gemfile LICENSE README.md]
 


### PR DESCRIPTION
## What changed and why
- Include RBS files in bundled Gems. Should hopefully fix #134.
- Make sure `ld` build flag `-Wl,-undefined,dynamic_lookup` is always present on OSX. This fixes a build issue causing `Undefined symbols for architecture arm64` errors if Ruby was built with XCode 14+.
- Bump version number to 0.1.1, in prep for a new release.
