### PR TITLE
RPC cancellation support

### DIFF
--- a/temporalio/Cargo.lock
+++ b/temporalio/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "arbitrary"
@@ -1475,9 +1475,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.160"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b21006cd1874ae9e650973c565615676dc4a274c965bb0a73796dac838ce4f"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -2700,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "610f75ff4a8e3cb29b85da56eabdd1bff5b06739059a4b8e2967fef32e5d9944"
 dependencies = [
  "itoa",
  "memchr",
@@ -2894,6 +2894,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-triple"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
@@ -3115,6 +3121,7 @@ dependencies = [
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
  "tokio",
+ "tokio-util",
  "tonic",
  "tracing",
  "url",
@@ -3471,15 +3478,16 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8923cde76a6329058a86f04d033f0945a2c6df8b94093512e4ab188b3e3a8950"
+checksum = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4"
 dependencies = [
  "dissimilar",
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
  "toml",
 ]

--- a/temporalio/Rakefile
+++ b/temporalio/Rakefile
@@ -193,19 +193,15 @@ namespace :proto do
         # Calls #{class_name}.#{method.name} API call.
         #
         # @param request [#{method.input_type.msgclass}] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [#{method.output_type.msgclass}] API response.
-        def #{rpc}(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def #{rpc}(request, rpc_options: nil)
           invoke_rpc(
             rpc: '#{rpc}',
             request_class: #{method.input_type.msgclass},
             response_class: #{method.output_type.msgclass},
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
           TEXT
@@ -236,7 +232,10 @@ namespace :proto do
           # Camel case to snake case
           rpc = method.name.gsub(/([A-Z])/, '_\1').downcase.delete_prefix('_')
           file.puts <<-TEXT
-        def #{rpc}: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
+        def #{rpc}: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
           TEXT
         end
 

--- a/temporalio/ext/Cargo.toml
+++ b/temporalio/ext/Cargo.toml
@@ -20,6 +20,7 @@ temporal-sdk-core = { version = "0.1.0", path = "./sdk-core/core", features = ["
 temporal-sdk-core-api = { version = "0.1.0", path = "./sdk-core/core-api" }
 temporal-sdk-core-protos = { version = "0.1.0", path = "./sdk-core/sdk-core-protos" }
 tokio = "1.26"
+tokio-util = "0.7"
 tonic = "0.12"
 tracing = "0.1"
 url = "2.2"

--- a/temporalio/lib/temporalio/client.rb
+++ b/temporalio/lib/temporalio/client.rb
@@ -203,8 +203,7 @@ module Temporalio
     #   with `cron_schedule`.
     # @param request_eager_start [Boolean] Potentially reduce the latency to start this workflow by encouraging the
     #   server to start it on a local worker running with this same client. This is currently experimental.
-    # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-    # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+    # @param rpc_options [RPCOptions, nil] Advanced RPC options.
     #
     # @return [WorkflowHandle] A workflow handle to the started workflow.
     # @raise [Error::WorkflowAlreadyStartedError] Workflow already exists.
@@ -225,8 +224,7 @@ module Temporalio
       search_attributes: nil,
       start_delay: nil,
       request_eager_start: false,
-      rpc_metadata: nil,
-      rpc_timeout: nil
+      rpc_options: nil
     )
       @impl.start_workflow(Interceptor::StartWorkflowInput.new(
                              workflow:,
@@ -245,8 +243,7 @@ module Temporalio
                              start_delay:,
                              request_eager_start:,
                              headers: {},
-                             rpc_metadata:,
-                             rpc_timeout:
+                             rpc_options:
                            ))
     end
 
@@ -272,8 +269,7 @@ module Temporalio
     #   with `cron_schedule`.
     # @param request_eager_start [Boolean] Potentially reduce the latency to start this workflow by encouraging the
     #   server to start it on a local worker running with this same client. This is currently experimental.
-    # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-    # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+    # @param rpc_options [RPCOptions, nil] Advanced RPC options.
     #
     # @return [Object] Successful result of the workflow.
     # @raise [Error::WorkflowAlreadyStartedError] Workflow already exists.
@@ -295,8 +291,7 @@ module Temporalio
       search_attributes: nil,
       start_delay: nil,
       request_eager_start: false,
-      rpc_metadata: nil,
-      rpc_timeout: nil
+      rpc_options: nil
     )
       start_workflow(
         workflow,
@@ -314,8 +309,7 @@ module Temporalio
         search_attributes:,
         start_delay:,
         request_eager_start:,
-        rpc_metadata:,
-        rpc_timeout:
+        rpc_options:
       ).result
     end
 
@@ -339,47 +333,29 @@ module Temporalio
     # List workflows.
     #
     # @param query [String, nil] A Temporal visibility list filter.
-    # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-    # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+    # @param rpc_options [RPCOptions, nil] Advanced RPC options.
     #
     # @return [Enumerator<WorkflowExecution>] Enumerable workflow executions.
     #
     # @raise [Error::RPCError] RPC error from call.
     #
     # @see https://docs.temporal.io/visibility
-    def list_workflows(
-      query = nil,
-      rpc_metadata: nil,
-      rpc_timeout: nil
-    )
-      @impl.list_workflows(Interceptor::ListWorkflowsInput.new(
-                             query:,
-                             rpc_metadata:,
-                             rpc_timeout:
-                           ))
+    def list_workflows(query = nil, rpc_options: nil)
+      @impl.list_workflows(Interceptor::ListWorkflowsInput.new(query:, rpc_options:))
     end
 
     # Count workflows.
     #
     # @param query [String, nil] A Temporal visibility list filter.
-    # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-    # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+    # @param rpc_options [RPCOptions, nil] Advanced RPC options.
     #
     # @return [WorkflowExecutionCount] Count of workflows.
     #
     # @raise [Error::RPCError] RPC error from call.
     #
     # @see https://docs.temporal.io/visibility
-    def count_workflows(
-      query = nil,
-      rpc_metadata: nil,
-      rpc_timeout: nil
-    )
-      @impl.count_workflows(Interceptor::CountWorkflowsInput.new(
-                              query:,
-                              rpc_metadata:,
-                              rpc_timeout:
-                            ))
+    def count_workflows(query = nil, rpc_options: nil)
+      @impl.count_workflows(Interceptor::CountWorkflowsInput.new(query:, rpc_options:))
     end
 
     # Get an async activity handle.
@@ -399,6 +375,45 @@ module Temporalio
     # @!visibility private
     def _impl
       @impl
+    end
+
+    # Set of RPC options for RPC calls.
+    class RPCOptions
+      # @return [Hash<String, String>, nil] Headers to include on the RPC call.
+      attr_accessor :metadata
+
+      # @return [Float, nil] Number of seconds before timeout of the RPC call.
+      attr_accessor :timeout
+
+      # @return [Cancellation, nil] Cancellation to use to potentially cancel the call. If canceled, the RPC will return
+      #   {Error::CanceledError}.
+      attr_accessor :cancellation
+
+      # @return [Boolean, nil] Whether to override the default retry option which decides whether to retry calls
+      #   implicitly when known transient error codes are reached. By default when this is nil, high-level calls retry
+      #   known transient error codes and low-level/direct calls do not.
+      attr_accessor :override_retry
+
+      # Create RPC options.
+      #
+      # @param metadata [Hash<String, String>, nil] Headers to include on the RPC call.
+      # @param timeout [Float, nil] Number of seconds before timeout of the RPC call.
+      # @param cancellation [Cancellation, nil] Cancellation to use to potentially cancel the call. If canceled, the RPC
+      #   will return {Error::CanceledError}.
+      # @param override_retry [Boolean, nil] Whether to override the default retry option which decides whether to retry
+      #   calls implicitly when known transient error codes are reached. By default when this is nil, high-level calls
+      #   retry known transient error codes and low-level/direct calls do not.
+      def initialize(
+        metadata: nil,
+        timeout: nil,
+        cancellation: nil,
+        override_retry: nil
+      )
+        @metadata = metadata
+        @timeout = timeout
+        @cancellation = cancellation
+        @override_retry = override_retry
+      end
     end
   end
 end

--- a/temporalio/lib/temporalio/client/async_activity_handle.rb
+++ b/temporalio/lib/temporalio/client/async_activity_handle.rb
@@ -27,36 +27,24 @@ module Temporalio
       # Record a heartbeat for the activity.
       #
       # @param details [Array<Object>] Details of the heartbeat.
-      # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-      # @param rpc_timeout [Float, nil] Number of seconds before timeout.
-      def heartbeat(
-        *details,
-        rpc_metadata: nil,
-        rpc_timeout: nil
-      )
+      # @param rpc_options [RPCOptions, nil] Advanced RPC options.
+      def heartbeat(*details, rpc_options: nil)
         @client._impl.heartbeat_async_activity(Interceptor::HeartbeatAsyncActivityInput.new(
                                                  task_token_or_id_reference:,
                                                  details:,
-                                                 rpc_metadata:,
-                                                 rpc_timeout:
+                                                 rpc_options:
                                                ))
       end
 
       # Complete the activity.
       #
       # @param result [Object, nil] Result of the activity.
-      # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-      # @param rpc_timeout [Float, nil] Number of seconds before timeout.
-      def complete(
-        result = nil,
-        rpc_metadata: nil,
-        rpc_timeout: nil
-      )
+      # @param rpc_options [RPCOptions, nil] Advanced RPC options.
+      def complete(result = nil, rpc_options: nil)
         @client._impl.complete_async_activity(Interceptor::CompleteAsyncActivityInput.new(
                                                 task_token_or_id_reference:,
                                                 result:,
-                                                rpc_metadata:,
-                                                rpc_timeout:
+                                                rpc_options:
                                               ))
       end
 
@@ -64,39 +52,26 @@ module Temporalio
       #
       # @param error [Exception] Error for the activity.
       # @param last_heartbeat_details [Array<Object>] Last heartbeat details for the activity.
-      # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-      # @param rpc_timeout [Float, nil] Number of seconds before timeout.
-      def fail(
-        error,
-        last_heartbeat_details: [],
-        rpc_metadata: nil,
-        rpc_timeout: nil
-      )
+      # @param rpc_options [RPCOptions, nil] Advanced RPC options.
+      def fail(error, last_heartbeat_details: [], rpc_options: nil)
         @client._impl.fail_async_activity(Interceptor::FailAsyncActivityInput.new(
                                             task_token_or_id_reference:,
                                             error:,
                                             last_heartbeat_details:,
-                                            rpc_metadata:,
-                                            rpc_timeout:
+                                            rpc_options:
                                           ))
       end
 
       # Report the activity as canceled.
       #
       # @param details [Array<Object>] Cancellation details.
-      # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-      # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+      # @param rpc_options [RPCOptions, nil] Advanced RPC options.
       # @raise [AsyncActivityCanceledError] If the activity has been canceled.
-      def report_cancellation(
-        *details,
-        rpc_metadata: nil,
-        rpc_timeout: nil
-      )
+      def report_cancellation(*details, rpc_options: nil)
         @client._impl.report_cancellation_async_activity(Interceptor::ReportCancellationAsyncActivityInput.new(
                                                            task_token_or_id_reference:,
                                                            details:,
-                                                           rpc_metadata:,
-                                                           rpc_timeout:
+                                                           rpc_options:
                                                          ))
       end
 

--- a/temporalio/lib/temporalio/client/connection/cloud_service.rb
+++ b/temporalio/lib/temporalio/client/connection/cloud_service.rb
@@ -19,627 +19,495 @@ module Temporalio
         # Calls CloudService.GetUsers API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetUsersRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetUsersResponse] API response.
-        def get_users(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_users(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_users',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetUsersRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetUsersResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetUser API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetUserRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetUserResponse] API response.
-        def get_user(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_user(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_user',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetUserRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetUserResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.CreateUser API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::CreateUserRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::CreateUserResponse] API response.
-        def create_user(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def create_user(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'create_user',
             request_class: Temporalio::Api::Cloud::CloudService::V1::CreateUserRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::CreateUserResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.UpdateUser API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::UpdateUserRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::UpdateUserResponse] API response.
-        def update_user(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_user(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_user',
             request_class: Temporalio::Api::Cloud::CloudService::V1::UpdateUserRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::UpdateUserResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.DeleteUser API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::DeleteUserRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::DeleteUserResponse] API response.
-        def delete_user(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_user(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_user',
             request_class: Temporalio::Api::Cloud::CloudService::V1::DeleteUserRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::DeleteUserResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.SetUserNamespaceAccess API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::SetUserNamespaceAccessRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::SetUserNamespaceAccessResponse] API response.
-        def set_user_namespace_access(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def set_user_namespace_access(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'set_user_namespace_access',
             request_class: Temporalio::Api::Cloud::CloudService::V1::SetUserNamespaceAccessRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::SetUserNamespaceAccessResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetAsyncOperation API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetAsyncOperationRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetAsyncOperationResponse] API response.
-        def get_async_operation(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_async_operation(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_async_operation',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetAsyncOperationRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetAsyncOperationResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.CreateNamespace API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::CreateNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::CreateNamespaceResponse] API response.
-        def create_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def create_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'create_namespace',
             request_class: Temporalio::Api::Cloud::CloudService::V1::CreateNamespaceRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::CreateNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetNamespaces API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetNamespacesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetNamespacesResponse] API response.
-        def get_namespaces(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_namespaces(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_namespaces',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetNamespacesRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetNamespacesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetNamespace API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetNamespaceResponse] API response.
-        def get_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_namespace',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetNamespaceRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.UpdateNamespace API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::UpdateNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::UpdateNamespaceResponse] API response.
-        def update_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_namespace',
             request_class: Temporalio::Api::Cloud::CloudService::V1::UpdateNamespaceRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::UpdateNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.RenameCustomSearchAttribute API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::RenameCustomSearchAttributeRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::RenameCustomSearchAttributeResponse] API response.
-        def rename_custom_search_attribute(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def rename_custom_search_attribute(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'rename_custom_search_attribute',
             request_class: Temporalio::Api::Cloud::CloudService::V1::RenameCustomSearchAttributeRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::RenameCustomSearchAttributeResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.DeleteNamespace API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::DeleteNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::DeleteNamespaceResponse] API response.
-        def delete_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_namespace',
             request_class: Temporalio::Api::Cloud::CloudService::V1::DeleteNamespaceRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::DeleteNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.FailoverNamespaceRegion API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::FailoverNamespaceRegionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::FailoverNamespaceRegionResponse] API response.
-        def failover_namespace_region(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def failover_namespace_region(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'failover_namespace_region',
             request_class: Temporalio::Api::Cloud::CloudService::V1::FailoverNamespaceRegionRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::FailoverNamespaceRegionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.AddNamespaceRegion API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::AddNamespaceRegionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::AddNamespaceRegionResponse] API response.
-        def add_namespace_region(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def add_namespace_region(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'add_namespace_region',
             request_class: Temporalio::Api::Cloud::CloudService::V1::AddNamespaceRegionRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::AddNamespaceRegionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetRegions API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetRegionsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetRegionsResponse] API response.
-        def get_regions(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_regions(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_regions',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetRegionsRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetRegionsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetRegion API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetRegionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetRegionResponse] API response.
-        def get_region(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_region(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_region',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetRegionRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetRegionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetApiKeys API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetApiKeysRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetApiKeysResponse] API response.
-        def get_api_keys(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_api_keys(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_api_keys',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetApiKeysRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetApiKeysResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetApiKey API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetApiKeyRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetApiKeyResponse] API response.
-        def get_api_key(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_api_key(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_api_key',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetApiKeyRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetApiKeyResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.CreateApiKey API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::CreateApiKeyRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::CreateApiKeyResponse] API response.
-        def create_api_key(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def create_api_key(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'create_api_key',
             request_class: Temporalio::Api::Cloud::CloudService::V1::CreateApiKeyRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::CreateApiKeyResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.UpdateApiKey API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::UpdateApiKeyRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::UpdateApiKeyResponse] API response.
-        def update_api_key(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_api_key(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_api_key',
             request_class: Temporalio::Api::Cloud::CloudService::V1::UpdateApiKeyRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::UpdateApiKeyResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.DeleteApiKey API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::DeleteApiKeyRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::DeleteApiKeyResponse] API response.
-        def delete_api_key(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_api_key(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_api_key',
             request_class: Temporalio::Api::Cloud::CloudService::V1::DeleteApiKeyRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::DeleteApiKeyResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetUserGroups API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetUserGroupsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetUserGroupsResponse] API response.
-        def get_user_groups(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_user_groups(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_user_groups',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetUserGroupsRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetUserGroupsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetUserGroup API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetUserGroupRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetUserGroupResponse] API response.
-        def get_user_group(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_user_group(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_user_group',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetUserGroupRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetUserGroupResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.CreateUserGroup API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::CreateUserGroupRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::CreateUserGroupResponse] API response.
-        def create_user_group(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def create_user_group(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'create_user_group',
             request_class: Temporalio::Api::Cloud::CloudService::V1::CreateUserGroupRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::CreateUserGroupResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.UpdateUserGroup API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::UpdateUserGroupRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::UpdateUserGroupResponse] API response.
-        def update_user_group(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_user_group(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_user_group',
             request_class: Temporalio::Api::Cloud::CloudService::V1::UpdateUserGroupRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::UpdateUserGroupResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.DeleteUserGroup API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::DeleteUserGroupRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::DeleteUserGroupResponse] API response.
-        def delete_user_group(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_user_group(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_user_group',
             request_class: Temporalio::Api::Cloud::CloudService::V1::DeleteUserGroupRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::DeleteUserGroupResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.SetUserGroupNamespaceAccess API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::SetUserGroupNamespaceAccessRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::SetUserGroupNamespaceAccessResponse] API response.
-        def set_user_group_namespace_access(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def set_user_group_namespace_access(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'set_user_group_namespace_access',
             request_class: Temporalio::Api::Cloud::CloudService::V1::SetUserGroupNamespaceAccessRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::SetUserGroupNamespaceAccessResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.CreateServiceAccount API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::CreateServiceAccountRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::CreateServiceAccountResponse] API response.
-        def create_service_account(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def create_service_account(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'create_service_account',
             request_class: Temporalio::Api::Cloud::CloudService::V1::CreateServiceAccountRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::CreateServiceAccountResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetServiceAccount API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetServiceAccountRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetServiceAccountResponse] API response.
-        def get_service_account(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_service_account(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_service_account',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetServiceAccountRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetServiceAccountResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.GetServiceAccounts API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::GetServiceAccountsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::GetServiceAccountsResponse] API response.
-        def get_service_accounts(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_service_accounts(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_service_accounts',
             request_class: Temporalio::Api::Cloud::CloudService::V1::GetServiceAccountsRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::GetServiceAccountsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.UpdateServiceAccount API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::UpdateServiceAccountRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::UpdateServiceAccountResponse] API response.
-        def update_service_account(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_service_account(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_service_account',
             request_class: Temporalio::Api::Cloud::CloudService::V1::UpdateServiceAccountRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::UpdateServiceAccountResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls CloudService.DeleteServiceAccount API call.
         #
         # @param request [Temporalio::Api::Cloud::CloudService::V1::DeleteServiceAccountRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::Cloud::CloudService::V1::DeleteServiceAccountResponse] API response.
-        def delete_service_account(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_service_account(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_service_account',
             request_class: Temporalio::Api::Cloud::CloudService::V1::DeleteServiceAccountRequest,
             response_class: Temporalio::Api::Cloud::CloudService::V1::DeleteServiceAccountResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
       end

--- a/temporalio/lib/temporalio/client/connection/operator_service.rb
+++ b/temporalio/lib/temporalio/client/connection/operator_service.rb
@@ -19,228 +19,180 @@ module Temporalio
         # Calls OperatorService.AddSearchAttributes API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::AddSearchAttributesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::AddSearchAttributesResponse] API response.
-        def add_search_attributes(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def add_search_attributes(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'add_search_attributes',
             request_class: Temporalio::Api::OperatorService::V1::AddSearchAttributesRequest,
             response_class: Temporalio::Api::OperatorService::V1::AddSearchAttributesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.RemoveSearchAttributes API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::RemoveSearchAttributesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::RemoveSearchAttributesResponse] API response.
-        def remove_search_attributes(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def remove_search_attributes(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'remove_search_attributes',
             request_class: Temporalio::Api::OperatorService::V1::RemoveSearchAttributesRequest,
             response_class: Temporalio::Api::OperatorService::V1::RemoveSearchAttributesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.ListSearchAttributes API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::ListSearchAttributesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::ListSearchAttributesResponse] API response.
-        def list_search_attributes(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_search_attributes(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_search_attributes',
             request_class: Temporalio::Api::OperatorService::V1::ListSearchAttributesRequest,
             response_class: Temporalio::Api::OperatorService::V1::ListSearchAttributesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.DeleteNamespace API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::DeleteNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::DeleteNamespaceResponse] API response.
-        def delete_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_namespace',
             request_class: Temporalio::Api::OperatorService::V1::DeleteNamespaceRequest,
             response_class: Temporalio::Api::OperatorService::V1::DeleteNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.AddOrUpdateRemoteCluster API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::AddOrUpdateRemoteClusterRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::AddOrUpdateRemoteClusterResponse] API response.
-        def add_or_update_remote_cluster(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def add_or_update_remote_cluster(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'add_or_update_remote_cluster',
             request_class: Temporalio::Api::OperatorService::V1::AddOrUpdateRemoteClusterRequest,
             response_class: Temporalio::Api::OperatorService::V1::AddOrUpdateRemoteClusterResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.RemoveRemoteCluster API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::RemoveRemoteClusterRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::RemoveRemoteClusterResponse] API response.
-        def remove_remote_cluster(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def remove_remote_cluster(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'remove_remote_cluster',
             request_class: Temporalio::Api::OperatorService::V1::RemoveRemoteClusterRequest,
             response_class: Temporalio::Api::OperatorService::V1::RemoveRemoteClusterResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.ListClusters API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::ListClustersRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::ListClustersResponse] API response.
-        def list_clusters(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_clusters(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_clusters',
             request_class: Temporalio::Api::OperatorService::V1::ListClustersRequest,
             response_class: Temporalio::Api::OperatorService::V1::ListClustersResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.GetNexusEndpoint API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::GetNexusEndpointRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::GetNexusEndpointResponse] API response.
-        def get_nexus_endpoint(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_nexus_endpoint(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_nexus_endpoint',
             request_class: Temporalio::Api::OperatorService::V1::GetNexusEndpointRequest,
             response_class: Temporalio::Api::OperatorService::V1::GetNexusEndpointResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.CreateNexusEndpoint API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::CreateNexusEndpointRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::CreateNexusEndpointResponse] API response.
-        def create_nexus_endpoint(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def create_nexus_endpoint(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'create_nexus_endpoint',
             request_class: Temporalio::Api::OperatorService::V1::CreateNexusEndpointRequest,
             response_class: Temporalio::Api::OperatorService::V1::CreateNexusEndpointResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.UpdateNexusEndpoint API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::UpdateNexusEndpointRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::UpdateNexusEndpointResponse] API response.
-        def update_nexus_endpoint(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_nexus_endpoint(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_nexus_endpoint',
             request_class: Temporalio::Api::OperatorService::V1::UpdateNexusEndpointRequest,
             response_class: Temporalio::Api::OperatorService::V1::UpdateNexusEndpointResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.DeleteNexusEndpoint API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::DeleteNexusEndpointRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::DeleteNexusEndpointResponse] API response.
-        def delete_nexus_endpoint(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_nexus_endpoint(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_nexus_endpoint',
             request_class: Temporalio::Api::OperatorService::V1::DeleteNexusEndpointRequest,
             response_class: Temporalio::Api::OperatorService::V1::DeleteNexusEndpointResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls OperatorService.ListNexusEndpoints API call.
         #
         # @param request [Temporalio::Api::OperatorService::V1::ListNexusEndpointsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::OperatorService::V1::ListNexusEndpointsResponse] API response.
-        def list_nexus_endpoints(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_nexus_endpoints(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_nexus_endpoints',
             request_class: Temporalio::Api::OperatorService::V1::ListNexusEndpointsRequest,
             response_class: Temporalio::Api::OperatorService::V1::ListNexusEndpointsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
       end

--- a/temporalio/lib/temporalio/client/connection/workflow_service.rb
+++ b/temporalio/lib/temporalio/client/connection/workflow_service.rb
@@ -19,1197 +19,945 @@ module Temporalio
         # Calls WorkflowService.RegisterNamespace API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RegisterNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RegisterNamespaceResponse] API response.
-        def register_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def register_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'register_namespace',
             request_class: Temporalio::Api::WorkflowService::V1::RegisterNamespaceRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RegisterNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.DescribeNamespace API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::DescribeNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::DescribeNamespaceResponse] API response.
-        def describe_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def describe_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'describe_namespace',
             request_class: Temporalio::Api::WorkflowService::V1::DescribeNamespaceRequest,
             response_class: Temporalio::Api::WorkflowService::V1::DescribeNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListNamespaces API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListNamespacesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListNamespacesResponse] API response.
-        def list_namespaces(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_namespaces(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_namespaces',
             request_class: Temporalio::Api::WorkflowService::V1::ListNamespacesRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListNamespacesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.UpdateNamespace API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::UpdateNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::UpdateNamespaceResponse] API response.
-        def update_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_namespace',
             request_class: Temporalio::Api::WorkflowService::V1::UpdateNamespaceRequest,
             response_class: Temporalio::Api::WorkflowService::V1::UpdateNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.DeprecateNamespace API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::DeprecateNamespaceRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::DeprecateNamespaceResponse] API response.
-        def deprecate_namespace(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def deprecate_namespace(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'deprecate_namespace',
             request_class: Temporalio::Api::WorkflowService::V1::DeprecateNamespaceRequest,
             response_class: Temporalio::Api::WorkflowService::V1::DeprecateNamespaceResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.StartWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::StartWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::StartWorkflowExecutionResponse] API response.
-        def start_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def start_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'start_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::StartWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::StartWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ExecuteMultiOperation API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ExecuteMultiOperationRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ExecuteMultiOperationResponse] API response.
-        def execute_multi_operation(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def execute_multi_operation(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'execute_multi_operation',
             request_class: Temporalio::Api::WorkflowService::V1::ExecuteMultiOperationRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ExecuteMultiOperationResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.GetWorkflowExecutionHistory API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse] API response.
-        def get_workflow_execution_history(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_workflow_execution_history(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_workflow_execution_history',
             request_class: Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryRequest,
             response_class: Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.GetWorkflowExecutionHistoryReverse API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseResponse] API response.
-        def get_workflow_execution_history_reverse(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_workflow_execution_history_reverse(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_workflow_execution_history_reverse',
             request_class: Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseRequest,
             response_class: Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryReverseResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.PollWorkflowTaskQueue API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::PollWorkflowTaskQueueRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::PollWorkflowTaskQueueResponse] API response.
-        def poll_workflow_task_queue(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def poll_workflow_task_queue(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'poll_workflow_task_queue',
             request_class: Temporalio::Api::WorkflowService::V1::PollWorkflowTaskQueueRequest,
             response_class: Temporalio::Api::WorkflowService::V1::PollWorkflowTaskQueueResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondWorkflowTaskCompleted API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondWorkflowTaskCompletedRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondWorkflowTaskCompletedResponse] API response.
-        def respond_workflow_task_completed(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_workflow_task_completed(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_workflow_task_completed',
             request_class: Temporalio::Api::WorkflowService::V1::RespondWorkflowTaskCompletedRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondWorkflowTaskCompletedResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondWorkflowTaskFailed API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondWorkflowTaskFailedRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondWorkflowTaskFailedResponse] API response.
-        def respond_workflow_task_failed(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_workflow_task_failed(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_workflow_task_failed',
             request_class: Temporalio::Api::WorkflowService::V1::RespondWorkflowTaskFailedRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondWorkflowTaskFailedResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.PollActivityTaskQueue API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::PollActivityTaskQueueRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::PollActivityTaskQueueResponse] API response.
-        def poll_activity_task_queue(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def poll_activity_task_queue(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'poll_activity_task_queue',
             request_class: Temporalio::Api::WorkflowService::V1::PollActivityTaskQueueRequest,
             response_class: Temporalio::Api::WorkflowService::V1::PollActivityTaskQueueResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RecordActivityTaskHeartbeat API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatResponse] API response.
-        def record_activity_task_heartbeat(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def record_activity_task_heartbeat(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'record_activity_task_heartbeat',
             request_class: Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RecordActivityTaskHeartbeatById API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdResponse] API response.
-        def record_activity_task_heartbeat_by_id(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def record_activity_task_heartbeat_by_id(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'record_activity_task_heartbeat_by_id',
             request_class: Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatByIdResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondActivityTaskCompleted API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondActivityTaskCompletedRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondActivityTaskCompletedResponse] API response.
-        def respond_activity_task_completed(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_activity_task_completed(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_activity_task_completed',
             request_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskCompletedRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskCompletedResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondActivityTaskCompletedById API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdResponse] API response.
-        def respond_activity_task_completed_by_id(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_activity_task_completed_by_id(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_activity_task_completed_by_id',
             request_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskCompletedByIdResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondActivityTaskFailed API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedResponse] API response.
-        def respond_activity_task_failed(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_activity_task_failed(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_activity_task_failed',
             request_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondActivityTaskFailedById API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedByIdRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedByIdResponse] API response.
-        def respond_activity_task_failed_by_id(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_activity_task_failed_by_id(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_activity_task_failed_by_id',
             request_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedByIdRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedByIdResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondActivityTaskCanceled API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondActivityTaskCanceledRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondActivityTaskCanceledResponse] API response.
-        def respond_activity_task_canceled(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_activity_task_canceled(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_activity_task_canceled',
             request_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskCanceledRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskCanceledResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondActivityTaskCanceledById API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdResponse] API response.
-        def respond_activity_task_canceled_by_id(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_activity_task_canceled_by_id(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_activity_task_canceled_by_id',
             request_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondActivityTaskCanceledByIdResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RequestCancelWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RequestCancelWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RequestCancelWorkflowExecutionResponse] API response.
-        def request_cancel_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def request_cancel_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'request_cancel_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::RequestCancelWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RequestCancelWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.SignalWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::SignalWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::SignalWorkflowExecutionResponse] API response.
-        def signal_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def signal_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'signal_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::SignalWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::SignalWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.SignalWithStartWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionResponse] API response.
-        def signal_with_start_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def signal_with_start_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'signal_with_start_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ResetWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ResetWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ResetWorkflowExecutionResponse] API response.
-        def reset_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def reset_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'reset_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::ResetWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ResetWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.TerminateWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::TerminateWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse] API response.
-        def terminate_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def terminate_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'terminate_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::TerminateWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.DeleteWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::DeleteWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::DeleteWorkflowExecutionResponse] API response.
-        def delete_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::DeleteWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::DeleteWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListOpenWorkflowExecutions API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListOpenWorkflowExecutionsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListOpenWorkflowExecutionsResponse] API response.
-        def list_open_workflow_executions(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_open_workflow_executions(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_open_workflow_executions',
             request_class: Temporalio::Api::WorkflowService::V1::ListOpenWorkflowExecutionsRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListOpenWorkflowExecutionsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListClosedWorkflowExecutions API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListClosedWorkflowExecutionsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListClosedWorkflowExecutionsResponse] API response.
-        def list_closed_workflow_executions(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_closed_workflow_executions(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_closed_workflow_executions',
             request_class: Temporalio::Api::WorkflowService::V1::ListClosedWorkflowExecutionsRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListClosedWorkflowExecutionsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListWorkflowExecutions API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListWorkflowExecutionsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListWorkflowExecutionsResponse] API response.
-        def list_workflow_executions(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_workflow_executions(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_workflow_executions',
             request_class: Temporalio::Api::WorkflowService::V1::ListWorkflowExecutionsRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListWorkflowExecutionsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListArchivedWorkflowExecutions API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsResponse] API response.
-        def list_archived_workflow_executions(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_archived_workflow_executions(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_archived_workflow_executions',
             request_class: Temporalio::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListArchivedWorkflowExecutionsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ScanWorkflowExecutions API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ScanWorkflowExecutionsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ScanWorkflowExecutionsResponse] API response.
-        def scan_workflow_executions(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def scan_workflow_executions(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'scan_workflow_executions',
             request_class: Temporalio::Api::WorkflowService::V1::ScanWorkflowExecutionsRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ScanWorkflowExecutionsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.CountWorkflowExecutions API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::CountWorkflowExecutionsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::CountWorkflowExecutionsResponse] API response.
-        def count_workflow_executions(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def count_workflow_executions(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'count_workflow_executions',
             request_class: Temporalio::Api::WorkflowService::V1::CountWorkflowExecutionsRequest,
             response_class: Temporalio::Api::WorkflowService::V1::CountWorkflowExecutionsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.GetSearchAttributes API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::GetSearchAttributesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::GetSearchAttributesResponse] API response.
-        def get_search_attributes(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_search_attributes(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_search_attributes',
             request_class: Temporalio::Api::WorkflowService::V1::GetSearchAttributesRequest,
             response_class: Temporalio::Api::WorkflowService::V1::GetSearchAttributesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondQueryTaskCompleted API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondQueryTaskCompletedRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondQueryTaskCompletedResponse] API response.
-        def respond_query_task_completed(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_query_task_completed(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_query_task_completed',
             request_class: Temporalio::Api::WorkflowService::V1::RespondQueryTaskCompletedRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondQueryTaskCompletedResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ResetStickyTaskQueue API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ResetStickyTaskQueueRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ResetStickyTaskQueueResponse] API response.
-        def reset_sticky_task_queue(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def reset_sticky_task_queue(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'reset_sticky_task_queue',
             request_class: Temporalio::Api::WorkflowService::V1::ResetStickyTaskQueueRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ResetStickyTaskQueueResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.QueryWorkflow API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::QueryWorkflowRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::QueryWorkflowResponse] API response.
-        def query_workflow(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def query_workflow(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'query_workflow',
             request_class: Temporalio::Api::WorkflowService::V1::QueryWorkflowRequest,
             response_class: Temporalio::Api::WorkflowService::V1::QueryWorkflowResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.DescribeWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::DescribeWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse] API response.
-        def describe_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def describe_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'describe_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::DescribeWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.DescribeTaskQueue API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::DescribeTaskQueueRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::DescribeTaskQueueResponse] API response.
-        def describe_task_queue(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def describe_task_queue(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'describe_task_queue',
             request_class: Temporalio::Api::WorkflowService::V1::DescribeTaskQueueRequest,
             response_class: Temporalio::Api::WorkflowService::V1::DescribeTaskQueueResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.GetClusterInfo API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::GetClusterInfoRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::GetClusterInfoResponse] API response.
-        def get_cluster_info(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_cluster_info(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_cluster_info',
             request_class: Temporalio::Api::WorkflowService::V1::GetClusterInfoRequest,
             response_class: Temporalio::Api::WorkflowService::V1::GetClusterInfoResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.GetSystemInfo API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::GetSystemInfoRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::GetSystemInfoResponse] API response.
-        def get_system_info(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_system_info(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_system_info',
             request_class: Temporalio::Api::WorkflowService::V1::GetSystemInfoRequest,
             response_class: Temporalio::Api::WorkflowService::V1::GetSystemInfoResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListTaskQueuePartitions API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListTaskQueuePartitionsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListTaskQueuePartitionsResponse] API response.
-        def list_task_queue_partitions(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_task_queue_partitions(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_task_queue_partitions',
             request_class: Temporalio::Api::WorkflowService::V1::ListTaskQueuePartitionsRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListTaskQueuePartitionsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.CreateSchedule API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::CreateScheduleRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::CreateScheduleResponse] API response.
-        def create_schedule(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def create_schedule(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'create_schedule',
             request_class: Temporalio::Api::WorkflowService::V1::CreateScheduleRequest,
             response_class: Temporalio::Api::WorkflowService::V1::CreateScheduleResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.DescribeSchedule API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::DescribeScheduleRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::DescribeScheduleResponse] API response.
-        def describe_schedule(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def describe_schedule(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'describe_schedule',
             request_class: Temporalio::Api::WorkflowService::V1::DescribeScheduleRequest,
             response_class: Temporalio::Api::WorkflowService::V1::DescribeScheduleResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.UpdateSchedule API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::UpdateScheduleRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::UpdateScheduleResponse] API response.
-        def update_schedule(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_schedule(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_schedule',
             request_class: Temporalio::Api::WorkflowService::V1::UpdateScheduleRequest,
             response_class: Temporalio::Api::WorkflowService::V1::UpdateScheduleResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.PatchSchedule API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::PatchScheduleRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::PatchScheduleResponse] API response.
-        def patch_schedule(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def patch_schedule(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'patch_schedule',
             request_class: Temporalio::Api::WorkflowService::V1::PatchScheduleRequest,
             response_class: Temporalio::Api::WorkflowService::V1::PatchScheduleResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListScheduleMatchingTimes API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListScheduleMatchingTimesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListScheduleMatchingTimesResponse] API response.
-        def list_schedule_matching_times(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_schedule_matching_times(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_schedule_matching_times',
             request_class: Temporalio::Api::WorkflowService::V1::ListScheduleMatchingTimesRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListScheduleMatchingTimesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.DeleteSchedule API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::DeleteScheduleRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::DeleteScheduleResponse] API response.
-        def delete_schedule(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def delete_schedule(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'delete_schedule',
             request_class: Temporalio::Api::WorkflowService::V1::DeleteScheduleRequest,
             response_class: Temporalio::Api::WorkflowService::V1::DeleteScheduleResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListSchedules API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListSchedulesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListSchedulesResponse] API response.
-        def list_schedules(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_schedules(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_schedules',
             request_class: Temporalio::Api::WorkflowService::V1::ListSchedulesRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListSchedulesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.UpdateWorkerBuildIdCompatibility API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::UpdateWorkerBuildIdCompatibilityRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::UpdateWorkerBuildIdCompatibilityResponse] API response.
-        def update_worker_build_id_compatibility(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_worker_build_id_compatibility(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_worker_build_id_compatibility',
             request_class: Temporalio::Api::WorkflowService::V1::UpdateWorkerBuildIdCompatibilityRequest,
             response_class: Temporalio::Api::WorkflowService::V1::UpdateWorkerBuildIdCompatibilityResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.GetWorkerBuildIdCompatibility API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::GetWorkerBuildIdCompatibilityRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::GetWorkerBuildIdCompatibilityResponse] API response.
-        def get_worker_build_id_compatibility(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_worker_build_id_compatibility(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_worker_build_id_compatibility',
             request_class: Temporalio::Api::WorkflowService::V1::GetWorkerBuildIdCompatibilityRequest,
             response_class: Temporalio::Api::WorkflowService::V1::GetWorkerBuildIdCompatibilityResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.UpdateWorkerVersioningRules API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::UpdateWorkerVersioningRulesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::UpdateWorkerVersioningRulesResponse] API response.
-        def update_worker_versioning_rules(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_worker_versioning_rules(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_worker_versioning_rules',
             request_class: Temporalio::Api::WorkflowService::V1::UpdateWorkerVersioningRulesRequest,
             response_class: Temporalio::Api::WorkflowService::V1::UpdateWorkerVersioningRulesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.GetWorkerVersioningRules API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::GetWorkerVersioningRulesRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::GetWorkerVersioningRulesResponse] API response.
-        def get_worker_versioning_rules(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_worker_versioning_rules(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_worker_versioning_rules',
             request_class: Temporalio::Api::WorkflowService::V1::GetWorkerVersioningRulesRequest,
             response_class: Temporalio::Api::WorkflowService::V1::GetWorkerVersioningRulesResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.GetWorkerTaskReachability API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::GetWorkerTaskReachabilityRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::GetWorkerTaskReachabilityResponse] API response.
-        def get_worker_task_reachability(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def get_worker_task_reachability(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'get_worker_task_reachability',
             request_class: Temporalio::Api::WorkflowService::V1::GetWorkerTaskReachabilityRequest,
             response_class: Temporalio::Api::WorkflowService::V1::GetWorkerTaskReachabilityResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.UpdateWorkflowExecution API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::UpdateWorkflowExecutionRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::UpdateWorkflowExecutionResponse] API response.
-        def update_workflow_execution(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def update_workflow_execution(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'update_workflow_execution',
             request_class: Temporalio::Api::WorkflowService::V1::UpdateWorkflowExecutionRequest,
             response_class: Temporalio::Api::WorkflowService::V1::UpdateWorkflowExecutionResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.PollWorkflowExecutionUpdate API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::PollWorkflowExecutionUpdateRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::PollWorkflowExecutionUpdateResponse] API response.
-        def poll_workflow_execution_update(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def poll_workflow_execution_update(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'poll_workflow_execution_update',
             request_class: Temporalio::Api::WorkflowService::V1::PollWorkflowExecutionUpdateRequest,
             response_class: Temporalio::Api::WorkflowService::V1::PollWorkflowExecutionUpdateResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.StartBatchOperation API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::StartBatchOperationRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::StartBatchOperationResponse] API response.
-        def start_batch_operation(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def start_batch_operation(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'start_batch_operation',
             request_class: Temporalio::Api::WorkflowService::V1::StartBatchOperationRequest,
             response_class: Temporalio::Api::WorkflowService::V1::StartBatchOperationResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.StopBatchOperation API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::StopBatchOperationRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::StopBatchOperationResponse] API response.
-        def stop_batch_operation(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def stop_batch_operation(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'stop_batch_operation',
             request_class: Temporalio::Api::WorkflowService::V1::StopBatchOperationRequest,
             response_class: Temporalio::Api::WorkflowService::V1::StopBatchOperationResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.DescribeBatchOperation API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::DescribeBatchOperationRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::DescribeBatchOperationResponse] API response.
-        def describe_batch_operation(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def describe_batch_operation(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'describe_batch_operation',
             request_class: Temporalio::Api::WorkflowService::V1::DescribeBatchOperationRequest,
             response_class: Temporalio::Api::WorkflowService::V1::DescribeBatchOperationResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.ListBatchOperations API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::ListBatchOperationsRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::ListBatchOperationsResponse] API response.
-        def list_batch_operations(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def list_batch_operations(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'list_batch_operations',
             request_class: Temporalio::Api::WorkflowService::V1::ListBatchOperationsRequest,
             response_class: Temporalio::Api::WorkflowService::V1::ListBatchOperationsResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.PollNexusTaskQueue API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::PollNexusTaskQueueRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::PollNexusTaskQueueResponse] API response.
-        def poll_nexus_task_queue(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def poll_nexus_task_queue(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'poll_nexus_task_queue',
             request_class: Temporalio::Api::WorkflowService::V1::PollNexusTaskQueueRequest,
             response_class: Temporalio::Api::WorkflowService::V1::PollNexusTaskQueueResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondNexusTaskCompleted API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondNexusTaskCompletedRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondNexusTaskCompletedResponse] API response.
-        def respond_nexus_task_completed(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_nexus_task_completed(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_nexus_task_completed',
             request_class: Temporalio::Api::WorkflowService::V1::RespondNexusTaskCompletedRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondNexusTaskCompletedResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
 
         # Calls WorkflowService.RespondNexusTaskFailed API call.
         #
         # @param request [Temporalio::Api::WorkflowService::V1::RespondNexusTaskFailedRequest] API request.
-        # @param rpc_retry [Boolean] Whether to implicitly retry known retryable errors.
-        # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-        # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+        # @param rpc_options [RPCOptions, nil] Advanced RPC options.
         # @return [Temporalio::Api::WorkflowService::V1::RespondNexusTaskFailedResponse] API response.
-        def respond_nexus_task_failed(request, rpc_retry: false, rpc_metadata: nil, rpc_timeout: nil)
+        def respond_nexus_task_failed(request, rpc_options: nil)
           invoke_rpc(
             rpc: 'respond_nexus_task_failed',
             request_class: Temporalio::Api::WorkflowService::V1::RespondNexusTaskFailedRequest,
             response_class: Temporalio::Api::WorkflowService::V1::RespondNexusTaskFailedResponse,
             request:,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:
+            rpc_options:
           )
         end
       end

--- a/temporalio/lib/temporalio/client/interceptor.rb
+++ b/temporalio/lib/temporalio/client/interceptor.rb
@@ -35,24 +35,21 @@ module Temporalio
         :start_delay,
         :request_eager_start,
         :headers,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
       # Input for {Outbound.list_workflows}.
       ListWorkflowsInput = Struct.new(
         :query,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
       # Input for {Outbound.count_workflows}.
       CountWorkflowsInput = Struct.new(
         :query,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -60,8 +57,7 @@ module Temporalio
       DescribeWorkflowInput = Struct.new(
         :workflow_id,
         :run_id,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -72,8 +68,7 @@ module Temporalio
         :wait_new_event,
         :event_filter_type,
         :skip_archival,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -84,8 +79,7 @@ module Temporalio
         :signal,
         :args,
         :headers,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -97,8 +91,7 @@ module Temporalio
         :args,
         :reject_condition,
         :headers,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -111,8 +104,7 @@ module Temporalio
         :args,
         :wait_for_stage,
         :headers,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -121,8 +113,7 @@ module Temporalio
         :workflow_id,
         :run_id,
         :update_id,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -131,8 +122,7 @@ module Temporalio
         :workflow_id,
         :run_id,
         :first_execution_run_id,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -143,8 +133,7 @@ module Temporalio
         :first_execution_run_id,
         :reason,
         :details,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -152,8 +141,7 @@ module Temporalio
       HeartbeatAsyncActivityInput = Struct.new(
         :task_token_or_id_reference,
         :details,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -161,8 +149,7 @@ module Temporalio
       CompleteAsyncActivityInput = Struct.new(
         :task_token_or_id_reference,
         :result,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -171,8 +158,7 @@ module Temporalio
         :task_token_or_id_reference,
         :error,
         :last_heartbeat_details,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 
@@ -180,8 +166,7 @@ module Temporalio
       ReportCancellationAsyncActivityInput = Struct.new(
         :task_token_or_id_reference,
         :details,
-        :rpc_metadata,
-        :rpc_timeout,
+        :rpc_options,
         keyword_init: true
       )
 

--- a/temporalio/lib/temporalio/client/workflow_update_handle.rb
+++ b/temporalio/lib/temporalio/client/workflow_update_handle.rb
@@ -36,8 +36,7 @@ module Temporalio
       # Wait for and return the result of the update. The result may already be known in which case no network call is
       # made. Otherwise the result will be polled for until it is returned.
       #
-      # @param rpc_metadata [Hash<String, String>, nil] Headers to include on the RPC call.
-      # @param rpc_timeout [Float, nil] Number of seconds before timeout.
+      # @param rpc_options [RPCOptions, nil] Advanced RPC options.
       #
       # @return [Object, nil] Update result.
       #
@@ -45,13 +44,12 @@ module Temporalio
       # @raise [Error::WorkflowUpdateRPCTimeoutOrCanceledError] This update call timed out or was canceled. This doesn't
       #   mean the update itself was timed out or canceled.
       # @raise [Error::RPCError] RPC error from call.
-      def result(rpc_metadata: nil, rpc_timeout: nil)
+      def result(rpc_options: nil)
         @known_outcome ||= @client._impl.poll_workflow_update(Interceptor::PollWorkflowUpdateInput.new(
                                                                 workflow_id:,
                                                                 run_id: workflow_run_id,
                                                                 update_id: id,
-                                                                rpc_metadata:,
-                                                                rpc_timeout:
+                                                                rpc_options:
                                                               ))
 
         if @known_outcome.failure

--- a/temporalio/lib/temporalio/internal/bridge/client.rb
+++ b/temporalio/lib/temporalio/internal/bridge/client.rb
@@ -65,18 +65,23 @@ module Temporalio
           rpc:,
           request:,
           response_class:,
-          rpc_retry:,
-          rpc_metadata:,
-          rpc_timeout:
+          rpc_options:
         )
+          # Build cancellation token if needed
+          if rpc_options&.cancellation
+            rpc_cancellation_token = CancellationToken.new
+            rpc_options&.cancellation&.add_cancel_callback { rpc_cancellation_token.cancel }
+          end
+
           queue = Queue.new
           async_invoke_rpc(
             service:,
             rpc:,
             request: request.to_proto,
-            rpc_retry:,
-            rpc_metadata:,
-            rpc_timeout:,
+            rpc_retry: rpc_options&.override_retry || false,
+            rpc_metadata: rpc_options&.metadata,
+            rpc_timeout: rpc_options&.timeout,
+            rpc_cancellation_token:,
             queue:
           )
           result = queue.pop

--- a/temporalio/sig/temporalio/client.rbs
+++ b/temporalio/sig/temporalio/client.rbs
@@ -69,8 +69,7 @@ module Temporalio
       ?search_attributes: SearchAttributes?,
       ?start_delay: Float?,
       ?request_eager_start: bool,
-      ?rpc_metadata: Hash[String, String]?,
-      ?rpc_timeout: Float?
+      ?rpc_options: RPCOptions?
     ) -> WorkflowHandle
 
     def execute_workflow: (
@@ -89,8 +88,7 @@ module Temporalio
       ?search_attributes: SearchAttributes?,
       ?start_delay: Float?,
       ?request_eager_start: bool,
-      ?rpc_metadata: Hash[String, String]?,
-      ?rpc_timeout: Float?
+      ?rpc_options: RPCOptions?
     ) -> Object?
 
     def workflow_handle: (
@@ -101,18 +99,30 @@ module Temporalio
 
     def list_workflows: (
       ?String query,
-      ?rpc_metadata: Hash[String, String]?,
-      ?rpc_timeout: Float?
+      ?rpc_options: RPCOptions?
     ) -> Enumerator[WorkflowExecution, WorkflowExecution]
 
     def count_workflows: (
       ?String query,
-      ?rpc_metadata: Hash[String, String]?,
-      ?rpc_timeout: Float?
+      ?rpc_options: RPCOptions?
     ) -> WorkflowExecutionCount
 
     def async_activity_handle: (
       String | ActivityIDReference task_token_or_id_reference
     ) -> AsyncActivityHandle
+
+    class RPCOptions
+      attr_accessor metadata: Hash[String, String]?
+      attr_accessor timeout: Float?
+      attr_accessor cancellation: Cancellation?
+      attr_accessor override_retry: bool?
+
+      def initialize: (
+        ?metadata: Hash[String, String]?,
+        ?timeout: Float?,
+        ?cancellation: Cancellation?,
+        ?override_retry: bool?
+      ) -> void
+    end
   end
 end

--- a/temporalio/sig/temporalio/client/async_activity_handle.rbs
+++ b/temporalio/sig/temporalio/client/async_activity_handle.rbs
@@ -12,27 +12,23 @@ module Temporalio
 
       def heartbeat: (
         *Object? details,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> void
 
       def complete: (
         ?Object? result,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> void
 
       def fail: (
         Exception error,
         ?last_heartbeat_details: Array[Object?],
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> void
 
       def report_cancellation: (
         *Object? details,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> void
 
       private def task_token_or_id_reference: -> (String | ActivityIDReference)

--- a/temporalio/sig/temporalio/client/connection/cloud_service.rbs
+++ b/temporalio/sig/temporalio/client/connection/cloud_service.rbs
@@ -5,39 +5,138 @@ module Temporalio
     class Connection
       class CloudService < Service
         def initialize: (Connection) -> void
-        def get_users: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_user: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def create_user: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_user: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_user: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def set_user_namespace_access: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_async_operation: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def create_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_namespaces: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def rename_custom_search_attribute: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def failover_namespace_region: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def add_namespace_region: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_regions: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_region: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_api_keys: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_api_key: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def create_api_key: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_api_key: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_api_key: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_user_groups: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_user_group: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def create_user_group: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_user_group: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_user_group: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def set_user_group_namespace_access: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def create_service_account: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_service_account: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_service_accounts: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_service_account: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_service_account: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
+        def get_users: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_user: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def create_user: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_user: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_user: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def set_user_namespace_access: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_async_operation: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def create_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_namespaces: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def rename_custom_search_attribute: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def failover_namespace_region: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def add_namespace_region: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_regions: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_region: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_api_keys: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_api_key: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def create_api_key: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_api_key: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_api_key: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_user_groups: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_user_group: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def create_user_group: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_user_group: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_user_group: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def set_user_group_namespace_access: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def create_service_account: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_service_account: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_service_accounts: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_service_account: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_service_account: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
       end
     end
   end

--- a/temporalio/sig/temporalio/client/connection/operator_service.rbs
+++ b/temporalio/sig/temporalio/client/connection/operator_service.rbs
@@ -5,18 +5,54 @@ module Temporalio
     class Connection
       class OperatorService < Service
         def initialize: (Connection) -> void
-        def add_search_attributes: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def remove_search_attributes: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_search_attributes: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def add_or_update_remote_cluster: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def remove_remote_cluster: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_clusters: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_nexus_endpoint: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def create_nexus_endpoint: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_nexus_endpoint: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_nexus_endpoint: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_nexus_endpoints: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
+        def add_search_attributes: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def remove_search_attributes: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_search_attributes: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def add_or_update_remote_cluster: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def remove_remote_cluster: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_clusters: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_nexus_endpoint: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def create_nexus_endpoint: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_nexus_endpoint: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_nexus_endpoint: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_nexus_endpoints: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
       end
     end
   end

--- a/temporalio/sig/temporalio/client/connection/service.rbs
+++ b/temporalio/sig/temporalio/client/connection/service.rbs
@@ -9,9 +9,7 @@ module Temporalio
           request_class: class REQ,
           response_class: class RESP,
           request: REQ,
-          rpc_retry: bool,
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> RESP
       end
     end

--- a/temporalio/sig/temporalio/client/connection/workflow_service.rbs
+++ b/temporalio/sig/temporalio/client/connection/workflow_service.rbs
@@ -5,69 +5,258 @@ module Temporalio
     class Connection
       class WorkflowService < Service
         def initialize: (Connection) -> void
-        def register_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def describe_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_namespaces: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def deprecate_namespace: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def start_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def execute_multi_operation: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_workflow_execution_history: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_workflow_execution_history_reverse: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def poll_workflow_task_queue: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_workflow_task_completed: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_workflow_task_failed: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def poll_activity_task_queue: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def record_activity_task_heartbeat: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def record_activity_task_heartbeat_by_id: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_activity_task_completed: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_activity_task_completed_by_id: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_activity_task_failed: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_activity_task_failed_by_id: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_activity_task_canceled: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_activity_task_canceled_by_id: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def request_cancel_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def signal_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def signal_with_start_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def reset_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def terminate_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_open_workflow_executions: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_closed_workflow_executions: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_workflow_executions: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_archived_workflow_executions: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def scan_workflow_executions: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def count_workflow_executions: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_search_attributes: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_query_task_completed: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def reset_sticky_task_queue: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def query_workflow: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def describe_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def describe_task_queue: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_cluster_info: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_system_info: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_task_queue_partitions: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def create_schedule: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def describe_schedule: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_schedule: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def patch_schedule: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_schedule_matching_times: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def delete_schedule: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_schedules: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_worker_build_id_compatibility: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_worker_build_id_compatibility: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_worker_versioning_rules: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_worker_versioning_rules: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def get_worker_task_reachability: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def update_workflow_execution: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def poll_workflow_execution_update: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def start_batch_operation: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def stop_batch_operation: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def describe_batch_operation: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def list_batch_operations: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def poll_nexus_task_queue: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_nexus_task_completed: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
-        def respond_nexus_task_failed: (untyped request, ?rpc_retry: bool, ?rpc_metadata: Hash[String, String]?, ?rpc_timeout: Float?) -> untyped
+        def register_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def describe_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_namespaces: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def deprecate_namespace: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def start_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def execute_multi_operation: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_workflow_execution_history: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_workflow_execution_history_reverse: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def poll_workflow_task_queue: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_workflow_task_completed: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_workflow_task_failed: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def poll_activity_task_queue: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def record_activity_task_heartbeat: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def record_activity_task_heartbeat_by_id: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_activity_task_completed: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_activity_task_completed_by_id: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_activity_task_failed: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_activity_task_failed_by_id: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_activity_task_canceled: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_activity_task_canceled_by_id: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def request_cancel_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def signal_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def signal_with_start_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def reset_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def terminate_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_open_workflow_executions: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_closed_workflow_executions: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_workflow_executions: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_archived_workflow_executions: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def scan_workflow_executions: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def count_workflow_executions: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_search_attributes: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_query_task_completed: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def reset_sticky_task_queue: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def query_workflow: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def describe_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def describe_task_queue: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_cluster_info: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_system_info: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_task_queue_partitions: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def create_schedule: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def describe_schedule: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_schedule: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def patch_schedule: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_schedule_matching_times: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def delete_schedule: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_schedules: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_worker_build_id_compatibility: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_worker_build_id_compatibility: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_worker_versioning_rules: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_worker_versioning_rules: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def get_worker_task_reachability: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def update_workflow_execution: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def poll_workflow_execution_update: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def start_batch_operation: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def stop_batch_operation: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def describe_batch_operation: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def list_batch_operations: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def poll_nexus_task_queue: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_nexus_task_completed: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
+        def respond_nexus_task_failed: (
+          untyped request,
+          ?rpc_options: RPCOptions?
+        ) -> untyped
       end
     end
   end

--- a/temporalio/sig/temporalio/client/interceptor.rbs
+++ b/temporalio/sig/temporalio/client/interceptor.rbs
@@ -20,8 +20,7 @@ module Temporalio
         attr_accessor start_delay: Float?
         attr_accessor request_eager_start: bool
         attr_accessor headers: Hash[String, String]
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow: String,
@@ -40,46 +39,39 @@ module Temporalio
           start_delay: Float?,
           request_eager_start: bool,
           headers: Hash[String, String],
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
       class ListWorkflowsInput
         attr_accessor query: String?
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           query: String?,
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
       class CountWorkflowsInput
         attr_accessor query: String?
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           query: String?,
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
       class DescribeWorkflowInput
         attr_accessor workflow_id: String
         attr_accessor run_id: String?
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow_id: String,
           run_id: String?,
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
@@ -89,8 +81,7 @@ module Temporalio
         attr_accessor wait_new_event: bool
         attr_accessor event_filter_type: Integer
         attr_accessor skip_archival: bool
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow_id: String,
@@ -98,8 +89,7 @@ module Temporalio
           wait_new_event: bool,
           event_filter_type: Integer,
           skip_archival: bool,
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
@@ -109,8 +99,7 @@ module Temporalio
         attr_accessor signal: String
         attr_accessor args: Array[Object?]
         attr_accessor headers: Hash[String, String]
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow_id: String,
@@ -118,8 +107,7 @@ module Temporalio
           signal: String,
           args: Array[Object?],
           headers: Hash[String, String],
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
@@ -130,8 +118,7 @@ module Temporalio
         attr_accessor args: Array[Object?]
         attr_accessor reject_condition: WorkflowQueryRejectCondition::enum?
         attr_accessor headers: Hash[String, String]
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow_id: String,
@@ -140,8 +127,7 @@ module Temporalio
           args: Array[Object?],
           reject_condition: WorkflowQueryRejectCondition::enum?,
           headers: Hash[String, String],
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
@@ -153,8 +139,7 @@ module Temporalio
         attr_accessor args: Array[Object?]
         attr_accessor wait_for_stage: WorkflowUpdateWaitStage::enum
         attr_accessor headers: Hash[String, String]
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow_id: String,
@@ -164,8 +149,7 @@ module Temporalio
           args: Array[Object?],
           wait_for_stage: WorkflowUpdateWaitStage::enum,
           headers: Hash[String, String],
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
@@ -173,15 +157,13 @@ module Temporalio
         attr_accessor workflow_id: String
         attr_accessor run_id: String?
         attr_accessor update_id: String
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow_id: String,
           run_id: String?,
           update_id: String,
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
@@ -189,15 +171,13 @@ module Temporalio
         attr_accessor workflow_id: String
         attr_accessor run_id: String?
         attr_accessor first_execution_run_id: String?
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow_id: String,
           run_id: String?,
           first_execution_run_id: String?,
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
@@ -207,8 +187,7 @@ module Temporalio
         attr_accessor first_execution_run_id: String?
         attr_accessor reason: String?
         attr_accessor details: Array[Object?]
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           workflow_id: String,
@@ -216,36 +195,31 @@ module Temporalio
           first_execution_run_id: String?,
           reason: String?,
           details: Array[Object?],
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
       class HeartbeatAsyncActivityInput
         attr_accessor task_token_or_id_reference: String | ActivityIDReference
         attr_accessor details: Array[Object?]
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           task_token_or_id_reference: String | ActivityIDReference,
           details: Array[Object?],
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
       class CompleteAsyncActivityInput
         attr_accessor task_token_or_id_reference: String | ActivityIDReference
         attr_accessor result: Object?
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           task_token_or_id_reference: String | ActivityIDReference,
           result: Object?,
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
@@ -253,29 +227,25 @@ module Temporalio
         attr_accessor task_token_or_id_reference: String | ActivityIDReference
         attr_accessor error: Exception
         attr_accessor last_heartbeat_details: Array[Object?]
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           task_token_or_id_reference: String | ActivityIDReference,
           error: Exception,
           last_heartbeat_details: Array[Object?],
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 
       class ReportCancellationAsyncActivityInput
         attr_accessor task_token_or_id_reference: String | ActivityIDReference
         attr_accessor details: Array[Object?]
-        attr_accessor rpc_metadata: Hash[String, String]?
-        attr_accessor rpc_timeout: Float?
+        attr_accessor rpc_options: RPCOptions?
 
         def initialize: (
           task_token_or_id_reference: String | ActivityIDReference,
           details: Array[Object?],
-          rpc_metadata: Hash[String, String]?,
-          rpc_timeout: Float?
+          rpc_options: RPCOptions?
         ) -> void
       end
 

--- a/temporalio/sig/temporalio/client/workflow_handle.rbs
+++ b/temporalio/sig/temporalio/client/workflow_handle.rbs
@@ -16,19 +16,16 @@ module Temporalio
 
       def result: (
         ?follow_runs: bool,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> Object?
 
       def describe: (
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> WorkflowExecution::Description
 
       def fetch_history: (
         ?event_filter_type: Integer,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> WorkflowHistory
 
       def fetch_history_events: (
@@ -36,23 +33,20 @@ module Temporalio
         ?event_filter_type: Integer,
         ?skip_archival: bool,
         ?specific_run_id: String?,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> Enumerator[untyped, untyped]
 
       def signal: (
         String signal,
         *Object? args,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> void
 
       def query: (
         String query,
         *Object? args,
         ?reject_condition: WorkflowQueryRejectCondition::enum?,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> Object?
 
       def start_update: (
@@ -60,16 +54,14 @@ module Temporalio
         *Object? args,
         wait_for_stage: WorkflowUpdateWaitStage::enum,
         ?id: String,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> WorkflowUpdateHandle
 
       def execute_update: (
         String update,
         *Object? args,
         ?id: String,
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> Object?
 
       def update_handle: (
@@ -78,15 +70,13 @@ module Temporalio
       ) -> WorkflowUpdateHandle
 
       def cancel: (
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> void
 
       def terminate: (
         ?String? reason,
         ?details: Array[Object?],
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> void
     end
   end

--- a/temporalio/sig/temporalio/client/workflow_update_handle.rbs
+++ b/temporalio/sig/temporalio/client/workflow_update_handle.rbs
@@ -16,8 +16,7 @@ module Temporalio
       def result_obtained?: -> bool
 
       def result: (
-        ?rpc_metadata: Hash[String, String]?,
-        ?rpc_timeout: Float?
+        ?rpc_options: RPCOptions?
       ) -> Object?
     end
   end

--- a/temporalio/sig/temporalio/internal/bridge/client.rbs
+++ b/temporalio/sig/temporalio/internal/bridge/client.rbs
@@ -101,6 +101,7 @@ module Temporalio
           rpc_retry: bool,
           rpc_metadata: Hash[String, String]?,
           rpc_timeout: Float?,
+          rpc_cancellation_token: CancellationToken?,
           queue: Queue
         ) -> void
 
@@ -108,6 +109,11 @@ module Temporalio
           def code: -> Temporalio::Error::RPCError::Code::enum
           def message: -> String
           def details: -> String
+        end
+
+        class CancellationToken
+          def self.new: -> CancellationToken
+          def cancel: -> void
         end
       end
     end


### PR DESCRIPTION
## What was changed

* Added ability to provide `Cancellation` to all RPC calls to cancel them
* Move `rpc_metadata` and `rpc_timeout` (and low-level `rpc_retry`) into `Client::RPCOptions` along with this new `cancellation` field
  * 3, sometimes 4 kwargs for advanced RPC options that are rarely set became too much

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist

1. Closes #168