### PR TITLE
Fix auto_time_skipping_disabled

### DIFF
--- a/temporalio/lib/temporalio/testing/workflow_environment.rb
+++ b/temporalio/lib/temporalio/testing/workflow_environment.rb
@@ -322,7 +322,7 @@ module Temporalio
           raise 'Block required' unless block_given?
           return super unless supports_time_skipping?
 
-          already_disabled = @auto_time_skipping
+          already_disabled = !@auto_time_skipping
           @auto_time_skipping = false
           begin
             yield


### PR DESCRIPTION
## Checklist

1. Closes #259 

2. How was this tested:
  -  Made the change locally and it fixed the test I was writing in my application
  -  Wrote a test for this PR

Failing Before Fix
![CleanShot 2025-05-02 at 16 14 02@2x](https://github.com/user-attachments/assets/2091b94a-fbe9-4f0b-ab74-3b710ebe766d)

Passing After Fix
![CleanShot 2025-05-02 at 16 14 45@2x](https://github.com/user-attachments/assets/0838d5db-6ec7-4b59-820d-81b6b6e7fac4)

4. Any docs updates needed?
An example using this helper would be nice but probably out of scope for this PR
