### PR TITLE
Buffered metric support

### DIFF
--- a/temporalio/ext/src/client.rs
+++ b/temporalio/ext/src/client.rs
@@ -176,12 +176,15 @@ impl Client {
                     .await?;
                 Ok(core)
             },
-            move |_, result: Result<CoreClient, ClientInitError>| match result {
-                Ok(core) => callback.push(Client {
-                    core,
-                    runtime_handle,
-                }),
-                Err(err) => callback.push(new_error!("Failed client connect: {}", err)),
+            move |ruby, result: Result<CoreClient, ClientInitError>| match result {
+                Ok(core) => callback.push(
+                    &ruby,
+                    Client {
+                        core,
+                        runtime_handle,
+                    },
+                ),
+                Err(err) => callback.push(&ruby, new_error!("Failed client connect: {}", err)),
             },
         );
         Ok(())
@@ -325,12 +328,12 @@ where
             };
             res.map(|msg| msg.get_ref().encode_to_vec())
         },
-        move |_, result| {
+        move |ruby, result| {
             match result {
                 // TODO(cretz): Any reasonable way to prevent byte copy that is just going to get decoded into proto
                 // object?
-                Ok(val) => callback.push(RString::from_slice(&val)),
-                Err(status) => callback.push(RpcFailure { status }),
+                Ok(val) => callback.push(&ruby, RString::from_slice(&val)),
+                Err(status) => callback.push(&ruby, RpcFailure { status }),
             }
         },
     );

--- a/temporalio/ext/src/testing.rs
+++ b/temporalio/ext/src/testing.rs
@@ -77,13 +77,16 @@ impl EphemeralServer {
         let runtime_handle = runtime.handle.clone();
         runtime.handle.spawn(
             async move { opts.start_server().await },
-            move |_, result| match result {
-                Ok(core) => callback.push(EphemeralServer {
-                    target: core.target.clone(),
-                    core: Mutex::new(Some(core)),
-                    runtime_handle,
-                }),
-                Err(err) => callback.push(new_error!("Failed starting server: {}", err)),
+            move |ruby, result| match result {
+                Ok(core) => callback.push(
+                    &ruby,
+                    EphemeralServer {
+                        target: core.target.clone(),
+                        core: Mutex::new(Some(core)),
+                        runtime_handle,
+                    },
+                ),
+                Err(err) => callback.push(&ruby, new_error!("Failed starting server: {}", err)),
             },
         );
         Ok(())
@@ -109,13 +112,16 @@ impl EphemeralServer {
         let runtime_handle = runtime.handle.clone();
         runtime.handle.spawn(
             async move { opts.start_server().await },
-            move |_, result| match result {
-                Ok(core) => callback.push(EphemeralServer {
-                    target: core.target.clone(),
-                    core: Mutex::new(Some(core)),
-                    runtime_handle,
-                }),
-                Err(err) => callback.push(new_error!("Failed starting server: {}", err)),
+            move |ruby, result| match result {
+                Ok(core) => callback.push(
+                    &ruby,
+                    EphemeralServer {
+                        target: core.target.clone(),
+                        core: Mutex::new(Some(core)),
+                        runtime_handle,
+                    },
+                ),
+                Err(err) => callback.push(&ruby, new_error!("Failed starting server: {}", err)),
             },
         );
         Ok(())
@@ -149,9 +155,9 @@ impl EphemeralServer {
                 .spawn(
                     async move { core.shutdown().await },
                     move |ruby, result| match result {
-                        Ok(_) => callback.push(ruby.qnil()),
+                        Ok(_) => callback.push(&ruby, ruby.qnil()),
                         Err(err) => {
-                            callback.push(new_error!("Failed shutting down server: {}", err))
+                            callback.push(&ruby, new_error!("Failed shutting down server: {}", err))
                         }
                     },
                 )

--- a/temporalio/ext/src/worker.rs
+++ b/temporalio/ext/src/worker.rs
@@ -225,21 +225,23 @@ impl Worker {
                             Ok(None) => ruby.qnil().as_value(),
                             Err(err) => new_error!("Poll failure: {}", err).as_value(),
                         };
-                        callback.push(ruby.ary_new_from_values(&[
-                            poll_result.worker_index.into_value(),
-                            worker_type.into_value(),
-                            result,
-                        ]))
+                        callback.push(
+                            &ruby,
+                            ruby.ary_new_from_values(&[
+                                poll_result.worker_index.into_value(),
+                                worker_type.into_value(),
+                                result,
+                            ]),
+                        )
                     })));
                 }
             },
             move |ruby, _| {
                 // Call with nil, nil, nil to say done
-                complete_callback.push(ruby.ary_new_from_values(&[
-                    ruby.qnil(),
-                    ruby.qnil(),
-                    ruby.qnil(),
-                ]))
+                complete_callback.push(
+                    &ruby,
+                    ruby.ary_new_from_values(&[ruby.qnil(), ruby.qnil(), ruby.qnil()]),
+                )
             },
         );
         Ok(())
