### PR TITLE
Prevent using SDK runtimes/clients/workers across forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ opinions. Please communicate with us on [Slack](https://t.mp/slack) in the `#rub
   - [Rails](#rails)
     - [ActiveRecord](#activerecord)
     - [Lazy/Eager Loading](#lazyeager-loading)
+  - [Forking](#forking)
   - [Ractors](#ractors)
   - [Platform Support](#platform-support)
 - [Development](#development)
@@ -1201,6 +1202,16 @@ To resolve this, either always eagerly load (e.g. `config.eager_load = true`) or
 workflow at the top of the file.
 
 Note, this only affects non-production environments.
+
+### Forking
+
+Objects created with the Temporal Ruby SDK cannot be used across forks. This includes runtimes, clients, and workers. By
+default, using `Client.connect` uses `Runtime.default` which is lazily created. If it was already created on the parent,
+an exception will occur when trying to reuse it to create clients or workers in a forked child. Similarly any RPC
+invocation or worker execution inside of a forked child separate from where the runtime or client or worker were created
+will raise an exception.
+
+If forking must be used, make sure Temporal objects are only created _inside_ the fork.
 
 ### Ractors
 

--- a/temporalio/ext/src/runtime.rs
+++ b/temporalio/ext/src/runtime.rs
@@ -46,6 +46,7 @@ pub struct Runtime {
 
 #[derive(Clone)]
 pub(crate) struct RuntimeHandle {
+    pub(crate) pid: u32,
     pub(crate) core: Arc<CoreRuntime>,
     pub(crate) async_command_tx: Sender<AsyncCommand>,
 }
@@ -178,6 +179,7 @@ impl Runtime {
             channel();
         Ok(Self {
             handle: RuntimeHandle {
+                pid: std::process::id(),
                 core: Arc::new(core),
                 async_command_tx,
             },


### PR DESCRIPTION
## What was changed

* Add Rust code to track PID runtime was created on
* Add Rust checks to client create, client RPC call, worker create, and worker poll start to ensure same PID as runtime
* Added README clarifications

## Checklist

1. Closes #273
