### PR TITLE
Support unsafe IO/io_wait inside workflows

### DIFF
--- a/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
@@ -57,7 +57,7 @@ module Temporalio
                     :failure_converter, :cancellation, :continue_as_new_suggested, :current_history_length,
                     :current_history_size, :replaying, :random, :signal_handlers, :query_handlers, :update_handlers,
                     :context_frozen
-        attr_accessor :current_details
+        attr_accessor :io_enabled, :current_details
 
         def initialize(details)
           # Initialize general state
@@ -68,6 +68,7 @@ module Temporalio
           @logger = ReplaySafeLogger.new(logger: details.logger, instance: self)
           @logger.scoped_values_getter = proc { scoped_logger_info }
           @runtime_metric_meter = details.metric_meter
+          @io_enabled = details.unsafe_workflow_io_enabled
           @scheduler = Scheduler.new(self)
           @payload_converter = details.payload_converter
           @failure_converter = details.failure_converter

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
@@ -164,6 +164,16 @@ module Temporalio
             )
           end
 
+          def io_enabled(&)
+            prev = @instance.io_enabled
+            @instance.io_enabled = true
+            begin
+              yield
+            ensure
+              @instance.io_enabled = prev
+            end
+          end
+
           def logger
             @instance.logger
           end

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/details.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/details.rb
@@ -8,7 +8,7 @@ module Temporalio
         class Details
           attr_reader :namespace, :task_queue, :definition, :initial_activation, :logger, :metric_meter,
                       :payload_converter, :failure_converter, :interceptors, :disable_eager_activity_execution,
-                      :illegal_calls, :workflow_failure_exception_types
+                      :illegal_calls, :workflow_failure_exception_types, :unsafe_workflow_io_enabled
 
           def initialize(
             namespace:,
@@ -22,7 +22,8 @@ module Temporalio
             interceptors:,
             disable_eager_activity_execution:,
             illegal_calls:,
-            workflow_failure_exception_types:
+            workflow_failure_exception_types:,
+            unsafe_workflow_io_enabled:
           )
             @namespace = namespace
             @task_queue = task_queue
@@ -36,6 +37,7 @@ module Temporalio
             @disable_eager_activity_execution = disable_eager_activity_execution
             @illegal_calls = illegal_calls
             @workflow_failure_exception_types = workflow_failure_exception_types
+            @unsafe_workflow_io_enabled = unsafe_workflow_io_enabled
           end
         end
       end

--- a/temporalio/lib/temporalio/internal/worker/workflow_worker.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_worker.rb
@@ -67,6 +67,7 @@ module Temporalio
           illegal_workflow_calls:,
           workflow_failure_exception_types:,
           workflow_payload_codec_thread_pool:,
+          unsafe_workflow_io_enabled:,
           debug_mode:,
           on_eviction: nil
         )
@@ -109,7 +110,8 @@ module Temporalio
               end
 
               t
-            end.freeze
+            end.freeze,
+            unsafe_workflow_io_enabled:
           )
           @state.on_eviction = on_eviction if on_eviction
 
@@ -184,14 +186,14 @@ module Temporalio
         class State
           attr_reader :workflow_definitions, :bridge_worker, :logger, :metric_meter, :data_converter, :deadlock_timeout,
                       :illegal_calls, :namespace, :task_queue, :disable_eager_activity_execution,
-                      :workflow_interceptors, :workflow_failure_exception_types
+                      :workflow_interceptors, :workflow_failure_exception_types, :unsafe_workflow_io_enabled
 
           attr_writer :on_eviction
 
           def initialize(
             workflow_definitions:, bridge_worker:, logger:, metric_meter:, data_converter:, deadlock_timeout:,
             illegal_calls:, namespace:, task_queue:, disable_eager_activity_execution:,
-            workflow_interceptors:, workflow_failure_exception_types:
+            workflow_interceptors:, workflow_failure_exception_types:, unsafe_workflow_io_enabled:
           )
             @workflow_definitions = workflow_definitions
             @bridge_worker = bridge_worker
@@ -205,6 +207,7 @@ module Temporalio
             @disable_eager_activity_execution = disable_eager_activity_execution
             @workflow_interceptors = workflow_interceptors
             @workflow_failure_exception_types = workflow_failure_exception_types
+            @unsafe_workflow_io_enabled = unsafe_workflow_io_enabled
 
             @running_workflows = {}
             @running_workflows_mutex = Mutex.new

--- a/temporalio/lib/temporalio/worker.rb
+++ b/temporalio/lib/temporalio/worker.rb
@@ -52,6 +52,7 @@ module Temporalio
       :illegal_workflow_calls,
       :workflow_failure_exception_types,
       :workflow_payload_codec_thread_pool,