@@ -289,13 +291,16 @@ impl Worker {
             },
             move |ruby, errs| {
                 if errs.is_empty() {
-                    callback.push(ruby.qnil())
+                    callback.push(&ruby, ruby.qnil())
                 } else {
-                    callback.push(new_error!(
-                        "{} worker(s) failed to finalize, reasons: {}",
-                        errs.len(),
-                        errs.join(", ")
-                    ))
+                    callback.push(
+                        &ruby,
+                        new_error!(
+                            "{} worker(s) failed to finalize, reasons: {}",
+                            errs.len(),
+                            errs.join(", ")
+                        ),
+                    )
                 }
             },
         );
@@ -308,8 +313,8 @@ impl Worker {
         self.runtime_handle.spawn(
             async move { temporal_sdk_core_api::Worker::validate(&*worker).await },
             move |ruby, result| match result {
-                Ok(()) => callback.push(ruby.qnil()),
-                Err(err) => callback.push(new_error!("Failed validating worker: {}", err)),
+                Ok(()) => callback.push(&ruby, ruby.qnil()),
+                Err(err) => callback.push(&ruby, new_error!("Failed validating worker: {}", err)),
             },
         );
         Ok(())
@@ -325,8 +330,8 @@ impl Worker {
                 temporal_sdk_core_api::Worker::complete_activity_task(&*worker, completion).await
             },
             move |ruby, result| match result {
-                Ok(()) => callback.push((ruby.qnil(),)),
-                Err(err) => callback.push((new_error!("Completion failure: {}", err),)),
+                Ok(()) => callback.push(&ruby, (ruby.qnil(),)),
+                Err(err) => callback.push(&ruby, (new_error!("Completion failure: {}", err),)),
             },
         );
         Ok(())
@@ -357,16 +362,19 @@ impl Worker {
                     .await
             },
             move |ruby, result| {
-                callback.push(ruby.ary_new_from_values(&[
-                    (-1).into_value_with(&ruby),
-                    run_id.into_value_with(&ruby),
-                    match result {
-                        Ok(()) => ruby.qnil().into_value_with(&ruby),
-                        Err(err) => {
-                            new_error!("Completion failure: {}", err).into_value_with(&ruby)
-                        }
-                    },
-                ]))
+                callback.push(
+                    &ruby,
+                    ruby.ary_new_from_values(&[
+                        (-1).into_value_with(&ruby),
+                        run_id.into_value_with(&ruby),
+                        match result {
+                            Ok(()) => ruby.qnil().into_value_with(&ruby),
+                            Err(err) => {
+                                new_error!("Completion failure: {}", err).into_value_with(&ruby)
+                            }
+                        },
+                    ]),
+                )
             },
         );
         Ok(())

--- a/temporalio/lib/temporalio/runtime/metric_buffer.rb
+++ b/temporalio/lib/temporalio/runtime/metric_buffer.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Temporalio
+  class Runtime
+    # Metric buffer for use with a runtime to capture metrics. Only one metric buffer can be associated with a runtime
+    # and {retrieve_updates} cannot be called before the runtime is created. Once runtime created, users should
+    # regularly call {retrieve_updates} to drain the buffer.
+    #
+    # @note WARNING: It is important that the buffer size is set to a high number and that {retrieve_updates} is called
+    #   regularly to drain the buffer. If the buffer is full, metric updates will be dropped and an error will be
+    #   logged.
+    class MetricBuffer
+      # Enumerates for the duration format.
+      module DurationFormat
+        # Durations are millisecond integers.
+        MILLISECONDS = :milliseconds
+
+        # Durations are second floats.
+        SECONDS = :seconds
+      end
+
+      Update = Data.define(:metric, :value, :attributes)
+
+      # Metric buffer update.
+      #
+      # @note WARNING: The constructor of this class should not be invoked by users and may change in incompatible ways
+      #   in the future.
+      #
+      # @!attribute metric
+      #   @return [Metric] Metric for this update. For performance reasons, this is created lazily on first use and is
+      #     the same object each time an update on this metric exists.
+      # @!attribute value
+      #   @return [Integer, Float] Metric value for this update.
+      # @!attribute attributes
+      #   @return [Hash{String => String, Integer, Float, Boolean}] Attributes for this value as a frozen hash.
+      #     For performance reasons this is sometimes the same hash if the attribute set is reused at a metric level.
+      class Update # rubocop:disable Lint/EmptyClass
+        # DEV NOTE: This class is instantiated inside Rust, be careful changing it.
+      end
+
+      Metric = Data.define(:name, :description, :unit, :kind)
+
+      # Metric definition present on an update.
+      #
+      # @!attribute name
+      #   @return [String] Name of the metric.
+      # @!attribute description
+      #   @return [String, nil] Description of the metric if any.
+      # @!attribute unit
+      #   @return [String, nil] Unit of the metric if any.
+      # @!attribute kind
+      #   @return [:counter, :histogram, :gauge] Kind of the metric.
+      class Metric # rubocop:disable Lint/EmptyClass
+        # DEV NOTE: This class is instantiated inside Rust, be careful changing it.
+      end
+
+      # Create a metric buffer with the given size.
+      #
+      # @note WARNING: It is important that the buffer size is set to a high number and is drained regularly. See
+      #   {MetricBuffer} warning.
+      #
+      # @param buffer_size [Integer] Maximum size of the buffer before metrics will be dropped.
+      # @param duration_format [DurationFormat] How durations are represented.
+      def initialize(buffer_size, duration_format: DurationFormat::MILLISECONDS)
+        @buffer_size = buffer_size
+        @duration_format = duration_format
+        @runtime = nil
+      end
+
+      # Drain the buffer and return all metric updates.
+      #
+      # @note WARNING: It is important that this is called regularly. See {MetricBuffer} warning.
+      #
+      # @return [Array<Update>] Updates since last time this was called.
+      def retrieve_updates
+        raise 'Attempting to retrieve updates before runtime created' unless @runtime
+
+        @runtime._core_runtime.retrieve_buffered_metrics(@duration_format == DurationFormat::SECONDS)
+      end
+
+      # @!visibility private
+      def _buffer_size
+        @buffer_size
+      end
+
+      # @!visibility private
+      def _set_runtime(runtime)
+        raise 'Metric buffer already attached to a runtime' if @runtime
+
+        @runtime = runtime
+      end
+    end
+  end
+end

