### PR TITLE
Worker client replacement and activity client access

### DIFF
--- a/temporalio/lib/temporalio/activity/context.rb
+++ b/temporalio/lib/temporalio/activity/context.rb
@@ -108,7 +108,14 @@ module Temporalio
       end
 
       # @return [Metric::Meter] Metric meter to create metrics on, with some activity-specific attributes already set.
+      # @raise [RuntimeError] Called within a {Testing::ActivityEnvironment} and it was not set.
       def metric_meter
+        raise NotImplementedError
+      end
+
+      # @return [Client] Temporal client this activity worker is running in.
+      # @raise [RuntimeError] Called within a {Testing::ActivityEnvironment} and it was not set.
+      def client
         raise NotImplementedError
       end
     end

--- a/temporalio/lib/temporalio/internal/worker/activity_worker.rb
+++ b/temporalio/lib/temporalio/internal/worker/activity_worker.rb
@@ -201,6 +201,7 @@ module Temporalio
 
           # Run
           activity = RunningActivity.new(
+            worker: @worker,
             info:,
             cancellation: Cancellation.new,
             worker_shutdown_cancellation: @worker._worker_shutdown_cancellation,
@@ -299,6 +300,7 @@ module Temporalio
           attr_accessor :instance, :_outbound_impl, :_server_requested_cancel
 
           def initialize( # rubocop:disable Lint/MissingSuper
+            worker:,
             info:,
             cancellation:,
             worker_shutdown_cancellation:,
@@ -306,6 +308,7 @@ module Temporalio
             logger:,
             runtime_metric_meter:
           )
+            @worker = worker
             @info = info
             @cancellation = cancellation
             @worker_shutdown_cancellation = worker_shutdown_cancellation
@@ -333,6 +336,10 @@ module Temporalio
                 activity_type: info.activity_type
               }
             )
+          end
+
+          def client
+            @worker.client
           end
         end
 

--- a/temporalio/sig/temporalio/activity/context.rbs
+++ b/temporalio/sig/temporalio/activity/context.rbs
@@ -19,6 +19,7 @@ module Temporalio
       def _scoped_logger_info: -> Hash[Symbol, Object]
 
       def metric_meter: -> Metric::Meter
+      def client: -> Client
     end
   end
 end

--- a/temporalio/sig/temporalio/internal/worker/activity_worker.rbs
+++ b/temporalio/sig/temporalio/internal/worker/activity_worker.rbs
@@ -32,6 +32,7 @@ module Temporalio
           attr_accessor _server_requested_cancel: bool
 
           def initialize: (
+            worker: Temporalio::Worker,
             info: Activity::Info,
             cancellation: Cancellation,
             worker_shutdown_cancellation: Cancellation,

--- a/temporalio/sig/temporalio/testing/activity_environment.rbs
+++ b/temporalio/sig/temporalio/testing/activity_environment.rbs
@@ -10,7 +10,9 @@ module Temporalio
         ?worker_shutdown_cancellation: Cancellation,
         ?payload_converter: Converters::PayloadConverter,
         ?logger: Logger,
-        ?activity_executors: Hash[Symbol, Worker::ActivityExecutor]
+        ?activity_executors: Hash[Symbol, Worker::ActivityExecutor],
+        ?metric_meter: Metric::Meter?,
+        ?client: Client?
       ) -> void
 
       def run: (

--- a/temporalio/sig/temporalio/worker.rbs
+++ b/temporalio/sig/temporalio/worker.rbs
@@ -60,6 +60,8 @@ module Temporalio
         workflow_payload_codec_thread_pool: ThreadPool?,
         debug_mode: bool
       ) -> void
+
+      def with: (**Object kwargs) -> Options
     end
 
     def self.default_build_id: -> String
@@ -109,6 +111,9 @@ module Temporalio
     ) -> void
 
     def task_queue: -> String
