### PR TITLE
Metric meter support

### DIFF
--- a/temporalio/.rubocop.yml
+++ b/temporalio/.rubocop.yml
@@ -21,10 +21,19 @@ AllCops:
 Layout/ClassStructure:
   Enabled: true
 
+# RBS annotations allowed
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+
 # Don't need super for activities
 Lint/MissingSuper:
   AllowedParentClasses:
     - Temporalio::Activity
+
+# Allow tests to nest methods
+Lint/NestedMethodDefinition:
+  Exclude:
+    - test/**/*
 
 # The default is too small and triggers simply setting lots of values on a proto
 Metrics/AbcSize:

--- a/temporalio/ext/src/lib.rs
+++ b/temporalio/ext/src/lib.rs
@@ -2,6 +2,7 @@ use magnus::{prelude::*, value::Lazy, Error, ExceptionClass, RModule, Ruby};
 
 mod client;
 mod client_rpc_generated;
+mod metric;
 mod runtime;
 mod testing;
 mod util;
@@ -49,6 +50,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     Lazy::force(&ROOT_ERR, ruby);
 
     client::init(ruby)?;
+    metric::init(ruby)?;
     runtime::init(ruby)?;
     testing::init(ruby)?;
     worker::init(ruby)?;

--- a/temporalio/ext/src/metric.rs
+++ b/temporalio/ext/src/metric.rs
@@ -1,0 +1,257 @@
+use std::{sync::Arc, time::Duration};
+
+use magnus::{
+    class, function, method, prelude::*, r_hash::ForEach, value::{IntoId, Qfalse, Qtrue}, DataTypeFunctions, Error, Float, Integer, RHash, RString, Ruby, Symbol, TryConvert, TypedData, Value
+};
+use temporal_sdk_core_api::telemetry::metrics;
+
+use crate::{error, id, runtime::Runtime, ROOT_MOD};
+
+pub fn init(ruby: &Ruby) -> Result<(), Error> {
+    let root_mod = ruby.get_inner(&ROOT_MOD);
+
+    let class = root_mod.define_class("Metric", class::object())?;
+    class.define_singleton_method("new", function!(Metric::new, 6))?;
+    class.define_method("record_value", method!(Metric::record_value, 2))?;
+
+    let inner_class = class.define_class("Meter", class::object())?;
+    inner_class.define_singleton_method("new", function!(MetricMeter::new, 1))?;
+    inner_class.define_method(
+        "default_attributes",
+        method!(MetricMeter::default_attributes, 0),
+    )?;
+
+    let inner_class = class.define_class("Attributes", class::object())?;
+    inner_class.define_method(
+        "with_additional",
+        method!(MetricAttributes::with_additional, 1),
+    )?;
+
+    Ok(())
+}
+
+#[derive(DataTypeFunctions, TypedData)]
+#[magnus(class = "Temporalio::Internal::Bridge::Metric", free_immediately)]
+pub struct Metric {
+    instrument: Arc<dyn Instrument>,
+}
+
+impl Metric {
+    pub fn new(
+        meter: &MetricMeter,
+        metric_type: Symbol,
+        name: String,
+        description: Option<String>,
+        unit: Option<String>,
+        value_type: Symbol,
+    ) -> Result<Metric, Error> {
+        let ruby = Ruby::get().expect("Ruby not available");
+        let counter = id!("counter");
+        let histogram = id!("histogram");
+        let gauge = id!("gauge");
+        let integer = id!("integer");
+        let float = id!("float");
+        let duration = id!("duration");
+
+        let params = build_metric_parameters(name, description, unit);
+        let metric_type = metric_type.into_id_with(&ruby);
+        let value_type = value_type.into_id_with(&ruby);
+        let instrument: Arc<dyn Instrument> = if metric_type == counter {
+            if value_type != integer {
+                return Err(error!("Unrecognized value type for counter, must be :integer"));
+            }
+            Arc::new(meter.core.inner.counter(params))
+        } else if metric_type == histogram {
+            if value_type == integer {
+                Arc::new(meter.core.inner.histogram(params))
+            } else if value_type == float {
+                Arc::new(meter.core.inner.histogram_f64(params))
+            } else if value_type == duration {
+                Arc::new(meter.core.inner.histogram_duration(params))
+            } else {
+                return Err(error!("Unrecognized value type for histogram, must be :integer, :float, or :duration"));
+            }
+        } else if metric_type == gauge {
+            if value_type == integer {
+                Arc::new(meter.core.inner.gauge(params))
+            } else if value_type == float {
+                Arc::new(meter.core.inner.gauge_f64(params))
+            } else {
+                return Err(error!("Unrecognized value type for gauge, must be :integer or :float"));
+            }
+        } else {
+            return Err(error!("Unrecognized instrument type, must be :counter, :histogram, or :gauge"));
+        };
+        Ok(Metric { instrument })
+    }
+
+    pub fn record_value(&self, value: Value, attrs: &MetricAttributes) -> Result<(), Error> {
+        self.instrument.record_value(value, &attrs.core)
+    }
+}
+
+#[derive(DataTypeFunctions, TypedData)]
+#[magnus(
+    class = "Temporalio::Internal::Bridge::Metric::Meter",
+    free_immediately
+)]
+pub struct MetricMeter {
+    core: metrics::TemporalMeter,
+    default_attributes: metrics::MetricAttributes,
+}
+
+impl MetricMeter {
+    pub fn new(runtime: &Runtime) -> Result<Option<MetricMeter>, Error> {
+        Ok(runtime
+            .handle
+            .core
+            .telemetry()
+            .get_metric_meter()
+            .map(|core| {
+                let default_attributes = core.inner.new_attributes(core.default_attribs.clone());
+                MetricMeter {
+                    core,
+                    default_attributes,
+                }
+            }))
+    }
+
+    pub fn default_attributes(&self) -> Result<MetricAttributes, Error> {
+        Ok(MetricAttributes {
+            core: self.default_attributes.clone(),
+            core_meter: self.core.clone(),
+        })
+    }
+}
+
+#[derive(DataTypeFunctions, TypedData)]
+#[magnus(
+    class = "Temporalio::Internal::Bridge::Metric::Attributes",
+    free_immediately
+)]
+pub struct MetricAttributes {
+    core: metrics::MetricAttributes,
+    core_meter: metrics::TemporalMeter,
+}
+
+impl MetricAttributes {
+    pub fn with_additional(&self, attrs: RHash) -> Result<MetricAttributes, Error> {
+        let attributes = metric_key_values(attrs)?;
+        let core = self
+            .core_meter
+            .inner
+            .extend_attributes(self.core.clone(), metrics::NewAttributes { attributes });
+        Ok(MetricAttributes {
+            core,
+            core_meter: self.core_meter.clone(),
+        })
+    }
+}
+
+trait Instrument: Send + Sync {
+    fn record_value(&self, value: Value, attrs: &metrics::MetricAttributes) -> Result<(), Error>;
+}
+
+impl Instrument for Arc<dyn metrics::Counter> {
+    fn record_value(&self, value: Value, attrs: &metrics::MetricAttributes) -> Result<(), Error> {
+        self.add(TryConvert::try_convert(value)?, attrs);
+        Ok(())
+    }
+}
+
+impl Instrument for Arc<dyn metrics::Histogram> {
+    fn record_value(&self, value: Value, attrs: &metrics::MetricAttributes) -> Result<(), Error> {
+        self.record(TryConvert::try_convert(value)?, attrs);
+        Ok(())
+    }
+}
+
+impl Instrument for Arc<dyn metrics::HistogramF64> {
+    fn record_value(&self, value: Value, attrs: &metrics::MetricAttributes) -> Result<(), Error> {
+        self.record(TryConvert::try_convert(value)?, attrs);
+        Ok(())
+    }
+}
+
+impl Instrument for Arc<dyn metrics::HistogramDuration> {
+    fn record_value(&self, value: Value, attrs: &metrics::MetricAttributes) -> Result<(), Error> {
+        let secs = f64::try_convert(value)?;
+        if secs < 0.0 {
+            return Err(error!("Duration cannot be negative"))
+        }
+        self.record(Duration::from_secs_f64(secs), attrs);
+        Ok(())
+    }
+}
+
+impl Instrument for Arc<dyn metrics::Gauge> {
+    fn record_value(&self, value: Value, attrs: &metrics::MetricAttributes) -> Result<(), Error> {
+        self.record(TryConvert::try_convert(value)?, attrs);
+        Ok(())
+    }
+}
+
+impl Instrument for Arc<dyn metrics::GaugeF64> {
+    fn record_value(&self, value: Value, attrs: &metrics::MetricAttributes) -> Result<(), Error> {
+        self.record(TryConvert::try_convert(value)?, attrs);
+        Ok(())
+    }
+}
+
+fn build_metric_parameters(
+    name: String,
+    description: Option<String>,
+    unit: Option<String>,
+) -> metrics::MetricParameters {
+    let mut build = metrics::MetricParametersBuilder::default();
+    build.name(name);
+    if let Some(description) = description {
+        build.description(description);
+    }
+    if let Some(unit) = unit {
+        build.unit(unit);
+    }
+    // Should be nothing that would fail validation here
+    build.build().unwrap()
+}
+
+fn metric_key_values(hash: RHash) -> Result<Vec<metrics::MetricKeyValue>, Error> {
+    let mut vals = Vec::with_capacity(hash.len());
+    hash.foreach(|k: Value, v: Value| {
+        vals.push(metric_key_value(k, v));
+        Ok(ForEach::Continue)
+    })?;
+    vals.into_iter()
+        .collect::<Result<Vec<metrics::MetricKeyValue>, Error>>()
+}
+
+fn metric_key_value(k: Value, v: Value) -> Result<metrics::MetricKeyValue, Error> {
+    // Attribute key can be string or symbol
+    let key = if let Some(k) = RString::from_value(k) {
+        k.to_string()?
+    } else if let Some(k) = Symbol::from_value(k) {
+        k.name()?.to_string()
+    } else {
+        return Err(error!(
+            "Invalid value type for attribute key, must be String or Symbol"
+        ));
+    };
+
+    // Value can be string, bool, int, or float
+    let val = if let Some(v) = RString::from_value(v) {
+        metrics::MetricValue::String(v.to_string()?)
+    } else if let Some(_) = Qtrue::from_value(v) {
+        metrics::MetricValue::Bool(true)
+    } else if let Some(_) = Qfalse::from_value(v) {
+        metrics::MetricValue::Bool(false)
+    } else if let Some(v) = Integer::from_value(v) {
+        metrics::MetricValue::Int(v.to_i64()?)
+    } else if let Some(v) = Float::from_value(v) {
+        metrics::MetricValue::Float(v.to_f64())
+    } else {
+        return Err(error!(
+            "Invalid value type for attribute value, must be String, Integer, Float, or boolean"
+        ));
+    };
+    Ok(metrics::MetricKeyValue::new(key, val))
+}

