### PR TITLE
Added first_execution_run_id to Workflow::Info

### DIFF
--- a/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
@@ -125,6 +125,7 @@ module Temporalio
               continued_run_id: ProtoUtils.string_or(@init_job.continued_from_execution_run_id),
               cron_schedule: ProtoUtils.string_or(@init_job.cron_schedule),
               execution_timeout: ProtoUtils.duration_to_seconds(@init_job.workflow_execution_timeout),
+              first_execution_run_id: @init_job.first_execution_run_id,
               headers: ProtoUtils.headers_from_proto_map(@init_job.headers, @payload_converter) || {},
               last_failure: if @init_job.continued_failure
                               @failure_converter.from_failure(@init_job.continued_failure, @payload_converter)

--- a/temporalio/lib/temporalio/workflow/info.rb
+++ b/temporalio/lib/temporalio/workflow/info.rb
@@ -7,6 +7,7 @@ module Temporalio
       :continued_run_id,
       :cron_schedule,
       :execution_timeout,
+      :first_execution_run_id,
       :headers,
       :last_failure,
       :last_result,
@@ -35,6 +36,8 @@ module Temporalio
     #   @return [String, nil] Cron schedule if applicable.
     # @!attribute execution_timeout
     #   @return [Float, nil] Execution timeout for the workflow.
+    # @!attribute first_execution_run_id
+    #   @return [String] The very first run ID the workflow ever had, following continuation chains.
     # @!attribute headers
     #   @return [Hash<String, Api::Common::V1::Payload>] Headers.
     # @!attribute last_failure

--- a/temporalio/sig/temporalio/workflow/info.rbs
+++ b/temporalio/sig/temporalio/workflow/info.rbs
@@ -5,6 +5,7 @@ module Temporalio
       attr_reader continued_run_id: String?
       attr_reader cron_schedule: String?
       attr_reader execution_timeout: Float?
+      attr_reader first_execution_run_id: String
       attr_reader headers: Hash[String, untyped]
       attr_reader last_failure: Exception?
       attr_reader last_result: Object?
@@ -26,6 +27,7 @@ module Temporalio
         continued_run_id: String?,
         cron_schedule: String?,
         execution_timeout: Float?,
+        first_execution_run_id: String,
         headers: Hash[String, untyped],
         last_failure: Exception?,
         last_result: Object?,

--- a/temporalio/test/worker_workflow_test.rb
+++ b/temporalio/test/worker_workflow_test.rb
@@ -4,6 +4,7 @@ require 'base64_codec'
 require 'gc_utils'
 require 'net/http'
 require 'temporalio/client'
+require 'temporalio/error'
 require 'temporalio/testing'
 require 'temporalio/worker'
 require 'temporalio/workflow'
@@ -542,6 +543,10 @@ class WorkerWorkflowTest < Test
       return past_run_ids if past_run_ids.size == 5
 
       past_run_ids << Temporalio::Workflow.info.continued_run_id if Temporalio::Workflow.info.continued_run_id
+      if !past_run_ids.empty? && Temporalio::Workflow.info.first_execution_run_id != past_run_ids.first
+        raise Temporalio::Error::ApplicationError.new('wrong first_execution_run_id', non_retryable: true)
+      end
+
       raise Temporalio::Workflow::ContinueAsNewError.new(
         past_run_ids,
         memo: { past_run_id_count: past_run_ids.size },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added `first_execution_run_id` to `Workflow::Info`.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/29

## Checklist
<!--- add/delete as needed --->

1. Closes #311

2. How was this tested: modified `test_continue_as_new` in `temporalio/test/worker_workflow_test.rb`