### PR TITLE
fix(ci): Fix incorrect build artifact name

### DIFF
--- a/.github/workflows/build-native-ext.yml
+++ b/.github/workflows/build-native-ext.yml
@@ -81,8 +81,8 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: |
           bundle exec rake thermite:tarball
-          echo bridge-*.tar.gz
-          echo "tarball=$(echo bridge-*.tar.gz)" >> $GITHUB_OUTPUT
+          echo temporal_sdk_ruby_bridge-*.tar.gz
+          echo "tarball=$(echo temporal_sdk_ruby_bridge-*.tar.gz)" >> $GITHUB_OUTPUT
 
       - name: Upload artifacts
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
## What changed

- Updated CI workflow to use the correct file name pattern when looking for generated bridge's tar.gz file