--- a/temporalio/lib/temporalio/activity/context.rb
+++ b/temporalio/lib/temporalio/activity/context.rb
@@ -101,7 +101,10 @@ module Temporalio
         }.freeze
       end
 
-      # TODO(cretz): metric meter
+      # @return [Metric::Meter] Metric meter to create metrics on, with some activity-specific attributes already set.
+      def metric_meter
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/temporalio/lib/temporalio/internal/metric.rb
+++ b/temporalio/lib/temporalio/internal/metric.rb
@@ -81,9 +81,9 @@ module Temporalio
         def create_metric(
           metric_type,
           name,
-          description:,
-          unit:,
-          value_type:
+          description: nil,
+          unit: nil,
+          value_type: :integer
         )
           NullMetric.new(
             metric_type:,

--- a/temporalio/lib/temporalio/internal/metric.rb
+++ b/temporalio/lib/temporalio/internal/metric.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'temporalio/internal/bridge'
+require 'temporalio/metric'
+
+module Temporalio
+  module Internal
+    class Metric < Temporalio::Metric
+      attr_reader :metric_type, :name, :description, :unit, :value_type
+
+      def initialize(metric_type:, name:, description:, unit:, value_type:, bridge:, bridge_attrs:) # rubocop:disable Lint/MissingSuper
+        @metric_type = metric_type
+        @name = name
+        @description = description
+        @unit = unit
+        @value_type = value_type
+        @bridge = bridge
+        @bridge_attrs = bridge_attrs
+      end
+
+      def record(value, additional_attributes: nil)
+        bridge_attrs = @bridge_attrs
+        bridge_attrs = @bridge_attrs.with_additional(additional_attributes) if additional_attributes
+        @bridge.record_value(value, bridge_attrs)
+      end
+
+      def with_additional_attributes(additional_attributes)
+        Metric.new(
+          metric_type:,
+          name:,
+          description:,
+          unit:,
+          value_type:,
+          bridge: @bridge,
+          bridge_attrs: @bridge_attrs.with_additional(additional_attributes)
+        )
+      end
+
+      class Meter < Temporalio::Metric::Meter
+        def self.create_from_runtime(runtime)
+          bridge = Bridge::Metric::Meter.new(runtime._core_runtime)
+          return nil unless bridge
+
+          Meter.new(bridge, bridge.default_attributes)
+        end
+
+        def initialize(bridge, bridge_attrs) # rubocop:disable Lint/MissingSuper
+          @bridge = bridge
+          @bridge_attrs = bridge_attrs
+        end
+
+        def create_metric(
+          metric_type,
+          name,
+          description: nil,
+          unit: nil,
+          value_type: :integer
+        )
+          Metric.new(
+            metric_type:,
+            name:,
+            description:,
+            unit:,
+            value_type:,
+            bridge: Bridge::Metric.new(@bridge, metric_type, name, description, unit, value_type),
+            bridge_attrs: @bridge_attrs
+          )
+        end
+
+        def with_additional_attributes(additional_attributes)
+          Meter.new(@bridge, @bridge_attrs.with_additional(additional_attributes))
+        end
+      end
+
+      class NullMeter < Temporalio::Metric::Meter
+        include Singleton
+
+        def initialize # rubocop:disable Style/RedundantInitialize,Lint/MissingSuper
+        end
+
+        def create_metric(
+          metric_type,
+          name,
+          description:,
+          unit:,
+          value_type:
+        )
+          NullMetric.new(
+            metric_type:,
+            name:,
+            description:,
+            unit:,
+            value_type:
+          )
+        end
+
+        def with_additional_attributes(_additional_attributes)
+          self
+        end
+      end
+
+      class NullMetric < Temporalio::Metric
+        attr_reader :metric_type, :name, :description, :unit, :value_type
+
+        def initialize(metric_type:, name:, description:, unit:, value_type:) # rubocop:disable Lint/MissingSuper
+          @metric_type = metric_type
+          @name = name
+          @description = description
+          @unit = unit
+          @value_type = value_type
+        end
+
+        def record(value, additional_attributes: nil); end
+
+        def with_additional_attributes(_additional_attributes)
+          self
+        end
+      end
+    end
+  end
+end

--- a/temporalio/lib/temporalio/metric.rb
+++ b/temporalio/lib/temporalio/metric.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'temporalio/internal/metric'
+
+module Temporalio
+  # Metric that can be recorded from a metric meter. This is obtained via {Meter.create_metric}. The metric meter is
+  # obtained via workflow environment, activity context, or from the {Runtime} if in neither of those. This class is
+  # effectively abstract and will fail if `initialize` is attempted.
+  class Metric
+    # @!visibility private
+    def initialize
+      raise NotImplementedError, 'Metric is abstract, implementations override initialize'
+    end
+
+    # Record a value for the metric. For counters, this adds to any existing. For histograms, this records into proper
+    # buckets. For gauges, this sets the value. The value type must match the expectation.
+    #
+    # @param value [Numeric] Value to record. For counters and duration-based histograms, this value cannot be negative.
+    # @param additional_attributes [Hash{String, Symbol => String, Integer, Float, Boolean}, nil] Additional attributes
+    #   on this specific record. For better performance for attribute reuse, users are encouraged to use
+    #   {with_additional_attributes} to make a copy of this metric with those attributes.
+    def record(value, additional_attributes: nil)
+      raise NotImplementedError
+    end
+
+    # Create a copy of this metric but with the given additional attributes. This is more performant than providing
+    # attributes on each {record} call.
+    #
+    # @param additional_attributes [Hash{String, Symbol => String, Integer, Float, Boolean}] Attributes to set on the
+    #   resulting metric.
+    # @return [Metric] Copy of this metric with the additional attributes.
+    def with_additional_attributes(additional_attributes)
+      raise NotImplementedError
+    end
+
+    # @return [:counter, :histogram, :gauge] Metric type.
+    def metric_type
+      raise NotImplementedError
+    end
+
+    # @return [String] Metric name.
+    def name
+      raise NotImplementedError
+    end
+
+    # @return [String, nil] Metric description.
+    def description
+      raise NotImplementedError
+    end
+
+    # @return [String, nil] Metric unit.
+    def unit
+      raise NotImplementedError
+    end
+
+    # @return [:integer, :float, :duration] Metric value type.
+    def value_type
+      raise NotImplementedError
+    end
+
+    # Meter for creating metrics to record values on. This is obtained via workflow environment, activity context, or
+    # from the {Runtime} if in neither of those. This class is effectively abstract and will fail if `initialize` is
+    # attempted.
+    class Meter
+      # @return [Meter] A no-op instance of {Meter}.
+      def self.null
+        Internal::Metric::NullMeter.instance
+      end
+
+      # @!visibility private
+      def initialize
+        raise NotImplementedError, 'Meter is abstract, implementations override initialize'
+      end
+
+      # Create a new metric. Only certain metric types are accepted and only value types can work with certain metric
+      # types.
+      #
+      # @param metric_type [:counter, :histogram, :gauge] Metric type. Counters can only have `:integer` value types,
+      #   histograms can have `:integer`, `:float`, or :duration` value types, and gauges can have `:integer` or
+      #   `:float` value types.
+      # @param name [String] Metric name.
+      # @param description [String, nil] Metric description.
+      # @param unit [String, nil] Metric unit.
+      # @param value_type [:integer, :float, :duration] Metric value type. `:integer` works for all metric types,
+      #   `:float` works for `:histogram` and `:gauge` metric types, and `:duration` only works for `:histogram` metric
+      #   types.
+      # @return [Metric] Created metric.
+      def create_metric(
+        metric_type,
+        name,
+        description: nil,
+        unit: nil,
+        value_type: :integer
+      )
+        raise NotImplementedError
+      end
+
+      # Create a copy of this meter but with the given additional attributes. This is more performant than providing
+      # attributes on each {record} call.
+      #
+      # @param additional_attributes [Hash{String, Symbol => String, Integer, Float, Boolean}] Attributes to set on the
+      #   resulting meter.
+      # @return [Meter] Copy of this meter with the additional attributes.
+      def with_additional_attributes(additional_attributes)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/temporalio/sig/temporalio/activity/context.rbs
+++ b/temporalio/sig/temporalio/activity/context.rbs
@@ -16,6 +16,8 @@ module Temporalio
       def logger: -> ScopedLogger
 
       def _scoped_logger_info: -> Hash[Symbol, Object]
+
+      def metric_meter: -> Metric::Meter
     end
   end
 end

--- a/temporalio/sig/temporalio/internal/bridge/metric.rbs
+++ b/temporalio/sig/temporalio/internal/bridge/metric.rbs
@@ -1,0 +1,28 @@
+module Temporalio
+  module Internal
+    module Bridge
+      class Metric
+        def initialize: (
+          Meter meter,
+          Symbol metric_type,
+          String name,
+          String? description,
+          String? unit,
+          Symbol value_type
+        ) -> void
+
+        def record_value: (untyped value, Attributes attrs) -> void
+
+        class Meter
+          def initialize: (Runtime runtime) -> void
+
+          def default_attributes: -> Attributes
+        end
+
+        class Attributes
+          def with_additional: (Hash[untyped, untyped] attrs) -> Attributes
+        end
+      end
+    end
+  end
+end

--- a/temporalio/sig/temporalio/internal/metric.rbs
+++ b/temporalio/sig/temporalio/internal/metric.rbs
@@ -1,7 +1,27 @@
 module Temporalio
   module Internal
     class Metric < Temporalio::Metric
+      def initialize: (
+        metric_type: (:counter | :histogram | :gauge),
+        name: String,
+        description: String?,
+        unit: String?,
+        value_type: (:integer | :float | :duration),
+        bridge: Bridge::Metric,
+        bridge_attrs: Bridge::Metric::Attributes
+      ) -> void
+
       class Meter < Temporalio::Metric::Meter
+        def self.create_from_runtime: (Runtime runtime) -> Meter?
+
+        def initialize: (Bridge::Metric::Meter bridge, Bridge::Metric::Attributes bridge_attrs) -> void
+      end
+
+      class NullMeter < Temporalio::Metric::Meter
+        def self.instance: -> NullMeter
+      end
+
+      class NullMetric < Temporalio::Metric
         def initialize: (
           metric_type: (:counter | :histogram | :gauge),
           name: String,

--- a/temporalio/sig/temporalio/internal/metric.rbs
+++ b/temporalio/sig/temporalio/internal/metric.rbs
@@ -1,0 +1,15 @@
+module Temporalio
+  module Internal
+    class Metric < Temporalio::Metric
+      class Meter < Temporalio::Metric::Meter
+        def initialize: (
+          metric_type: (:counter | :histogram | :gauge),
+          name: String,
+          description: String?,
+          unit: String?,
+          value_type: (:integer | :float | :duration)
+        ) -> void
+      end
+    end
+  end
+end

--- a/temporalio/sig/temporalio/internal/worker/activity_worker.rbs
+++ b/temporalio/sig/temporalio/internal/worker/activity_worker.rbs
@@ -34,7 +34,8 @@ module Temporalio
             cancellation: Cancellation,
             worker_shutdown_cancellation: Cancellation,
             payload_converter: Converters::PayloadConverter,
-            logger: ScopedLogger
+            logger: ScopedLogger,
+            runtime_metric_meter: Metric::Meter
           ) -> void
         end
 

--- a/temporalio/sig/temporalio/metric.rbs
+++ b/temporalio/sig/temporalio/metric.rbs
@@ -1,0 +1,55 @@
+module Temporalio
+  class Metric
+    def record: (
+      Numeric value,
+      ?additional_attributes: Hash[String | Symbol, String | Integer | Float | bool]?
+    ) -> void
+
+    def with_additional_attributes: (
+      Hash[String | Symbol, String | Integer | Float | bool] additional_attributes
+    ) -> Metric
+
+    def metric_type: -> (:counter | :histogram | :gauge)
+
+    def name: -> String
+
+    def description: -> String?
+
+    def unit: -> String?
+
+    def value_type: -> (:integer | :float | :duration)
+
+    class Meter
+      def self.null: -> Meter
+
+      def create_metric:
+        (
+          :counter metric_type,
+          String name,
+          ?description: String?,
+          ?unit: String?,
+          ?description: :integer
+        ) -> Metric
+        |
+        (
+          :histogram metric_type,
+          String name,
+          ?description: String?,
+          ?unit: String?,
+          ?description: (:integer | :float | :duration)
+        ) -> Metric
+        |
+        (
+          :gauge metric_type,
+          String name,
+          ?description: String?,
+          ?unit: String?,
+          ?description: (:integer | :float)
+        ) -> Metric
+
+        def with_additional_attributes: (
+          Hash[String | Symbol, String | Integer | Float | bool] additional_attributes
+        ) -> Meter
+    end
+  end
+end

--- a/temporalio/sig/temporalio/metric.rbs
+++ b/temporalio/sig/temporalio/metric.rbs
@@ -28,7 +28,7 @@ module Temporalio
           String name,
           ?description: String?,
           ?unit: String?,
-          ?description: :integer
+          ?value_type: :integer
         ) -> Metric
         |
         (
@@ -36,7 +36,7 @@ module Temporalio
           String name,
           ?description: String?,
           ?unit: String?,
-          ?description: (:integer | :float | :duration)
+          ?value_type: (:integer | :float | :duration)
         ) -> Metric
         |
         (
@@ -44,7 +44,7 @@ module Temporalio
           String name,
           ?description: String?,
           ?unit: String?,
-          ?description: (:integer | :float)
+          ?value_type: (:integer | :float)
         ) -> Metric
 
         def with_additional_attributes: (

--- a/temporalio/sig/temporalio/runtime.rbs
+++ b/temporalio/sig/temporalio/runtime.rbs
@@ -98,6 +98,8 @@ module Temporalio
     def self.default: -> Runtime
     def self.default=: (Runtime runtime) -> void
 
+    attr_reader metric_meter: Metric::Meter
+
     def initialize: (?telemetry: TelemetryOptions) -> void
 
     def _core_runtime: -> Internal::Bridge::Runtime

--- a/temporalio/test/runtime_test.rb
+++ b/temporalio/test/runtime_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'temporalio/client'
+require 'temporalio/runtime'
+require 'test'
+require 'uri'
+
+class RuntimeTest < Test
+  def test_metric_basics
+    # In this test, we'll use Prometheus and confirm existing metrics and custom
+    # ones
+    prom_addr = "127.0.0.1:#{find_free_port}"
+    runtime = Temporalio::Runtime.new(
+      telemetry: Temporalio::Runtime::TelemetryOptions.new(
+        metrics: Temporalio::Runtime::MetricsOptions.new(
+          prometheus: Temporalio::Runtime::PrometheusMetricsOptions.new(
+            bind_address: prom_addr
+          )
+        )
+      )
+    )
+
+    # Create a client on this runtime and start a non-existent workflow
+    conn_opts = env.client.connection.options.dup #: Hash
+    conn_opts[:runtime] = runtime
+    client_opts = env.client.options.dup
+    client_opts[:connection] = Temporalio::Client::Connection.new(**conn_opts.to_h)
+    client = Temporalio::Client.new(**client_opts.to_h)
+    client.start_workflow('bad-workflow', id: "bad-wf-#{SecureRandom.uuid}", task_queue: 'bad-task-queue')
+
+    # Check Prometheus metrics for a count of our request
+    dump = Net::HTTP.get(URI("http://#{prom_addr}/metrics"))
+
+    def assert_metric_line(dump, metric, **required_attrs)
+      lines = dump.split("\n").select do |l|
+        l.start_with?("#{metric}{") && required_attrs.all? { |k, v| l.include?("#{k}=\"#{v}\"") }
+      end
+      assert_equal 1, lines.size
+      lines.first.split.last
+    end
+
+    assert_equal '1', assert_metric_line(dump, 'temporal_request', operation: 'StartWorkflowExecution')
+
+    # Make a metric meter with an additional attribute or so
+    meter = runtime.metric_meter.with_additional_attributes(
+      { 'attr_str' => 'str-val', attr_bool: true, attr_int: 123, attr_float: 4.56 }
+    )
+
+    # Add some custom metrics
+    counter_int = meter.create_metric(
+      :counter, 'my-counter-int', description: 'my-counter-int-desc', unit: 'my-counter-int-unit'
+    )
+    histogram_int = meter.create_metric(:histogram, 'my-histogram-int')
+    histogram_float = meter.create_metric(:histogram, 'my-histogram-float', value_type: :float)
+    histogram_duration = meter.create_metric(:histogram, 'my-histogram-duration', value_type: :duration)
+    gauge_int = meter.create_metric(:gauge, 'my-gauge-int')
+    gauge_float = meter.create_metric(:gauge, 'my-gauge-float', value_type: :float)
+
+    # Record values on them
+    counter_int.record(12)
+    counter_int.record(34)
+    counter_int.record(56, additional_attributes: { attr_int: 234, 'another_attr' => 'another-val' })
+    histogram_int.record(75)
+    histogram_int.record(125)
+    histogram_float.record(525.6)
+    histogram_duration.record(0.6)
+    gauge_int.record(23)
+    gauge_float.record(24.5)
+
+    # Check
+    dump = Net::HTTP.get(URI("http://#{prom_addr}/metrics"))
+
+    assert(dump.split("\n").any? { |l| l == '# HELP my_counter_int my-counter-int-desc' })
+    assert_equal '46', assert_metric_line(dump, 'my_counter_int',
+                                          attr_str: 'str-val', attr_bool: true, attr_int: 123, attr_float: 4.56)
+    assert_equal '56', assert_metric_line(dump, 'my_counter_int',
+                                          attr_str: 'str-val', attr_bool: true,
+                                          attr_int: 234, attr_float: 4.56, another_attr: 'another-val')
+
+    assert_equal '0', assert_metric_line(dump, 'my_histogram_int_bucket', attr_str: 'str-val', le: 50)
+    assert_equal '1', assert_metric_line(dump, 'my_histogram_int_bucket', attr_str: 'str-val', le: 100)
+    assert_equal '2', assert_metric_line(dump, 'my_histogram_int_bucket', attr_str: 'str-val', le: 500)
+    assert_equal '525.6', assert_metric_line(dump, 'my_histogram_float_sum', attr_str: 'str-val')
+    assert_equal '600', assert_metric_line(dump, 'my_histogram_duration_sum', attr_str: 'str-val')
+
+    assert_equal '23', assert_metric_line(dump, 'my_gauge_int', attr_str: 'str-val')
+    assert_equal '24.5', assert_metric_line(dump, 'my_gauge_float', attr_str: 'str-val')
+
+    # Confirm proper failure of bad types to calls
+
+    def assert_bad_call(message_includes = nil, &)
+      err = assert_raises(&)
+      assert_includes err.message, message_includes if message_includes
+    end
+
+    assert_bad_call('Unrecognized instrument type') { meter.create_metric(:invalid_metric_type, 'bad-metric') }
+    assert_bad_call('Unrecognized value type') { meter.create_metric(:counter, 'bad-metric', value_type: :float) }
+    assert_bad_call('Unrecognized value type') { meter.create_metric(:counter, 'bad-metric', value_type: :duration) }
+    assert_bad_call('Unrecognized value type') { meter.create_metric(:histogram, 'bad-metric', value_type: :bad) }
+    assert_bad_call('Unrecognized value type') { meter.create_metric(:gauge, 'bad-metric', value_type: :duration) }
+
+    counter_int.record(45.6)
+    assert_bad_call { counter_int.record(-45) }
+    assert_bad_call { counter_int.record('bad') }
+    histogram_float.record(-45)
+    assert_bad_call { histogram_float.record('bad') }
+    assert_bad_call { histogram_duration.record(-45) }
+    assert_bad_call { histogram_duration.record('bad') }
+
+    counter_int.record(
+      1,
+      additional_attributes: { foo: 'str', 'bar' => 1, baz: true, qux: false, quux: true, corge: 5.67 }
+    )
+    assert_bad_call { counter_int.record(1, additional_attributes: { foo: :bad }) }
+    assert_bad_call { counter_int.record(1, additional_attributes: { foo: nil }) }
+    assert_bad_call { counter_int.record(1, additional_attributes: { 123 => 'foo' }) }
+  end
+end

--- a/temporalio/test/sig/runtime_test.rbs
+++ b/temporalio/test/sig/runtime_test.rbs
@@ -1,0 +1,9 @@
+class RuntimeTest < Test
+  def assert_metric_line: (
+    String dump,
+    String metric,
+    **untyped required_attrs
+  ) -> String?
+
+  def assert_bad_call: (?String? message_includes) { (?) -> untyped } -> void
+end

--- a/temporalio/test/sig/test.rbs
+++ b/temporalio/test/sig/test.rbs
@@ -15,6 +15,8 @@ class Test < Minitest::Test
 
   def run_in_background: { (?) -> untyped } -> (Thread | Fiber)
 
+  def find_free_port: -> String
+
   class TestEnvironment
     include Singleton
 

--- a/temporalio/test/test.rb
+++ b/temporalio/test/test.rb
@@ -6,6 +6,7 @@ require 'logger'
 require 'minitest/autorun'
 require 'securerandom'
 require 'singleton'
+require 'socket'
 require 'temporalio/internal/bridge'
 require 'temporalio/testing'
 require 'timeout'
@@ -93,6 +94,13 @@ class Test < Minitest::Test
 
       current = current.cause
     end
+  end
+
+  def find_free_port
+    socket = TCPServer.new('127.0.0.1', 0)
+    port = socket.addr[1]
+    socket.close
+    port
   end
 
   class TestEnvironment

--- a/temporalio/test/worker_activity_test.rb
+++ b/temporalio/test/worker_activity_test.rb
@@ -845,10 +845,10 @@ class WorkerActivityTest < Test
       )
     )
     conn_opts = env.client.connection.options.dup
