### PR TITLE
Update version to not mark gem as prerelease and add source gem

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -1,5 +1,6 @@
 name: Build Gems
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -1,13 +1,12 @@
 name: Build Gems
 on:
-  pull_request:
   push:
     branches:
       - main
       - "releases/*"
 
 jobs:
-  build-gems:
+  build-platform-gems:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -31,7 +30,7 @@ jobs:
           working-directory: ./temporalio
           cache-version: v1-${{ matrix.rubyPlatform }}
 
-      - name: Cross compile gems
+      - name: Cross compile gem
         uses: oxidize-rb/actions/cross-gem@v1
         id: cross-gem
         with:
@@ -39,15 +38,45 @@ jobs:
           ruby-versions: "3.1,3.2,3.3"
           working-directory: ./temporalio
 
-      - name: Upload gems
+      - name: Upload gem
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.rubyPlatform }}-gem
           path: ${{ steps.cross-gem.outputs.gem-path }}
 
+  build-source-gem:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Ruby and Rust
+        uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          cargo-cache: true
+          cache-version: v1-source
+
+      - name: Install bundle
+        working-directory: ./temporalio
+        run: bundle install
+
+      - name: Build
+        working-directory: ./temporalio
+        run: bundle exec rake build
+
+      - name: Upload gem
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-gem
+          path: temporalio/pkg/*.gem
+
   smoke-test-gems:
     needs:
-      - build-gems
+      - build-platform-gems
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -1,6 +1,5 @@
 name: Build Gems
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -75,9 +75,8 @@ gem install temporalio -v '<version>'
 **NOTE**: Due to [an issue](https://github.com/temporalio/sdk-ruby/issues/162), fibers (and `async` gem) are only
 supported on Ruby versions 3.3 and newer.
 
-**NOTE**: MinGW-based Windows is not currently supported natively, but is via WSL. Prebuilt gems for Linux MUSL are also
-not currently present. We also do not publish a gem for building from source at this time. See the
-[Platform Support](#platform-support) section later for more information.
+**NOTE**: MinGW-based Windows, Linux MUSL, and pure source based gems are not currently published. See the
+[Platform Support](#platform-support) section for more information.
 
 ### Implementing an Activity
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 ![Ruby 3.1 | 3.2 | 3.3](https://img.shields.io/badge/ruby-3.1%20%7C%203.2%20%7C%203.3-blue.svg?style=for-the-badge)
 [![MIT](https://img.shields.io/github/license/temporalio/sdk-ruby.svg?style=for-the-badge)](LICENSE)
-<!-- TODO: [![Gem](https://img.shields.io/gem/v/temporalio?style=for-the-badge)](https://rubygems.org/gems/temporalio) -->
+[![Gem](https://img.shields.io/gem/v/temporalio?style=for-the-badge)](https://rubygems.org/gems/temporalio)
 
 [Temporal](https://temporal.io/) is a distributed, scalable, durable, and highly available orchestration engine used to
 execute asynchronous, long-running business logic in a scalable and resilient way.
 
 **Temporal Ruby SDK** is the framework for authoring workflows and activities using the Ruby programming language.
+
+Also see:
+
+* [Ruby Samples](https://github.com/temporalio/samples-ruby)
+* [API Documentation](https://rubydoc.info/gems/temporalio)
 
 ⚠️ UNDER ACTIVE DEVELOPMENT
 
@@ -59,17 +64,16 @@ Notably missing from this SDK:
 
 ### Installation
 
-Install the gem to the desired version as mentioned at https://rubygems.org/gems/temporalio. Since the SDK is still in
-pre-release, the version should be specified explicitly. So either in a Gemfile like:
+Can require in a Gemfile like:
 
 ```
-gem 'temporalio', '<version>'
+gem 'temporalio'
 ```
 
 Or via `gem install` like:
 
 ```
-gem install temporalio -v '<version>'
+gem install temporalio
 ```
 
 **NOTE**: Due to [an issue](https://github.com/temporalio/sdk-ruby/issues/162), fibers (and `async` gem) are only

--- a/temporalio/Rakefile
+++ b/temporalio/Rakefile
@@ -10,8 +10,12 @@ task build: :compile
 
 GEMSPEC = Gem::Specification.load('temporalio.gemspec')
 
-RbSys::ExtensionTask.new('temporalio_bridge', GEMSPEC) do |ext|
-  ext.lib_dir = 'lib/temporalio/internal/bridge'
+begin
+  RbSys::ExtensionTask.new('temporalio_bridge', GEMSPEC) do |ext|
+    ext.lib_dir = 'lib/temporalio/internal/bridge'
+  end
+rescue RbSys::CargoMetadataError
+  raise 'Source gem cannot be installed directly, must be a supported platform'
 end
 
 require 'rake/testtask'

--- a/temporalio/lib/temporalio/version.rb
+++ b/temporalio/lib/temporalio/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Temporalio
-  VERSION = '0.2.0-alpha1'
+  VERSION = '0.2.0'
 end

--- a/temporalio/temporalio.gemspec
+++ b/temporalio/temporalio.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/temporalio/sdk-ruby'
 
-  spec.files = Dir['lib/**/*.rb', 'LICENSE', 'README.md', 'Cargo.*']
+  spec.files = Dir['lib/**/*.rb', 'LICENSE', 'README.md', 'Cargo.*', 'temporalio.gemspec']
 
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }

--- a/temporalio/temporalio.gemspec
+++ b/temporalio/temporalio.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/temporalio/sdk-ruby'
 
-  spec.files = Dir['lib/**/*.rb', 'LICENSE', 'README.md', 'Cargo.*', 'temporalio.gemspec']
+  spec.files = Dir['lib/**/*.rb', 'LICENSE', 'README.md', 'Cargo.*', 'temporalio.gemspec', 'Gemfile', 'Rakefile']
 
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }


### PR DESCRIPTION
## What was changed

* Update version to `0.2.0` instead of `0.2.0-alpha` for a couple of reasons:
  * We have existing Ruby gems that cannot easily be yanked (past 30d window)
  * rubydoc.info does not have API docs for prerelease
* Add source gem
* Make sure gemspec and other files are in gem
* README changes

Acknowledged that we can alter the smoke test to do higher-level gem install test to ensure compatibility, but that can be done separately.