+      :unsafe_workflow_io_enabled,
       :debug_mode
     )
 
@@ -347,6 +348,9 @@ module Temporalio
     # @param workflow_payload_codec_thread_pool [ThreadPool, nil] Thread pool to run payload codec encode/decode within.
     #   This is required if a payload codec exists and the worker is not fiber based. Codecs can potentially block
     #   execution which is why they need to be run in the background.
+    # @param unsafe_workflow_io_enabled [Boolean] If false, the default, workflow code that invokes io_wait on the fiber
+    #   scheduler will fail. Instead of setting this to true, users are encouraged to use {Workflow::Unsafe.io_enabled}
+    #   with a block for narrower enabling of IO.
     # @param debug_mode [Boolean] If true, deadlock detection is disabled. Deadlock detection will fail workflow tasks
     #   if they block the thread for too long. This defaults to true if the `TEMPORAL_DEBUG` environment variable is
     #   `true` or `1`.
@@ -378,6 +382,7 @@ module Temporalio
       illegal_workflow_calls: Worker.default_illegal_workflow_calls,
       workflow_failure_exception_types: [],
       workflow_payload_codec_thread_pool: nil,
+      unsafe_workflow_io_enabled: false,
       debug_mode: %w[true 1].include?(ENV['TEMPORAL_DEBUG'].to_s.downcase)
     )
       raise ArgumentError, 'Must have at least one activity or workflow' if activities.empty? && workflows.empty?
@@ -412,6 +417,7 @@ module Temporalio
         illegal_workflow_calls:,
         workflow_failure_exception_types:,
         workflow_payload_codec_thread_pool:,
+        unsafe_workflow_io_enabled:,
         debug_mode:
       ).freeze
 
@@ -483,6 +489,7 @@ module Temporalio
           illegal_workflow_calls:,
           workflow_failure_exception_types:,
           workflow_payload_codec_thread_pool:,
+          unsafe_workflow_io_enabled:,
           debug_mode:
         )
       end

--- a/temporalio/lib/temporalio/worker/workflow_executor/thread_pool.rb
+++ b/temporalio/lib/temporalio/worker/workflow_executor/thread_pool.rb
@@ -213,7 +213,8 @@ module Temporalio
                 interceptors: worker_state.workflow_interceptors,
                 disable_eager_activity_execution: worker_state.disable_eager_activity_execution,
                 illegal_calls: worker_state.illegal_calls,
-                workflow_failure_exception_types: worker_state.workflow_failure_exception_types
+                workflow_failure_exception_types: worker_state.workflow_failure_exception_types,
+                unsafe_workflow_io_enabled: worker_state.unsafe_workflow_io_enabled
               )
             )
           end

--- a/temporalio/lib/temporalio/worker/workflow_replayer.rb
+++ b/temporalio/lib/temporalio/worker/workflow_replayer.rb
@@ -30,6 +30,7 @@ module Temporalio
         :illegal_workflow_calls,
         :workflow_failure_exception_types,
         :workflow_payload_codec_thread_pool,
+        :unsafe_workflow_io_enabled,
         :debug_mode,
         :runtime
       )
@@ -69,6 +70,9 @@ module Temporalio
       # @param workflow_payload_codec_thread_pool [ThreadPool, nil] Thread pool to run payload codec encode/decode
       #   within. This is required if a payload codec exists and the worker is not fiber based. Codecs can potentially
       #   block execution which is why they need to be run in the background.
+      # @param unsafe_workflow_io_enabled [Boolean] If false, the default, workflow code that invokes io_wait on the
+      #   fiber scheduler will fail. Instead of setting this to true, users are encouraged to use
+      #   {Workflow::Unsafe.io_enabled} with a block for narrower enabling of IO.
       # @param debug_mode [Boolean] If true, deadlock detection is disabled. Deadlock detection will fail workflow tasks
       #   if they block the thread for too long. This defaults to true if the `TEMPORAL_DEBUG` environment variable is
       #   `true` or `1`.
@@ -89,6 +93,7 @@ module Temporalio
         illegal_workflow_calls: Worker.default_illegal_workflow_calls,
         workflow_failure_exception_types: [],
         workflow_payload_codec_thread_pool: nil,
+        unsafe_workflow_io_enabled: false,
         debug_mode: %w[true 1].include?(ENV['TEMPORAL_DEBUG'].to_s.downcase),
         runtime: Runtime.default,
         &
@@ -106,6 +111,7 @@ module Temporalio
           illegal_workflow_calls:,
           workflow_failure_exception_types:,
           workflow_payload_codec_thread_pool:,
+          unsafe_workflow_io_enabled:,
           debug_mode:,
           runtime:
         ).freeze