-    conn_opts[:runtime] = runtime
+    conn_opts.runtime = runtime
     client_opts = env.client.options.dup
-    client_opts[:connection] = Temporalio::Client::Connection.new(**conn_opts.to_h)
-    client = Temporalio::Client.new(**client_opts.to_h)
+    client_opts.connection = Temporalio::Client::Connection.new(**conn_opts.to_h) # steep:ignore
+    client = Temporalio::Client.new(**client_opts.to_h) # steep:ignore
 
     assert_equal 'done', execute_activity(CustomMetricActivity, client:)
 

--- a/temporalio/test/worker_activity_test.rb
+++ b/temporalio/test/worker_activity_test.rb
@@ -822,6 +822,56 @@ class WorkerActivityTest < Test
     assert_equal ['heartbeat-val'], interceptor.calls[2][1].details
   end
 
+  class CustomMetricActivity < Temporalio::Activity
+    def execute
+      counter = Temporalio::Activity::Context.current.metric_meter.create_metric(
+        :counter, 'my-counter'
+      ).with_additional_attributes({ someattr: 'someval' })
+      counter.record(123, additional_attributes: { anotherattr: 'anotherval' })
+      'done'
+    end
+  end
+
+  def test_activity_metric
+    # Create a client w/ a Prometheus-enabled runtime
+    prom_addr = "127.0.0.1:#{find_free_port}"
+    runtime = Temporalio::Runtime.new(
+      telemetry: Temporalio::Runtime::TelemetryOptions.new(
+        metrics: Temporalio::Runtime::MetricsOptions.new(
+          prometheus: Temporalio::Runtime::PrometheusMetricsOptions.new(
+            bind_address: prom_addr
+          )
+        )
+      )
+    )
+    conn_opts = env.client.connection.options.dup
+    conn_opts[:runtime] = runtime
+    client_opts = env.client.options.dup
+    client_opts[:connection] = Temporalio::Client::Connection.new(**conn_opts.to_h)
+    client = Temporalio::Client.new(**client_opts.to_h)
+
+    assert_equal 'done', execute_activity(CustomMetricActivity, client:)
+
+    dump = Net::HTTP.get(URI("http://#{prom_addr}/metrics"))
+    lines = dump.split("\n")
+
+    # Confirm we have the regular activity metrics
+    line = lines.find { |l| l.start_with?('temporal_activity_task_received{') }
+    assert_includes line, 'activity_type="CustomMetricActivity"'
+    assert_includes line, 'task_queue="'
+    assert_includes line, 'namespace="default"'
+    assert line.end_with?(' 1')
+
+    # Confirm custom metric has the tags we expect
+    line = lines.find { |l| l.start_with?('my_counter{') }
+    assert_includes line, 'activity_type="CustomMetricActivity"'
+    assert_includes line, 'task_queue="'
+    assert_includes line, 'namespace="default"'
+    assert_includes line, 'someattr="someval"'
+    assert_includes line, 'anotherattr="anotherval"'
+    assert line.end_with?(' 123')
+  end
+
   # steep:ignore
   def execute_activity(
     activity,


### PR DESCRIPTION
## What was changed

* Added `Temporalio::Metric::Meter` and `Temporalio::Metric` and supporting structure
* Exposed `metric_meter` in `Temporalio::Runtime` and `Temporalio::Activity::Context` for use by users

## Checklist

1. Closes #169
