### PR TITLE
Dynamic activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,6 +906,11 @@ Some notes about activity definition:
   "Activity Concurrency and Executors" section later for more details.
 * Technically an activity definition can be created manually via `Temporalio::Activity::Definition::Info.new` that
   accepts a proc or a block, but the class form is recommended.
+* `activity_dynamic` can be used to mark an activity dynamic. Dynamic activities do not have names and handle any
+  activity that is not otherwise registered. A worker can only have one dynamic activity.
+* `workflow_raw_args` can be used to have activity arguments delivered to `execute` as
+  `Temporalio::Converters::RawValue`s. These are wrappers for the raw payloads that have not been converted to types
+  (but they have been decoded by the codec if present). They can be converted with `payload_converter` on the context.
 
 #### Activity Context
 

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/outbound_implementation.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/outbound_implementation.rb
@@ -64,6 +64,8 @@ module Temporalio
                             else
                               raise ArgumentError, 'Activity must be a definition class, or a symbol/string'
                             end
+            raise 'Cannot invoke dynamic activities' unless activity_type
+
             execute_activity_with_local_backoffs(local: false, cancellation: input.cancellation) do
               seq = (@activity_counter += 1)
               @instance.add_command(
@@ -102,6 +104,8 @@ module Temporalio
                             else
                               raise ArgumentError, 'Activity must be a definition class, or a symbol/string'
                             end
+            raise 'Cannot invoke dynamic activities' unless activity_type
+
             execute_activity_with_local_backoffs(local: true, cancellation: input.cancellation) do |do_backoff|
               seq = (@activity_counter += 1)
               @instance.add_command(

--- a/temporalio/lib/temporalio/workflow/definition.rb
+++ b/temporalio/lib/temporalio/workflow/definition.rb
@@ -38,8 +38,8 @@ module Temporalio
         end
 
         # Have workflow arguments delivered to `execute` (and `initialize` if {workflow_init} in use) as
-        # {Converters::RawValue}s. These are wrappers for the raw payloads that have not been decoded. They can be
-        # decoded with {Workflow.payload_converter}.
+        # {Converters::RawValue}s. These are wrappers for the raw payloads that have not been converted to types (but
+        # they have been decoded by the codec if present). They can be converted with {Workflow.payload_converter}.
         #
         # @param value [Boolean] Whether the workflow accepts raw arguments.
         def workflow_raw_args(value = true) # rubocop:disable Style/OptionalBooleanParameter

--- a/temporalio/sig/temporalio/activity/definition.rbs
+++ b/temporalio/sig/temporalio/activity/definition.rbs
@@ -4,27 +4,32 @@ module Temporalio
       def self.activity_name: (String | Symbol name) -> void
       def self.activity_executor: (Symbol executor_name) -> void
       def self.activity_cancel_raise: (bool cancel_raise) -> void
+      def self.activity_dynamic: (?bool value) -> void
+      def self.activity_raw_args: (?bool value) -> void
   
       def self._activity_definition_details: -> {
-        activity_name: String | Symbol,
+        activity_name: String | Symbol | nil,
         activity_executor: Symbol,
-        activity_cancel_raise: bool
+        activity_cancel_raise: bool,
+        activity_raw_args: bool
       }
   
       def execute: (*untyped) -> untyped
 
       class Info
-        attr_reader name: String | Symbol
+        attr_reader name: String | Symbol | nil
         attr_reader proc: Proc
         attr_reader executor: Symbol
         attr_reader cancel_raise: bool
+        attr_reader raw_args: bool
 
         def self.from_activity: (Definition | singleton(Definition) | Info activity) -> Info
 
         def initialize: (
-          name: String | Symbol,
+          name: String | Symbol | nil,
           ?executor: Symbol,
-          ?cancel_raise: bool
+          ?cancel_raise: bool,
+          ?raw_args: bool
         ) { (?) -> untyped } -> void
       end
     end


### PR DESCRIPTION
## What was changed

* Add `activity_dynamic` as an option for activity definitions (marks an activity as dynamic)
* Add `activity_raw_args` as an option for activity definitions (marks an activity as wanting to receive raw args)

Both of these match dynamic workflow, signal, query, and update support today.

## Checklist

1. Closes #166