### PR TITLE
Support parentless OTel workflow spans

### DIFF
--- a/temporalio/sig/temporalio/contrib/open_telemetry.rbs
+++ b/temporalio/sig/temporalio/contrib/open_telemetry.rbs
@@ -11,7 +11,8 @@ module Temporalio
         def initialize: (
           untyped tracer,
           ?header_key: String,
-          ?propagator: untyped
+          ?propagator: untyped,
+          ?always_create_workflow_spans: bool
         ) -> void
 
         def _apply_context_to_headers: (Hash[String, untyped] headers, ?context: untyped) -> void
@@ -23,6 +24,7 @@ module Temporalio
           ?attributes: Hash[untyped, untyped]?,
           ?outbound_input: untyped
         ) { () -> T } -> T
+        def _always_create_workflow_spans: -> bool
 
         class WorkflowInbound < Worker::Interceptor::Workflow::Inbound
           def initialize: (TracingInterceptor root, Worker::Interceptor::Workflow::Inbound next_interceptor) -> void

--- a/temporalio/test/sig/contrib/open_telemetry_test.rbs
+++ b/temporalio/test/sig/contrib/open_telemetry_test.rbs
@@ -2,11 +2,16 @@ module Contrib
   class OpenTelemetryTest < Test
     def init_tracer_and_exporter: -> [untyped, untyped]
     def trace: (
-      ?tracer_and_exporter: [untyped, untyped]
+      ?tracer_and_exporter: [untyped, untyped],
+      ?always_create_workflow_spans: bool,
+      ?check_root: bool
     ) { (Temporalio::Client) -> void } -> untyped
     def trace_workflow: (
       Symbol scenario,
-      ?tracer_and_exporter: [untyped, untyped]
+      ?tracer_and_exporter: [untyped, untyped],
+      ?start_with_untraced_client: bool,
+      ?always_create_workflow_spans: bool,
+      ?check_root: bool
     ) { (Temporalio::Client::WorkflowHandle) -> void } -> untyped
 
     class ExpectedSpan
@@ -30,7 +35,8 @@ module Contrib
         name: String,
         ?attributes: Hash[untyped, untyped],
         ?links: Array[ExpectedSpan],
-        ?exception_message: String?
+        ?exception_message: String?,
+        ?insert_at: Integer?
       ) -> ExpectedSpan
 
       def to_s_indented: (?indent: String) -> String

--- a/temporalio/test/sig/workflow_utils.rbs
+++ b/temporalio/test/sig/workflow_utils.rbs
@@ -17,7 +17,8 @@ module WorkflowUtils
     ?id_conflict_policy: Temporalio::WorkflowIDConflictPolicy::enum,
     ?max_heartbeat_throttle_interval: Float,
     ?task_timeout: duration?,
-    ?on_worker_run: Proc?
+    ?on_worker_run: Proc?,
+    ?start_workflow_client: Temporalio::Client
   ) -> Object? |
   [T] (
     singleton(Temporalio::Workflow::Definition) workflow,
@@ -37,7 +38,8 @@ module WorkflowUtils
     ?id_conflict_policy: Temporalio::WorkflowIDConflictPolicy::enum,
     ?max_heartbeat_throttle_interval: Float,
     ?task_timeout: duration?,
-    ?on_worker_run: Proc?
+    ?on_worker_run: Proc?,
+    ?start_workflow_client: Temporalio::Client
   ) { (Temporalio::Client::WorkflowHandle, Temporalio::Worker) -> T } -> T
 
   def assert_eventually_task_fail: (

--- a/temporalio/test/workflow_utils.rb
+++ b/temporalio/test/workflow_utils.rb
@@ -29,7 +29,8 @@ module WorkflowUtils
     max_heartbeat_throttle_interval: 60.0,
     task_timeout: nil,
     interceptors: [],
-    on_worker_run: nil
+    on_worker_run: nil,
+    start_workflow_client: client
   )
     worker = Temporalio::Worker.new(
       client:,
@@ -45,7 +46,7 @@ module WorkflowUtils
     )
     worker.run do
       on_worker_run&.call
-      handle = client.start_workflow(
+      handle = start_workflow_client.start_workflow(
         workflow,
         *args,
         id:,


### PR DESCRIPTION
## What was changed

* Added `always_create_workflow_spans` option to tracer and docs/README details to explain purpose. 
* Fixed test to account for the fact that signal can come before or after child _actually_ starts
