### PR TITLE
Added option to set local activity summary. Added activity summary tests

### DIFF
--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
@@ -130,6 +130,7 @@ module Temporalio
           def execute_local_activity(
             activity,
             *args,
+            summary:,
             schedule_to_close_timeout:,
             schedule_to_start_timeout:,
             start_to_close_timeout:,
@@ -157,6 +158,7 @@ module Temporalio
               Temporalio::Worker::Interceptor::Workflow::ExecuteLocalActivityInput.new(
                 activity:,
                 args:,
+                summary:,
                 schedule_to_close_timeout:,
                 schedule_to_start_timeout:,
                 start_to_close_timeout:,

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/outbound_implementation.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/outbound_implementation.rb
@@ -114,7 +114,8 @@ module Temporalio
                     local_retry_threshold: ProtoUtils.seconds_to_duration(input.local_retry_threshold),
                     attempt: do_backoff&.attempt || 0,
                     original_schedule_time: do_backoff&.original_schedule_time
-                  )
+                  ),
+                  user_metadata: ProtoUtils.to_user_metadata(input.summary, nil, @instance.payload_converter)
                 )
               )
               seq

--- a/temporalio/lib/temporalio/worker/interceptor.rb
+++ b/temporalio/lib/temporalio/worker/interceptor.rb
@@ -228,6 +228,7 @@ module Temporalio
         ExecuteLocalActivityInput = Data.define(
           :activity,
           :args,
+          :summary,
           :schedule_to_close_timeout,
           :schedule_to_start_timeout,
           :start_to_close_timeout,

--- a/temporalio/lib/temporalio/workflow.rb
+++ b/temporalio/lib/temporalio/workflow.rb
@@ -208,14 +208,16 @@ module Temporalio
     #
     # @param activity [Class<Activity::Definition>, Symbol, String] Activity definition class or name.
     # @param args [Array<Object>] Arguments to the activity.
+    # @param summary [String, nil] Single-line summary for this activity that may appear in CLI/UI. This can be in
+    #   single-line Temporal markdown format. This is currently experimental.
     # @param schedule_to_close_timeout [Float, nil] Max amount of time the activity can take from first being scheduled
     #   to being completed before it times out. This is inclusive of all retries.
     # @param schedule_to_start_timeout [Float, nil] Max amount of time the activity can take to be started from first
     #   being scheduled.
     # @param start_to_close_timeout [Float, nil] Max amount of time a single activity run can take from when it starts
     #   to when it completes. This is per retry.
-    # @param retry_policy [RetryPolicy] How an activity is retried on failure. If unset, a server-defined default is
-    #   used. Set maximum attempts to 1 to disable retries.
+    # @param retry_policy [RetryPolicy, nil] How an activity is retried on failure. If unset, a default policy is used.
+    #   Set maximum attempts to 1 to disable retries.
     # @param local_retry_threshold [Float, nil] If the activity is retrying and backoff would exceed this value, a timer
     #   is scheduled and the activity is retried after. Otherwise, backoff will happen internally within the task.
     #   Defaults to 1 minute.
@@ -238,6 +240,7 @@ module Temporalio
     def self.execute_local_activity(
       activity,
       *args,
+      summary: nil,
       schedule_to_close_timeout: nil,
       schedule_to_start_timeout: nil,
       start_to_close_timeout: nil,
@@ -251,7 +254,7 @@ module Temporalio
     )
       _current.execute_local_activity(
         activity, *args,
-        schedule_to_close_timeout:, schedule_to_start_timeout:, start_to_close_timeout:,
+        summary:, schedule_to_close_timeout:, schedule_to_start_timeout:, start_to_close_timeout:,
         retry_policy:, local_retry_threshold:, cancellation:, cancellation_type:,
         activity_id:, arg_hints:, result_hint:
       )

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance/context.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance/context.rbs
@@ -48,6 +48,7 @@ module Temporalio
           def execute_local_activity: (
             singleton(Activity::Definition) | Symbol | String activity,
             *Object? args,
+            summary: String?,
             schedule_to_close_timeout: duration?,
             schedule_to_start_timeout: duration?,
             start_to_close_timeout: duration?,

--- a/temporalio/sig/temporalio/worker/interceptor.rbs
+++ b/temporalio/sig/temporalio/worker/interceptor.rbs
@@ -175,6 +175,7 @@ module Temporalio
         class ExecuteLocalActivityInput
           attr_reader activity: String
           attr_reader args: Array[Object?]
+          attr_reader summary: String?
           attr_reader schedule_to_close_timeout: duration?
           attr_reader schedule_to_start_timeout: duration?
           attr_reader start_to_close_timeout: duration?
@@ -190,6 +191,7 @@ module Temporalio
           def initialize: (
             activity: String,
             args: Array[Object?],
+            summary: String?,
             schedule_to_close_timeout: duration?,
             schedule_to_start_timeout: duration?,
             start_to_close_timeout: duration?,

--- a/temporalio/sig/temporalio/workflow.rbs
+++ b/temporalio/sig/temporalio/workflow.rbs
@@ -62,6 +62,7 @@ module Temporalio
     def self.execute_local_activity: (
       singleton(Activity::Definition) | Symbol | String activity,
       *Object? args,
+      ?summary: String?,
       ?schedule_to_close_timeout: duration?,
       ?schedule_to_start_timeout: duration?,
       ?start_to_close_timeout: duration?,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Added option to set local activity summary.
- Added activity and local activity summary tests.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/637

## Checklist
<!--- add/delete as needed --->

1. Closes #298

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added `test_activity_summary` and `test_local_activity_summary` to `test/worker_workflow_activity_test.rb`.