### PR TITLE
Support HTTP protocol for OTel metrics

### DIFF
--- a/temporalio/ext/src/runtime.rs
+++ b/temporalio/ext/src/runtime.rs
@@ -12,8 +12,8 @@ use std::{future::Future, sync::Arc};
 use temporal_sdk_core::telemetry::{build_otlp_metric_exporter, start_prometheus_metric_exporter};
 use temporal_sdk_core::{CoreRuntime, TokioRuntimeBuilder};
 use temporal_sdk_core_api::telemetry::{
-    Logger, MetricTemporality, OtelCollectorOptionsBuilder, PrometheusExporterOptionsBuilder,
-    TelemetryOptionsBuilder,
+    Logger, MetricTemporality, OtelCollectorOptionsBuilder, OtlpProtocol,
+    PrometheusExporterOptionsBuilder, TelemetryOptionsBuilder,
 };
 use tracing::error as log_error;
 use url::Url;
@@ -116,6 +116,9 @@ impl Runtime {
                     }
                     if let Some(global_tags) = metrics.member::<Option<HashMap<String, String>>>(id!("global_tags"))? {
                         opts_build.global_tags(global_tags);
+                    }
+                    if opentelemetry.member::<bool>(id!("http"))? {
+                        opts_build.protocol(OtlpProtocol::Http);
                     }
                     let opts = opts_build
                         .build()

--- a/temporalio/lib/temporalio/activity/definition.rb
+++ b/temporalio/lib/temporalio/activity/definition.rb
@@ -90,7 +90,7 @@ module Temporalio
         {
           activity_name:,
           activity_executor: @activity_executor || :default,
-          activity_cancel_raise: @activity_cancel_raise.nil? ? true : @activity_cancel_raise,
+          activity_cancel_raise: @activity_cancel_raise.nil? || @activity_cancel_raise,
           activity_raw_args: @activity_raw_args.nil? ? false : @activity_raw_args
         }
       end

--- a/temporalio/lib/temporalio/internal/bridge/runtime.rb
+++ b/temporalio/lib/temporalio/internal/bridge/runtime.rb
@@ -37,6 +37,7 @@ module Temporalio
           :metric_periodicity, # Optional
           :metric_temporality_delta,
           :durations_as_seconds,
+          :http,
           keyword_init: true
         )
 

--- a/temporalio/lib/temporalio/runtime.rb
+++ b/temporalio/lib/temporalio/runtime.rb
@@ -164,7 +164,8 @@ module Temporalio
       :headers,
       :metric_periodicity,
       :metric_temporality,
-      :durations_as_seconds
+      :durations_as_seconds,
+      :http
     )
 
     # Options for exporting metrics to OpenTelemetry.
@@ -181,6 +182,8 @@ module Temporalio
     # @!attribute durations_as_seconds
     #   @return [Boolean] Whether to use float seconds instead of integer milliseconds for durations, default is
     #     +false+.
+    # @!attribute http
+    #   @return [Boolean] True if the protocol is HTTP, false if gRPC (the default).
     class OpenTelemetryMetricsOptions
       # OpenTelemetry metric temporality.
       module MetricTemporality
@@ -196,12 +199,14 @@ module Temporalio
       # @param metric_temporality [MetricTemporality] How frequently metrics should be exported.
       # @param durations_as_seconds [Boolean] Whether to use float seconds instead of integer milliseconds for
       #   durations.
+      # @param http [Boolean] True if the protocol is HTTP, false if gRPC (the default).
       def initialize(
         url:,
         headers: nil,
         metric_periodicity: nil,
         metric_temporality: MetricTemporality::CUMULATIVE,
-        durations_as_seconds: false
+        durations_as_seconds: false,
+        http: false
       )
         super
       end
@@ -218,7 +223,8 @@ module Temporalio
                                     when MetricTemporality::DELTA then true
                                     else raise 'Unrecognized metric temporality'
                                     end,
-          durations_as_seconds:
+          durations_as_seconds:,
+          http:
         )
       end
     end

--- a/temporalio/lib/temporalio/workflow/future.rb
+++ b/temporalio/lib/temporalio/workflow/future.rb
@@ -8,7 +8,7 @@ module Temporalio
     # workflows.
     class Future
       # Return a future that completes when any of the given futures complete. The returned future will return the first
-      # completed futures value or raise the first completed futures exception. To not raise the exception, see
+      # completed future's value or raise the first completed future's exception. To not raise the exception, see
       # {try_any_of}.
       #
       # @param futures [Array<Future<Object>>] Futures to wait for the first to complete.
@@ -16,7 +16,7 @@ module Temporalio
       def self.any_of(*futures)
         Future.new do
           Workflow.wait_condition(cancellation: nil) { futures.any?(&:done?) }
-          # We know a future is always returned from find, the & just helps type checker
+          # We know a future is always returned from find, the || just helps type checker
           (futures.find(&:done?) || raise).wait
         end
       end

--- a/temporalio/sig/temporalio/internal/bridge/runtime.rbs
+++ b/temporalio/sig/temporalio/internal/bridge/runtime.rbs
@@ -48,13 +48,15 @@ module Temporalio
           attr_accessor metric_periodicity: Float?
           attr_accessor metric_temporality_delta: bool
           attr_accessor durations_as_seconds: bool
+          attr_accessor http: bool
     
           def initialize: (
             url: String,
             headers: Hash[String, String]?,
             metric_periodicity: Float?,
             metric_temporality_delta: bool,
-            durations_as_seconds: bool
+            durations_as_seconds: bool,
+            http: bool
           ) -> void
         end
     

--- a/temporalio/sig/temporalio/runtime.rbs
+++ b/temporalio/sig/temporalio/runtime.rbs
@@ -67,13 +67,15 @@ module Temporalio
       attr_reader metric_periodicity: Float?
       attr_reader metric_temporality: MetricTemporality
       attr_reader durations_as_seconds: bool
+      attr_reader http: bool
 
       def initialize: (
         url: String,
         ?headers: Hash[String, String]?,
         ?metric_periodicity: Float?,
         ?metric_temporality: MetricTemporality,
-        ?durations_as_seconds: bool
+        ?durations_as_seconds: bool,
+        ?http: bool
       ) -> void
 
       def _to_bridge: -> Internal::Bridge::Runtime::OpenTelemetryMetricsOptions


### PR DESCRIPTION
## What was changed

Added `Temporalio::Runtime::OpenTelemetryMetricsOptions#http` option. Can't really test this reasonably since it's all in Core and we haven't added explicit tests in other languages we have added this.

## Checklist

1. Closes #196