### PR TITLE
Added application error category

### DIFF
--- a/temporalio/lib/temporalio/converters/failure_converter.rb
+++ b/temporalio/lib/temporalio/converters/failure_converter.rb
@@ -45,7 +45,8 @@ module Temporalio
             type: error.type,
             non_retryable: error.non_retryable,
             details: converter.to_payloads(error.details),
-            next_retry_delay: Internal::ProtoUtils.seconds_to_duration(error.next_retry_delay)
+            next_retry_delay: Internal::ProtoUtils.seconds_to_duration(error.next_retry_delay),
+            category: error.category
           )
         when Error::TimeoutError
           failure.timeout_failure_info = Api::Failure::V1::TimeoutFailureInfo.new(
@@ -132,7 +133,9 @@ module Temporalio
                     non_retryable: failure.application_failure_info.non_retryable,
                     next_retry_delay: Internal::ProtoUtils.duration_to_seconds(
                       failure.application_failure_info.next_retry_delay
-                    )
+                    ),
+                    category: Internal::ProtoUtils.enum_to_int(Api::Enums::V1::ApplicationErrorCategory,
+                                                               failure.application_failure_info.category)
                   )
                 elsif failure.timeout_failure_info
                   Error::TimeoutError.new(

--- a/temporalio/lib/temporalio/error/failure.rb
+++ b/temporalio/lib/temporalio/error/failure.rb
@@ -46,6 +46,9 @@ module Temporalio
       # @return [Float, nil] Delay in seconds before the next activity retry attempt.
       attr_reader :next_retry_delay
 
+      # @return [Category] Error category.
+      attr_reader :category
+
       # Create an application error.
       #
       # @param message [String] Error message.
@@ -53,17 +56,32 @@ module Temporalio
       # @param type [String, nil] Error type.
       # @param non_retryable [Boolean] Whether this error should be considered non-retryable.
       # @param next_retry_delay [Float, nil] Specific amount of time to delay before next retry.
-      def initialize(message, *details, type: nil, non_retryable: false, next_retry_delay: nil)
+      # @param category [Category] Error category.
+      def initialize(
+        message,
+        *details,
+        type: nil,
+        non_retryable: false,
+        next_retry_delay: nil,
+        category: Category::UNSPECIFIED
+      )
         super(message)
         @details = details
         @type = type
         @non_retryable = non_retryable
         @next_retry_delay = next_retry_delay
+        @category = category
       end
 
       # @return [Boolean] Inverse of {non_retryable}.
       def retryable?
         !@non_retryable
+      end
+
+      # Error category.
+      module Category
+        UNSPECIFIED = Api::Enums::V1::ApplicationErrorCategory::APPLICATION_ERROR_CATEGORY_UNSPECIFIED
+        BENIGN = Api::Enums::V1::ApplicationErrorCategory::APPLICATION_ERROR_CATEGORY_BENIGN
       end
     end
 

--- a/temporalio/lib/temporalio/internal/worker/activity_worker.rb
+++ b/temporalio/lib/temporalio/internal/worker/activity_worker.rb
@@ -279,8 +279,13 @@ module Temporalio
               )
             else
               # General failure
-              @scoped_logger.warn('Completing activity as failed')
-              @scoped_logger.warn(e)
+              log_level = if e.is_a?(Error::ApplicationError) && e.category == Error::ApplicationError::Category::BENIGN
+                            Logger::DEBUG
+                          else
+                            Logger::WARN
+                          end
+              @scoped_logger.add(log_level, 'Completing activity as failed')
+              @scoped_logger.add(log_level, e)
               Bridge::Api::ActivityResult::ActivityExecutionResult.new(
                 failed: Bridge::Api::ActivityResult::Failure.new(
                   failure: @worker.options.client.data_converter.to_failure(e)

--- a/temporalio/sig/temporalio/error/failure.rbs
+++ b/temporalio/sig/temporalio/error/failure.rbs
@@ -16,16 +16,25 @@ module Temporalio
       attr_reader type: String?
       attr_reader non_retryable: bool
       attr_reader next_retry_delay: duration?
+      attr_reader category: Category::enum
 
       def initialize: (
         String message,
         *Object? details,
         ?type: String?,
         ?non_retryable: bool,
-        ?next_retry_delay: duration?
+        ?next_retry_delay: duration?,
+        ?category: Category::enum
       ) -> void
 
       def retryable?: -> bool
+
+      module Category
+        type enum = Integer
+
+        UNSPECIFIED: enum
+        BENIGN: enum
+      end
     end
 
     class CanceledError < Failure


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added `category` field and associated enum to `ApplicationError`.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/614

## Checklist
<!--- add/delete as needed --->

1. Closes #242

2. How was this tested: added benign failure test case to `worker_activity_test.rb#test_failure`.