### PR TITLE
Fix issue with high-contention mutex causing hung workflows

### DIFF
--- a/temporalio/lib/temporalio/converters/payload_converter/json_plain.rb
+++ b/temporalio/lib/temporalio/converters/payload_converter/json_plain.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'temporalio/api'
 require 'temporalio/converters/payload_converter/encoding'
+require 'temporalio/workflow'
 
 module Temporalio
   module Converters
@@ -28,15 +29,31 @@ module Temporalio
 
         # (see Encoding.to_payload)
         def to_payload(value, hint: nil) # rubocop:disable Lint/UnusedMethodArgument
-          Api::Common::V1::Payload.new(
-            metadata: { 'encoding' => ENCODING },
-            data: JSON.generate(value, @generate_options).b
-          )
+          # For generate and parse, if we are in a workflow, we need to do this outside of the durable scheduler since
+          # some things like the recent https://github.com/ruby/json/pull/832 may make illegal File.expand_path calls.
+          # And other future things may be slightly illegal in JSON generate/parse and we don't want to break everyone
+          # when it happens.
+          data = if Temporalio::Workflow.in_workflow?
+                   Temporalio::Workflow::Unsafe.durable_scheduler_disabled do
+                     JSON.generate(value, @generate_options).b
+                   end
+                 else
+                   JSON.generate(value, @generate_options).b
+                 end
+
+          Api::Common::V1::Payload.new(metadata: { 'encoding' => ENCODING }, data:)
         end
 
         # (see Encoding.from_payload)
         def from_payload(payload, hint: nil) # rubocop:disable Lint/UnusedMethodArgument
-          JSON.parse(payload.data, @parse_options)
+          # See comment in to_payload about why we have to do something different in workflow
+          if Temporalio::Workflow.in_workflow?
+            Temporalio::Workflow::Unsafe.durable_scheduler_disabled do
+              JSON.parse(payload.data, @parse_options)
+            end
+          else
+            JSON.parse(payload.data, @parse_options)
+          end
         end
       end
     end

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
@@ -64,11 +64,12 @@ module Temporalio
 
           def durable_scheduler_disabled(&)
             prev = Fiber.current_scheduler
-            illegal_call_tracing_disabled { Fiber.set_scheduler(nil) }
-            begin
+            # Imply illegal call tracing disabled
+            illegal_call_tracing_disabled do
+              Fiber.set_scheduler(nil)
               yield
             ensure
-              illegal_call_tracing_disabled { Fiber.set_scheduler(prev) }
+              Fiber.set_scheduler(prev)
             end
           end
 

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
@@ -63,7 +63,7 @@ module Temporalio
           end
 
           def durable_scheduler_disabled(&)
-            prev = Fiber.current_scheduler
+            prev = Fiber.scheduler
             # Imply illegal call tracing disabled
             illegal_call_tracing_disabled do
               Fiber.set_scheduler(nil)

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/replay_safe_logger.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/replay_safe_logger.rb
@@ -27,8 +27,11 @@ module Temporalio
               return true
             end
 
-            # Disable illegal call tracing for the log call
-            @instance.illegal_call_tracing_disabled { super }
+            # Disable scheduler since logs technically have local mutexes in them that cannot be done durably or they
+            # will block workflows
+            @instance.context.durable_scheduler_disabled do
+              super
+            end
           end
         end
       end

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/scheduler.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/scheduler.rb
@@ -141,7 +141,8 @@ module Temporalio
             unless @instance.io_enabled
               raise Workflow::NondeterminismError,
                     'Cannot perform IO from inside a workflow. If this is known to be safe, ' \
-                    'the code can be run in a Temporalio::Workflow::Unsafe.io_enabled block.'
+                    'the code can be run in a Temporalio::Workflow::Unsafe.durable_scheduler_disabled ' \
+                    'or Temporalio::Workflow::Unsafe.io_enabled block.'
             end
 
             # Use regular Ruby behavior of blocking this thread. There is no Ruby implementation of io_wait we can just

--- a/temporalio/lib/temporalio/workflow.rb
+++ b/temporalio/lib/temporalio/workflow.rb
@@ -555,6 +555,8 @@ module Temporalio
       # fiber scheduler and no workflow helpers will be available in the block. This is usually only needed in advanced
       # situations where a third party library does something like use "Timeout" in a way that shouldn't be made
       # durable.