@@ -237,6 +243,7 @@ module Temporalio
             illegal_workflow_calls: options.illegal_workflow_calls,
             workflow_failure_exception_types: options.workflow_failure_exception_types,
             workflow_payload_codec_thread_pool: options.workflow_payload_codec_thread_pool,
+            unsafe_workflow_io_enabled: options.unsafe_workflow_io_enabled,
             debug_mode: options.debug_mode,
             on_eviction: proc { |_, remove_job| @last_workflow_remove_job = remove_job } # steep:ignore
           )

--- a/temporalio/lib/temporalio/workflow.rb
+++ b/temporalio/lib/temporalio/workflow.rb
@@ -503,6 +503,13 @@ module Temporalio
       def self.illegal_call_tracing_disabled(&)
         Workflow._current.illegal_call_tracing_disabled(&)
       end
+
+      # Run a block of code with IO enabled. Specifically this allows the `io_wait` call of the fiber scheduler to work.
+      # Users should be cautious about using this as it can often signify unsafe code. Note, this is often only
+      # applicable to network code as file IO and most process-based IO does not go through scheduler `io_wait`.
+      def self.io_enabled(&)
+        Workflow._current.io_enabled(&)
+      end
     end
 
     # Error that is raised by a workflow out of the primary workflow method to issue a continue-as-new.

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance.rbs
@@ -34,6 +34,7 @@ module Temporalio
         attr_reader update_handlers: Hash[String?, Workflow::Definition::Update]
         attr_reader context_frozen: bool
 
+        attr_accessor io_enabled: bool
         attr_accessor current_details: String?
 
         def initialize: (Details details) -> void

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance/context.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance/context.rbs
@@ -61,6 +61,8 @@ module Temporalio
 
           def initialize_continue_as_new_error: (Workflow::ContinueAsNewError error) -> void
 
+          def io_enabled: [T] { -> T } -> T
+
           def logger: -> ReplaySafeLogger
 
           def memo: -> ExternallyImmutableHash[String, Object?]

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance/details.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance/details.rbs
@@ -15,6 +15,7 @@ module Temporalio
           attr_reader disable_eager_activity_execution: bool
           attr_reader illegal_calls: Hash[String, :all | Hash[Symbol, bool]]
           attr_reader workflow_failure_exception_types: Array[singleton(Exception)]
+          attr_reader unsafe_workflow_io_enabled: bool
 
           def initialize: (
             namespace: String,
@@ -28,7 +29,8 @@ module Temporalio
             interceptors: Array[Temporalio::Worker::Interceptor::Workflow],
             disable_eager_activity_execution: bool,
             illegal_calls: Hash[String, :all | Hash[Symbol, bool]],
-            workflow_failure_exception_types: Array[singleton(Exception)]
+            workflow_failure_exception_types: Array[singleton(Exception)],
+            unsafe_workflow_io_enabled: bool
           ) -> void
         end
       end

--- a/temporalio/sig/temporalio/internal/worker/workflow_worker.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_worker.rbs
@@ -25,6 +25,7 @@ module Temporalio
           illegal_workflow_calls: Hash[String, :all | Array[Symbol]],
           workflow_failure_exception_types: Array[singleton(Exception)],
           workflow_payload_codec_thread_pool: Temporalio::Worker::ThreadPool?,
+          unsafe_workflow_io_enabled: bool,
           debug_mode: bool,
           ?on_eviction: (^(String run_id, untyped cache_remove_job) -> void)?
         ) -> void
@@ -61,6 +62,7 @@ module Temporalio
           attr_reader disable_eager_activity_execution: bool
           attr_reader workflow_interceptors: Array[Temporalio::Worker::Interceptor::Workflow]
           attr_reader workflow_failure_exception_types: Array[singleton(Exception)]
+          attr_reader unsafe_workflow_io_enabled: bool
 
           attr_writer on_eviction: ^(String run_id, untyped cache_remove_job) -> void
 
@@ -76,7 +78,8 @@ module Temporalio
             task_queue: String,
             disable_eager_activity_execution: bool,
             workflow_interceptors: Array[Temporalio::Worker::Interceptor::Workflow],
-            workflow_failure_exception_types: Array[singleton(Exception)]
+            workflow_failure_exception_types: Array[singleton(Exception)],
+            unsafe_workflow_io_enabled: bool
           ) -> void
 
           def get_or_create_running_workflow: [T] (String run_id) { -> T } -> T

--- a/temporalio/sig/temporalio/worker.rbs
+++ b/temporalio/sig/temporalio/worker.rbs
@@ -28,6 +28,7 @@ module Temporalio
       attr_reader illegal_workflow_calls: Hash[String, :all | Array[Symbol]]
       attr_reader workflow_failure_exception_types: Array[singleton(Exception)]
       attr_reader workflow_payload_codec_thread_pool: ThreadPool?
