### PR TITLE
Added retry policy to activity info

### DIFF
--- a/temporalio/lib/temporalio/activity/info.rb
+++ b/temporalio/lib/temporalio/activity/info.rb
@@ -13,6 +13,7 @@ module Temporalio
       :heartbeat_timeout,
       :local?,
       :priority,
+      :retry_policy,
       :raw_heartbeat_details,
       :schedule_to_close_timeout,
       :scheduled_time,
@@ -42,6 +43,10 @@ module Temporalio
     #   @return [Boolean] Whether the activity is a local activity or not.
     # @!attribute priority
     #   @return [Priority] The priority of this activity.
+    # @!attribute retry_policy
+    #   @return [RetryPolicy, nil] Retry policy for the activity. Note that the server may have set a different policy
+    #     than the one provided when scheduling the activity. If the value is None, it means the server didn't send
+    #     information about retry policy (e.g. due to old server version), but it may still be defined server-side.
     # @!attribute raw_heartbeat_details
     #   @return [Array<Converter::RawValue>] Raw details from the last heartbeat of the last attempt. Can use
     #     {heartbeat_details} to get lazily-converted values.

--- a/temporalio/lib/temporalio/internal/worker/activity_worker.rb
+++ b/temporalio/lib/temporalio/internal/worker/activity_worker.rb
@@ -185,6 +185,7 @@ module Temporalio
               payloads = codec.decode(payloads) if codec
               payloads.map { |p| Temporalio::Converters::RawValue.new(p) }
             end,
+            retry_policy: (RetryPolicy._from_proto(start.retry_policy) if start.retry_policy),
             schedule_to_close_timeout: Internal::ProtoUtils.duration_to_seconds(start.schedule_to_close_timeout),
             scheduled_time: Internal::ProtoUtils.timestamp_to_time(start.scheduled_time) || raise, # Never nil
             start_to_close_timeout: Internal::ProtoUtils.duration_to_seconds(start.start_to_close_timeout),

--- a/temporalio/lib/temporalio/testing/activity_environment.rb
+++ b/temporalio/lib/temporalio/testing/activity_environment.rb
@@ -25,6 +25,7 @@ module Temporalio
           local?: false,
           priority: Temporalio::Priority.default,
           raw_heartbeat_details: [],
+          retry_policy: RetryPolicy.new,
           schedule_to_close_timeout: 1.0,
           scheduled_time: Time.at(0),
           start_to_close_timeout: 1.0,

--- a/temporalio/sig/temporalio/activity/info.rbs
+++ b/temporalio/sig/temporalio/activity/info.rbs
@@ -9,6 +9,7 @@ module Temporalio
       attr_reader local?: bool
       attr_reader priority: Temporalio::Priority
       attr_reader raw_heartbeat_details: Array[Converters::RawValue]
+      attr_reader retry_policy: RetryPolicy?
       attr_reader schedule_to_close_timeout: Float?
       attr_reader scheduled_time: Time
       attr_reader start_to_close_timeout: Float?
@@ -29,6 +30,7 @@ module Temporalio
         local?: bool,
         priority: Temporalio::Priority?,
         raw_heartbeat_details: Array[Converters::RawValue],
+        retry_policy: RetryPolicy?,
         schedule_to_close_timeout: Float?,
         scheduled_time: Time,
         start_to_close_timeout: Float?,

--- a/temporalio/test/test.rb
+++ b/temporalio/test/test.rb
@@ -143,7 +143,8 @@ class Test < Minitest::Test
 
     def initialize
       # Start workflow env for an existing server if env vars present
-      if ENV['TEMPORAL_TEST_CLIENT_TARGET_HOST'].blank?
+      target_host = ENV['TEMPORAL_TEST_CLIENT_TARGET_HOST']
+      if target_host.nil? || target_host.empty?
         @server = Temporalio::Testing::WorkflowEnvironment.start_local(
           logger: Logger.new($stdout),
           dev_server_extra_args: [
@@ -162,7 +163,7 @@ class Test < Minitest::Test
         end
       else
         client = Temporalio::Client.connect(
-          ENV.fetch('TEMPORAL_TEST_CLIENT_TARGET_HOST'),
+          target_host,
           ENV['TEMPORAL_TEST_CLIENT_TARGET_NAMESPACE'] || 'default',
           logger: Logger.new($stdout)
         )

--- a/temporalio/test/test.rb
+++ b/temporalio/test/test.rb
@@ -143,8 +143,8 @@ class Test < Minitest::Test
 
     def initialize
       # Start workflow env for an existing server if env vars present
-      target_host = ENV['TEMPORAL_TEST_CLIENT_TARGET_HOST']
-      if target_host.nil? || target_host.empty?
+      target_host = ENV.fetch('TEMPORAL_TEST_CLIENT_TARGET_HOST', '')
+      if target_host.empty?
         @server = Temporalio::Testing::WorkflowEnvironment.start_local(
           logger: Logger.new($stdout),
           dev_server_extra_args: [

--- a/temporalio/test/worker_activity_test.rb
+++ b/temporalio/test/worker_activity_test.rb
@@ -264,9 +264,9 @@ class WorkerActivityTest < Test
     assert_equal 1, info.attempt
     refute_nil info.current_attempt_scheduled_time
     assert_equal false, info.local?
+    refute_nil info.retry_policy
     refute_nil info.schedule_to_close_timeout
     refute_nil info.scheduled_time
-    refute_nil info.current_attempt_scheduled_time
     refute_nil info.start_to_close_timeout
     refute_nil info.started_time
     refute_nil info.task_queue


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Added retry policy to activity info.
- Upgraded Core to latest version, which is needed for activity retry policy to be filled in correctly.
- Small correction to test base class so it doesn't crash when target host env var is nil.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/615

## Checklist
<!--- add/delete as needed --->

1. Closes #248

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added assertion to `test_info` in `test/worker_activity_test.rb`.