### PR TITLE
Add some require calls for newer code

### DIFF
--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/externally_immutable_hash.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/externally_immutable_hash.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'delegate'
+
 module Temporalio
   module Internal
     module Worker

--- a/temporalio/lib/temporalio/workflow.rb
+++ b/temporalio/lib/temporalio/workflow.rb
@@ -2,6 +2,7 @@
 
 require 'random/formatter'
 require 'temporalio/error'
+require 'temporalio/internal/worker/workflow_instance'
 require 'temporalio/priority'
 require 'temporalio/workflow/activity_cancellation_type'
 require 'temporalio/workflow/child_workflow_cancellation_type'


### PR DESCRIPTION
## What was changed

Added some `require` calls.

We can't catch these well in our tests due to how Ruby caches imports, so it only fails on certain samples that use minimal imports. And even then, it's only certain samples. This was found when doing release sanity tests. We can look into possibly including some sample smoke tests in CI, but it still won't catch every needed require (and it's not a bug per se, a user just has to import a bit more sometimes if we don't do it for them). Just an unfortunate Ruby situation where we can't tell which requires are needed exactly.