+      attr_reader unsafe_workflow_io_enabled: bool
       attr_reader debug_mode: bool
 
       def initialize: (
@@ -58,6 +59,7 @@ module Temporalio
         illegal_workflow_calls: Hash[String, :all | Array[Symbol]],
         workflow_failure_exception_types: Array[singleton(Exception)],
         workflow_payload_codec_thread_pool: ThreadPool?,
+        unsafe_workflow_io_enabled: bool,
         debug_mode: bool
       ) -> void
 
@@ -107,6 +109,7 @@ module Temporalio
       ?illegal_workflow_calls: Hash[String, :all | Array[Symbol]],
       ?workflow_failure_exception_types: Array[singleton(Exception)],
       ?workflow_payload_codec_thread_pool: ThreadPool?,
+      ?unsafe_workflow_io_enabled: bool,
       ?debug_mode: bool
     ) -> void
 

--- a/temporalio/sig/temporalio/worker/workflow_replayer.rbs
+++ b/temporalio/sig/temporalio/worker/workflow_replayer.rbs
@@ -14,6 +14,7 @@ module Temporalio
         attr_reader illegal_workflow_calls: Hash[String, :all | Array[Symbol]]
         attr_reader workflow_failure_exception_types: Array[singleton(Exception)]
         attr_reader workflow_payload_codec_thread_pool: ThreadPool?
+        attr_reader unsafe_workflow_io_enabled: bool
         attr_reader debug_mode: bool
         attr_reader runtime: Runtime
   
@@ -30,6 +31,7 @@ module Temporalio
           illegal_workflow_calls: Hash[String, :all | Array[Symbol]],
           workflow_failure_exception_types: Array[singleton(Exception)],
           workflow_payload_codec_thread_pool: ThreadPool?,
+          unsafe_workflow_io_enabled: bool,
           debug_mode: bool,
           runtime: Runtime
         ) -> void
@@ -50,6 +52,7 @@ module Temporalio
         ?illegal_workflow_calls: Hash[String, :all | Array[Symbol]],
         ?workflow_failure_exception_types: Array[singleton(Exception)],
         ?workflow_payload_codec_thread_pool: ThreadPool?,
+        ?unsafe_workflow_io_enabled: bool,
         ?debug_mode: bool,
         ?runtime: Runtime
       ) ?{ (ReplayWorker worker) -> untyped } -> void

--- a/temporalio/sig/temporalio/workflow.rbs
+++ b/temporalio/sig/temporalio/workflow.rbs
@@ -138,6 +138,8 @@ module Temporalio
       def self.replaying?: -> bool
 
       def self.illegal_call_tracing_disabled: [T] { -> T } -> T
+
+      def self.io_enabled: [T] { -> T } -> T
     end
 
     class ContinueAsNewError < Error

--- a/temporalio/test/sig/workflow_utils.rbs
+++ b/temporalio/test/sig/workflow_utils.rbs
@@ -37,7 +37,8 @@ module WorkflowUtils
     ?id_conflict_policy: Temporalio::WorkflowIDConflictPolicy::enum,
     ?max_heartbeat_throttle_interval: Float,
     ?task_timeout: duration?,
-    ?on_worker_run: Proc?
+    ?on_worker_run: Proc?,
+    ?unsafe_workflow_io_enabled: bool
   ) { (Temporalio::Client::WorkflowHandle, Temporalio::Worker) -> T } -> T
 
   def assert_eventually_task_fail: (

--- a/temporalio/test/workflow_utils.rb
+++ b/temporalio/test/workflow_utils.rb
@@ -29,7 +29,8 @@ module WorkflowUtils
     max_heartbeat_throttle_interval: 60.0,
     task_timeout: nil,
     interceptors: [],
-    on_worker_run: nil
+    on_worker_run: nil,
+    unsafe_workflow_io_enabled: false
   )
     worker = Temporalio::Worker.new(
       client:,
@@ -41,7 +42,8 @@ module WorkflowUtils
       logger: logger || client.options.logger,
       workflow_payload_codec_thread_pool:,
       max_heartbeat_throttle_interval:,
-      interceptors:
+      interceptors:,
+      unsafe_workflow_io_enabled:
     )
     worker.run do
       on_worker_run&.call


### PR DESCRIPTION
## What was changed

* Added `Temporalio::Workflow::Unsafe.io_enabled` that accepts a block to have IO enabled for
* Added `unsafe_workflow_io_enabled` default-false bool option for workers/replayers
* Implemented `Fiber::Scheduler#io_wait` to fail with clear message if not enabled, or work via blocking IO when enabled

## Checklist

1. Closes #239