### PR TITLE
Activity reset support

### DIFF
--- a/temporalio/lib/temporalio/client/async_activity_handle.rb
+++ b/temporalio/lib/temporalio/client/async_activity_handle.rb
@@ -29,6 +29,7 @@ module Temporalio
       # @param details [Array<Object>] Details of the heartbeat.
       # @param detail_hints [Array<Object>, nil] Converter hints for the details.
       # @param rpc_options [RPCOptions, nil] Advanced RPC options.
+      # @raise [Error::AsyncActivityCanceledError] If the activity was canceled, paused, and/or reset.
       def heartbeat(*details, detail_hints: nil, rpc_options: nil)
         @client._impl.heartbeat_async_activity(Interceptor::HeartbeatAsyncActivityInput.new(
                                                  task_token_or_id_reference:,

--- a/temporalio/lib/temporalio/error.rb
+++ b/temporalio/lib/temporalio/error.rb
@@ -97,9 +97,13 @@ module Temporalio
 
     # Error that occurs when an async activity handle tries to heartbeat and the activity is marked as canceled.
     class AsyncActivityCanceledError < Error
+      # @return [Activity::CancellationDetails]
+      attr_reader :details
+
       # @!visibility private
-      def initialize
+      def initialize(details)
         super('Activity canceled')
+        @details = details
       end
     end
 

--- a/temporalio/sig/temporalio/error.rbs
+++ b/temporalio/sig/temporalio/error.rbs
@@ -35,6 +35,16 @@ module Temporalio
       def initialize: -> void
     end
 
+    class ScheduleAlreadyRunningError < Error
+      def initialize: -> void
+    end
+
+    class AsyncActivityCanceledError < Error
+      attr_reader details: Activity::CancellationDetails
+
+      def initialize: (Activity::CancellationDetails details) -> void
+    end
+
     class RPCError < Error
       attr_reader code: Code::enum
 


### PR DESCRIPTION
## What was changed

* Leaned on most of the support already added as part of pause
* Added test to confirm reset reports details properly
* Properly added details to async handle heartbeat error

## Checklist

1. Closes #254