### PR TITLE
MUSL support

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # TODO(cretz): Enable x64-mingw-ucrt if we can figure out Windows issue, see
         # https://github.com/temporalio/sdk-ruby/issues/172
-        rubyPlatform: ["aarch64-linux", "x86_64-linux", "arm64-darwin", "x86_64-darwin"]
+        rubyPlatform: ["aarch64-linux", "aarch64-linux-musl", "x86_64-linux", "x86_64-linux-musl", "arm64-darwin", "x86_64-darwin"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -86,6 +86,10 @@ jobs:
         #   https://github.com/temporalio/sdk-ruby/issues/172
         os: [ubuntu-latest, macos-intel, macos-latest]
         rubyVersion: ["3.2", "3.3", "3.4"]
+        # Container defaults to empty/none, but additional container for Alpine
+        # added later
+        container: [""]
+
         include:
           - os: ubuntu-latest
             rubyPlatform: x86_64-linux
@@ -94,7 +98,12 @@ jobs:
             rubyPlatform: x86_64-darwin
           - os: macos-latest
             rubyPlatform: arm64-darwin
+          - os: ubuntu-latest
+            rubyVersion: "3.3"
+            container: alpine/git:latest
+            rubyPlatform: x86_64-linux-musl
     runs-on: ${{ matrix.runsOn || matrix.os }}
+    container: ${{ matrix.container }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,12 +116,19 @@ jobs:
           name: ${{ matrix.rubyPlatform }}-gem
           path: local-gem
 
+      # This only works on official runners
       - name: Setup Ruby
+        if: ${{ matrix.container == '' }}
         uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: "${{ matrix.rubyVersion }}"
           bundler-cache: true
           cargo-cache: false
+
+      # Works for Alpine
+      - name: Setup Ruby (Alpine)
+        if: ${{ matrix.container == 'alpine/git:latest' }}
+        run: apk add --no-cache ruby ruby-dev ruby-bundler build-base
 
       - name: Run smoke test
         run: ruby ./temporalio/smoke_test/smoke_test_gem.rb 'local-gem/*-${{ matrix.rubyPlatform }}.gem'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(cretz): Enable ubuntu-24.04-arm when oxidize-rb/actions/setup-ruby-and-rust
-        # supports it
+        # TODO(cretz): Enable ubuntu-24.04-arm when setup-ruby-and-rust supports it, see
+        # https://github.com/oxidize-rb/actions/issues/53
         # 
         # TODO(cretz): Enable x64-mingw-ucrt if we can figure out Windows issue, see
         # https://github.com/temporalio/sdk-ruby/issues/172

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ gem install temporalio
 
 **NOTE**: Only macOS ARM/x64 and Linux ARM/x64 are supported, and the platform-specific gem chosen is based on when the
 gem/bundle install is performed. A source gem is published but cannot be used directly and will fail to build if tried.
-MinGW-based Windows and Linux MUSL do not have gems. See the [Platform Support](#platform-support) section for more
-information.
+MinGW-based Windows is not currently supported. There are caveats with the Google Protobuf dependency on musl-based
+Linux. See the [Platform Support](#platform-support) section for more information.
 
 **NOTE**: Due to [an issue](https://github.com/temporalio/sdk-ruby/issues/162), fibers (and `async` gem) are only
 supported on Ruby versions 3.3 and newer.
@@ -1047,21 +1047,27 @@ This SDK is backed by a Ruby C extension written in Rust leveraging the
 [Temporal Rust Core](https://github.com/temporalio/sdk-core). Gems are currently published for the following platforms:
 
 * `aarch64-linux`
+* `aarch64-linux-musl`
 * `x86_64-linux`
+* `x86_64-linux-musl`
 * `arm64-darwin`
 * `x86_64-darwin`
 
-This means Linux and macOS for ARM and x64 have published gems. Currently, a gem is not published for
-`aarch64-linux-musl` so Alpine Linux users may need to build from scratch or use a libc-based distro.
+This means Linux and macOS for ARM and x64 have published gems.
 
 Due to [an issue](https://github.com/temporalio/sdk-ruby/issues/172) with Windows and multi-threaded Rust, MinGW-based
 Windows (i.e. `x64-mingw-ucrt`) is not supported. But WSL is supported using the normal Linux gem.
+
+Due to [an issue](https://github.com/protocolbuffers/protobuf/issues/16853) with Google Protobuf, latest Linux versions
+of Google Protobuf gems will not work in musl-based environments. Instead use the pure "ruby" platform which will build
+the Google Protobuf gem on install (e.g.
+`gem 'google-protobuf', force_ruby_platform: RUBY_PLATFORM.include?('linux-musl')` in the `Gemfile`).
 
 At this time a pure source gem is published for documentation reasons, but it cannot be built and will fail if tried.
 Building from source requires many files across submodules and requires Rust to be installed. See the [Build](#build)
 section for how to build a the repository.
 
-The SDK works on Ruby 3.1+, but due to [an issue](https://github.com/temporalio/sdk-ruby/issues/162), fibers (and
+The SDK works on Ruby 3.2+, but due to [an issue](https://github.com/temporalio/sdk-ruby/issues/162), fibers (and
 `async` gem) are only supported on Ruby versions 3.3 and newer.
 
 ## Development
@@ -1070,7 +1076,7 @@ The SDK works on Ruby 3.1+, but due to [an issue](https://github.com/temporalio/
 
 Prerequisites:
 
-* [Ruby](https://www.ruby-lang.org/) >= 3.1 (i.e. `ruby` and `bundle` on the `PATH`)
+* [Ruby](https://www.ruby-lang.org/) >= 3.2 (i.e. `ruby` and `bundle` on the `PATH`)
 * [Rust](https://www.rust-lang.org/) latest stable (i.e. `cargo` on the `PATH`)
 * This repository, cloned recursively
 * Change to the `temporalio/` directory

--- a/temporalio/smoke_test/smoke_test_gem.rb
+++ b/temporalio/smoke_test/smoke_test_gem.rb
@@ -5,6 +5,12 @@ raise 'Must provide gem file glob' if ARGV.length != 1
 gem_files = Dir.glob(ARGV.first)
 raise "Unable to find single gem file, found #{gem_files.length}" unless gem_files.length == 1
 
+# TODO(cretz): For Linux musl, we have to install google-protobuf manually because latest versions do not work with
+# musl. Remove this when https://github.com/protocolbuffers/protobuf/issues/16853 is resolved.
+if RUBY_PLATFORM.include?('linux-musl')
+  system('gem', 'install', '--verbose', 'google-protobuf', '--platform', 'ruby', exception: true)
+end
+
 system('gem', 'install', '--verbose', gem_files.first, exception: true)
 
 # Create a local environment and start a workflow


### PR DESCRIPTION
## What was changed

* Updated (and tested) the build-gems.yml CI workflow to build musl gems
  * Did not do in Alpine-based regular CI (requires lots of changes because setup-ruby and other things don't work there, and we have smoke test anyways)
  * Updated smoke test to run in Alpine container
  * Due to https://github.com/protocolbuffers/protobuf/issues/16853, had to use "ruby" platform Google Protobuf gem in smoke test (builds manually on install)
* Updated README

## Checklist

1. Closes #215