### PR TITLE
Make application error type default to unqualified type name

### DIFF
--- a/temporalio/lib/temporalio/converters/failure_converter.rb
+++ b/temporalio/lib/temporalio/converters/failure_converter.rb
@@ -86,7 +86,7 @@ module Temporalio
           )
         else
           failure.application_failure_info = Api::Failure::V1::ApplicationFailureInfo.new(
-            type: error.class.name
+            type: error.class.name.to_s.split('::').last
           )
         end
 

--- a/temporalio/test/worker_workflow_test.rb
+++ b/temporalio/test/worker_workflow_test.rb
@@ -417,12 +417,12 @@ class WorkerWorkflowTest < Test
     err = assert_raises(Temporalio::Error::WorkflowFailedError) { execute_workflow(TimerWorkflow, :timeout_stdlib) }
     assert_instance_of Temporalio::Error::ApplicationError, err.cause
     assert_equal 'execution expired', err.cause.message
-    assert_equal 'Timeout::Error', err.cause.type
+    assert_equal 'Error', err.cause.type
 
     err = assert_raises(Temporalio::Error::WorkflowFailedError) { execute_workflow(TimerWorkflow, :timeout_workflow) }
     assert_instance_of Temporalio::Error::ApplicationError, err.cause
     assert_equal 'execution expired', err.cause.message
-    assert_equal 'Timeout::Error', err.cause.type
+    assert_equal 'Error', err.cause.type
 
     err = assert_raises(Temporalio::Error::WorkflowFailedError) do
       execute_workflow(TimerWorkflow, :timeout_custom_info)
@@ -707,15 +707,15 @@ class WorkerWorkflowTest < Test
       execute_workflow(TaskFailureWorkflow, 1, workflow_failure_exception_types: [TaskFailureError1])
     end
     assert_equal 'one', err.cause.message
-    assert_equal 'WorkerWorkflowTest::TaskFailureError1', err.cause.type
+    assert_equal 'TaskFailureError1', err.cause.type
 
     # Fails workflow when configured on workflow, including inherited
     err = assert_raises(Temporalio::Error::WorkflowFailedError) { execute_workflow(TaskFailureWorkflow, 2) }
     assert_equal 'two', err.cause.message
-    assert_equal 'WorkerWorkflowTest::TaskFailureError2', err.cause.type
+    assert_equal 'TaskFailureError2', err.cause.type
     err = assert_raises(Temporalio::Error::WorkflowFailedError) { execute_workflow(TaskFailureWorkflow, 4) }
     assert_equal 'four', err.cause.message
-    assert_equal 'WorkerWorkflowTest::TaskFailureError4', err.cause.type
+    assert_equal 'TaskFailureError4', err.cause.type
 
     # Also supports stdlib errors
     err = assert_raises(Temporalio::Error::WorkflowFailedError) do


### PR DESCRIPTION
## What was changed

Do not qualify default `type` when converting from non-application-error to application error. We do not do this in other SDKs so we shouldn't here (even though it probably makes more sense in Ruby than any other).

## Checklist

1. Closes #294