+      #
+      # This implies {illegal_call_tracing_disabled}.
       def self.durable_scheduler_disabled(&)
         Workflow._current.durable_scheduler_disabled(&)
       end

--- a/temporalio/test/worker_workflow_test.rb
+++ b/temporalio/test/worker_workflow_test.rb
@@ -571,6 +571,10 @@ class WorkerWorkflowTest < Test
   def test_deadlock
     # TODO(cretz): Do we need more tests? This attempts to interrupt the workflow via a raise on the thread, but do we
     # need to concern ourselves with what happens if that's accidentally swallowed?
+    # TODO(cretz): Note that often mutexes and cond vars are not subject to Timeout.timeout which means they can not be
+    # interrupted by deadlock detection
+    # TODO(cretz): Note that a thread.join that does get deadlock detected may crash the VM on exit with a
+    # "[BUG] pthread_mutex_lock: Invalid argument (EINVAL)"
     # TODO(cretz): Decrease deadlock detection timeout to make test faster? It is 4s now because shutdown waits on
     # second task.
     execute_workflow(DeadlockWorkflow) do |handle|


### PR DESCRIPTION
## What was changed

The main issue is there was a case where, in high-contention situations, a logger's mutex will block for a short little bit. Since we make mutexes durable, we completed the workflow task while the mutex was waiting and never resume the workflow to wake it up. We've made a couple of changes to help here.

<details>

<summary>Code to replicate</summary>

```ruby
# frozen_string_literal: true

require 'logger'
require 'temporalio/client'
require 'temporalio/testing'
require 'temporalio/worker'

workflow_count = 500

logger = Logger.new($stdout)

class HangingTimersWorkflow < Temporalio::Workflow::Definition
  workflow_query_attr_reader :done

  def execute
    Temporalio::Workflow.logger.info 'Started demo timers workflow'
    5.times.each do |i|
      Temporalio::Workflow.logger.info("Timer fut #{i}")
      timer_fut(seconds: 1).wait
    end
    Temporalio::Workflow.logger.info 'Finished demo timers workflow'
  end

  def timer_fut(seconds:)
    Temporalio::Workflow::Future.new do
      Temporalio::Workflow.logger.info 'Timer starting'
      Temporalio::Workflow.sleep(seconds)
      Temporalio::Workflow.logger.info 'Timer finished'
    end.tap do
      # Temporalio::Workflow.logger.info "Timer created"
    end
  end
end

logger.info('Starting dev server...')
Temporalio::Testing::WorkflowEnvironment.start_local(logger:, ui: true, ui_port: 8233) do |env|
  # Start them all
  logger.info("Starting #{workflow_count} workflows...")
  handles = workflow_count.times.map do |i|
    env.client.start_workflow(HangingTimersWorkflow, id: "wf-#{i}", task_queue: 'default')
  end

  # Run worker
  logger.info('Starting worker...')
  worker = Temporalio::Worker.new(client: env.client, task_queue: 'default', workflows: [HangingTimersWorkflow])
  worker.run(shutdown_signals: ['SIGINT']) do
    # Every couple of seconds, let's describe all handles until they are all done
    logger.info('Now waiting')
    loop do
      logger.info('Tick')
      sleep(2)
      running_count = handles.count { |h| h.describe.close_time.nil? }
      logger.info("Of the original #{workflow_count}, #{running_count} still running")
      break if running_count.zero?
    end
  end
ensure
  logger.info('Stopping, press Enter to exit...')
  STDIN.gets
end
```

</details>

Changes:

* Use system/default scheduler for logging calls (this is the primary fix for the bug)
* Make `durable_scheduler_disabled` imply `illegal_call_tracing_disabled` and update usages accordingly
* Add note in README for workflow logic constraints saying that technically `puts` or non-workflow logger use at high-contention can cause hung workflows
* Add big sections to README to explain durable scheduler and illegal call tracing and how to work around them
* Updated JSON converter to skip scheduler during conversion
  * This was actually unrelated to this issue, but as of a recent change at https://github.com/ruby/json/pull/832, the what-we-consider-illegal `File.expand_path` is now invoked at runtime during deprecation warning. So we decided that JSON conversion and any future stdlib changes inside it can skip the illegal call checks
