### PR TITLE
Downgrade minimum protobuf version needed to 3.25

### DIFF
--- a/temporalio/temporalio.gemspec
+++ b/temporalio/temporalio.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.extensions = ['ext/Cargo.toml']
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency 'google-protobuf', '>= 3.27.0'
+  spec.add_dependency 'google-protobuf', '>= 3.25.0'
 end


### PR DESCRIPTION
## What was changed

Downgraded minimum protobuf version needed to 3.25. This is needed to interoperate with https://github.com/coinbase/temporal-ruby (along with https://github.com/coinbase/temporal-ruby/pull/335 from that side)