+
+    def client: -> Client
+    def client=: (Client new_client) -> void
 
     def run: [T] (
       ?cancellation: Cancellation,

--- a/temporalio/test/worker_activity_test.rb
+++ b/temporalio/test/worker_activity_test.rb
@@ -901,6 +901,19 @@ class WorkerActivityTest < Test
                  execute_activity(shared_instance, interceptors: [ContextInstanceInterceptor.new])
   end
 
+  class ClientAccessActivity < Temporalio::Activity::Definition
+    def execute
+      desc = Temporalio::Activity::Context.current.client.workflow_handle(
+        Temporalio::Activity::Context.current.info.workflow_id
+      ).describe
+      desc.raw_description.pending_activities.first.activity_type.name
+    end
+  end
+
+  def test_client_access
+    assert_equal 'ClientAccessActivity', execute_activity(ClientAccessActivity)
+  end
+
   # steep:ignore
   def execute_activity(
     activity,

--- a/temporalio/test/worker_workflow_test.rb
+++ b/temporalio/test/worker_workflow_test.rb
@@ -1769,13 +1769,59 @@ class WorkerWorkflowTest < Test
                  execute_workflow(ContextInstanceWorkflow, interceptors: [ContextInstanceInterceptor.new])
   end
 
+  class WorkerClientReplacementWorkflow < Temporalio::Workflow::Definition
+    def execute
+      Temporalio::Workflow.wait_condition { @complete }
+    end
+
+    workflow_signal
+    def complete(value)
+      @complete = value
+    end
+  end
+
+  def test_worker_client_replacement
+    # Create a second ephemeral server and start workflow on both servers
+    Temporalio::Testing::WorkflowEnvironment.start_local do |env2|
+      # Start both workflows on different servers
+      task_queue = "tq-#{SecureRandom.uuid}"
+      handle1 = env.client.start_workflow(WorkerClientReplacementWorkflow, id: "wf-#{SecureRandom.uuid}", task_queue:)
+      handle2 = env2.client.start_workflow(WorkerClientReplacementWorkflow, id: "wf-#{SecureRandom.uuid}", task_queue:)
+
+      # Run worker on the first env. Make sure cache is off and only 1 max poller
+      worker = Temporalio::Worker.new(
+        client: env.client, task_queue:, workflows: [WorkerClientReplacementWorkflow],
+        max_cached_workflows: 0, max_concurrent_workflow_task_polls: 1
+      )
+      worker.run do
+        # Confirm first workflow has a task complete but not the second
+        assert_eventually do
+          refute_nil handle1.fetch_history_events.find(&:workflow_task_completed_event_attributes)
+        end
+        assert_nil handle2.fetch_history_events.find(&:workflow_task_completed_event_attributes)
+
+        # Replace the client
+        worker.client = env2.client
+
+        # Signal both which should allow the current poll to wake up and it'll be a task failure when trying to submit
+        # that to the new client which is ignored. But also the new client will poll for the new workflow, which we will
+        # wait for it to complete.
+        handle1.signal(WorkerClientReplacementWorkflow.complete, 'done1')
+        handle2.signal(WorkerClientReplacementWorkflow.complete, 'done2')
+
+        # Confirm second workflow on new server completes
+        assert_equal 'done2', handle2.result
+        handle1.terminate
+      end
+    end
+  end
+
   # TODO(cretz): To test
   # * Common
   #   * Eager workflow start
   #   * Unawaited futures that have exceptions, need to log warning like Java does
   #   * Enhanced stack trace?
   #   * Separate abstract/interface demonstration
-  #   * Replace worker client
   #   * Reset update randomness seed
   #   * Confirm thread pool does not leak, meaning thread/worker goes away after last workflow
   #   * Test workflow cancel causing other cancels at the same time but in different coroutines


### PR DESCRIPTION
## What was changed

* Added `Temporalio::Worker#client` and `Temporalio::Worker#client=` to support replacing client on running worker
* Added `Temporalio::Activity::Context#client` to support accessing the client from the activity

## Checklist

1. Closes #165
1. Closes #181