--- a/temporalio/sig/temporalio/internal/bridge/runtime.rbs
+++ b/temporalio/sig/temporalio/internal/bridge/runtime.rbs
@@ -29,6 +29,7 @@ module Temporalio
         class MetricsOptions
           attr_accessor opentelemetry: OpenTelemetryMetricsOptions?
           attr_accessor prometheus: PrometheusMetricsOptions?
+          attr_accessor buffered_with_size: Integer?
           attr_accessor attach_service_name: bool
           attr_accessor global_tags: Hash[String, String]?
           attr_accessor metric_prefix: String?
@@ -36,6 +37,7 @@ module Temporalio
           def initialize: (
             opentelemetry: OpenTelemetryMetricsOptions?,
             prometheus: PrometheusMetricsOptions?,
+            buffered_with_size: Integer?,
             attach_service_name: bool,
             global_tags: Hash[String, String]?,
             metric_prefix: String?
@@ -79,6 +81,8 @@ module Temporalio
         def self.new: (Options options) -> Runtime
 
         def run_command_loop: -> void
+
+        def retrieve_buffered_metrics: (bool durations_as_seconds) -> Array[Temporalio::Runtime::MetricBuffer::Update]
       end
     end
   end

--- a/temporalio/sig/temporalio/runtime.rbs
+++ b/temporalio/sig/temporalio/runtime.rbs
@@ -39,6 +39,7 @@ module Temporalio
     class MetricsOptions
       attr_reader opentelemetry: OpenTelemetryMetricsOptions?
       attr_reader prometheus: PrometheusMetricsOptions?
+      attr_reader buffer: MetricBuffer?
       attr_reader attach_service_name: bool
       attr_reader global_tags: Hash[String, String]?
       attr_reader metric_prefix: String?
@@ -46,6 +47,7 @@ module Temporalio
       def initialize: (
         ?opentelemetry: OpenTelemetryMetricsOptions?,
         ?prometheus: PrometheusMetricsOptions?,
+        ?buffer: MetricBuffer?,
         ?attach_service_name: bool,
         ?global_tags: Hash[String, String]?,
         ?metric_prefix: String?

--- a/temporalio/sig/temporalio/runtime/metric_buffer.rbs
+++ b/temporalio/sig/temporalio/runtime/metric_buffer.rbs
@@ -1,0 +1,49 @@
+module Temporalio
+  class Runtime
+    class MetricBuffer
+      module DurationFormat
+        type enum = Symbol
+    
+        MILLISECONDS: enum
+        SECONDS: enum
+      end
+
+      class Update
+        attr_reader metric: Metric
+        attr_reader value: Integer | Float
+        attr_reader attributes: Hash[String, String | Integer | Float | bool]
+
+        def initialize: (
+          metric: Metric,
+          value: Integer | Float,
+          attributes: Hash[String, String | Integer | Float | bool]
+        ) -> void
+      end
+
+      class Metric
+        attr_reader name: String
+        attr_reader description: String?
+        attr_reader unit: String?
+        attr_reader kind: (:counter | :histogram | :gauge)
+
+        def initialize: (
+          name: String,
+          description: String?,
+          unit: String?,
+          kind: (:counter | :histogram | :gauge)
+        ) -> void
+      end
+
+      def initialize: (
+        Integer buffer_size,
+        ?duration_format: DurationFormat::enum
+      ) -> void
+
+      def retrieve_updates: -> Array[Update]
+
+      def _buffer_size: -> Integer
+
+      def _set_runtime: (Runtime runtime) -> void
+    end
+  end
+end


### PR DESCRIPTION
## What was changed

Added `Temporalio::Runtime::MetricBuffer` users can create with a size and set on `Runtime` to buffer metrics. They can call `retrieve_updates` on the buffer to get buffered metrics. This gives more freedom for users to do what they want with the metrics.

## Checklist

1. Closes #176