### PR TITLE
Cloud test and support for updating API keys and RPC metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,22 @@ jobs:
         working-directory: ./temporalio
         # Timeout just in case there's a hanging part in rake
         timeout-minutes: 20
+        # Set env vars for cloud tests. If secrets aren't present, tests will be skipped.
+        env:
+          # For mTLS tests
+          TEMPORAL_CLOUD_MTLS_TEST_TARGET_HOST: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}.tmprl.cloud:7233
+          TEMPORAL_CLOUD_MTLS_TEST_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
+          TEMPORAL_CLOUD_MTLS_TEST_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
+          TEMPORAL_CLOUD_MTLS_TEST_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
+
+          # For API key tests
+          TEMPORAL_CLOUD_API_KEY_TEST_TARGET_HOST: us-west-2.aws.api.temporal.io:7233
+          TEMPORAL_CLOUD_API_KEY_TEST_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
+          TEMPORAL_CLOUD_API_KEY_TEST_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+
+          # For cloud ops tests
+          TEMPORAL_CLOUD_OPS_TEST_TARGET_HOST: saas-api.tmprl.cloud:443
+          TEMPORAL_CLOUD_OPS_TEST_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
+          TEMPORAL_CLOUD_OPS_TEST_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+          TEMPORAL_CLOUD_OPS_TEST_API_VERSION: 2024-05-13-00
         run: bundle exec rake TESTOPTS="--verbose"

--- a/temporalio/sig/temporalio/client/connection.rbs
+++ b/temporalio/sig/temporalio/client/connection.rbs
@@ -111,6 +111,10 @@ module Temporalio
       def target_host: -> String
       def identity: -> String
       def connected?: -> bool
+      def api_key: -> String?
+      def api_key=: (String? new_key) -> void
+      def rpc_metadata: -> Hash[String, String]
+      def rpc_metadata=: (Hash[String, String] rpc_metadata) -> void
       def _core_client: -> Internal::Bridge::Client
       private def new_core_client: -> Internal::Bridge::Client
     end

--- a/temporalio/sig/temporalio/internal/bridge/client.rbs
+++ b/temporalio/sig/temporalio/internal/bridge/client.rbs
@@ -105,6 +105,9 @@ module Temporalio
           queue: Queue
         ) -> void
 
+        def update_metadata: (Hash[String, String]) -> void
+        def update_api_key: (String?) -> void
+
         class RPCFailure < Error
           def code: -> Temporalio::Error::RPCError::Code::enum
           def message: -> String

--- a/temporalio/test/client_cloud_test.rb
+++ b/temporalio/test/client_cloud_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'temporalio/api'
+require 'temporalio/client'
+require 'test'
+
+class ClientCloudTest < Test
+  class SimpleWorkflow < Temporalio::Workflow::Definition
+    def execute(name)
+      "Hello, #{name}!"
+    end
+  end
+
+  def test_mtls
+    client_private_key = ENV.fetch('TEMPORAL_CLOUD_MTLS_TEST_CLIENT_KEY', '')
+    skip('No cloud mTLS key') if client_private_key.empty?
+
+    client = Temporalio::Client.connect(
+      ENV.fetch('TEMPORAL_CLOUD_MTLS_TEST_TARGET_HOST'),
+      ENV.fetch('TEMPORAL_CLOUD_MTLS_TEST_NAMESPACE'),
+      tls: Temporalio::Client::Connection::TLSOptions.new(
+        client_cert: ENV.fetch('TEMPORAL_CLOUD_MTLS_TEST_CLIENT_CERT'),
+        client_private_key:
+      )
+    )
+    assert_equal 'Hello, Temporal!', execute_workflow(SimpleWorkflow, 'Temporal', client:)
+  end
+
+  def test_api_key
+    api_key = ENV.fetch('TEMPORAL_CLOUD_API_KEY_TEST_API_KEY', '')
+    skip('No cloud API key') if api_key.empty?
+
+    client = Temporalio::Client.connect(
+      ENV.fetch('TEMPORAL_CLOUD_API_KEY_TEST_TARGET_HOST'),
+      ENV.fetch('TEMPORAL_CLOUD_API_KEY_TEST_NAMESPACE'),
+      api_key:,
+      tls: true,
+      rpc_metadata: { 'temporal-namespace' => ENV.fetch('TEMPORAL_CLOUD_API_KEY_TEST_NAMESPACE') }
+    )
+    # Run workflow
+    id = "wf-#{SecureRandom.uuid}"
+    assert_equal 'Hello, Temporal!', execute_workflow(SimpleWorkflow, 'Temporal', id:, client:)
+    handle = client.workflow_handle(id)
+
+    # Confirm it can be described
+    assert_equal 'SimpleWorkflow', handle.describe.workflow_type
+
+    # Change API and confirm failure
+    client.connection.api_key = 'wrong'
+    assert_raises(Temporalio::Error::RPCError) { handle.describe.workflow_type }
+  end
+
+  def test_cloud_ops
+    api_key = ENV.fetch('TEMPORAL_CLOUD_OPS_TEST_API_KEY', '')
+    skip('No cloud API key') if api_key.empty?
+
+    # Create connection
+    conn = Temporalio::Client::Connection.new(
+      target_host: ENV.fetch('TEMPORAL_CLOUD_OPS_TEST_TARGET_HOST'),
+      api_key:,
+      tls: true,
+      rpc_metadata: { 'temporal-cloud-api-version' => ENV.fetch('TEMPORAL_CLOUD_OPS_TEST_API_VERSION') }
+    )
+
+    # Simple call
+    namespace = ENV.fetch('TEMPORAL_CLOUD_OPS_TEST_NAMESPACE')
+    res = conn.cloud_service.get_namespace(
+      Temporalio::Api::Cloud::CloudService::V1::GetNamespaceRequest.new(namespace:)
+    )
+    assert_equal namespace, res.namespace.namespace
+  end
+end


### PR DESCRIPTION
## What was changed

* Add `api_key` getter/setter on connection
* Add `rpc_metadata` getter/setter on connection
* Add cloud connectivity tests

## Checklist

1. Closes #164
