### PR TITLE
Use RawValue for built-in query response

### DIFF
--- a/temporalio/lib/temporalio/activity/definition.rb
+++ b/temporalio/lib/temporalio/activity/definition.rb
@@ -90,7 +90,7 @@ module Temporalio
         {
           activity_name:,
           activity_executor: @activity_executor || :default,
-          activity_cancel_raise: @activity_cancel_raise.nil? ? true : @activity_cancel_raise,
+          activity_cancel_raise: @activity_cancel_raise.nil? || @activity_cancel_raise,
           activity_raw_args: @activity_raw_args.nil? ? false : @activity_raw_args
         }
       end

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'temporalio'
 require 'temporalio/activity/definition'
 require 'temporalio/api'
+require 'temporalio/converters/payload_converter'
 require 'temporalio/converters/raw_value'
 require 'temporalio/error'
 require 'temporalio/internal/bridge/api'
@@ -388,9 +389,11 @@ module Temporalio
           schedule do
             # If it's a built-in, run it without interceptors, otherwise do normal behavior
             result = if job.query_type == '__stack_trace'
-                       scheduler.stack_trace
+                       # Use raw value built from default converter because we don't want to use user-conversion
+                       Converters::RawValue.new(Converters::PayloadConverter.default.to_payload(scheduler.stack_trace))
                      elsif job.query_type == '__temporal_workflow_metadata'
-                       workflow_metadata
+                       # Use raw value built from default converter because we don't want to use user-conversion
+                       Converters::RawValue.new(Converters::PayloadConverter.default.to_payload(workflow_metadata))
                      else
                        # Get query definition, falling back to dynamic if not present and not reserved
                        defn = query_handlers[job.query_type]


### PR DESCRIPTION
## What was changed

Use RawValue for built-in query response so user's payload converter is not used

## Checklist

1. Closes #224