### PR TITLE
Allow Thread::Mutex in RSpec mocks

### DIFF
--- a/temporalio/lib/temporalio/worker/illegal_workflow_call_validator.rb
+++ b/temporalio/lib/temporalio/worker/illegal_workflow_call_validator.rb
@@ -44,7 +44,10 @@ module Temporalio
       def self.known_safe_mutex_validator
         @known_safe_mutex_validator ||= IllegalWorkflowCallValidator.new do
           # Only Google Protobuf use of Mutex is known to be safe, fail unless any caller location path has protobuf
-          raise 'disallowed' unless caller_locations&.any? { |loc| loc.path&.include?('google/protobuf/') }
+          # Also allow Mutex for RSpec mocks
+          raise 'disallowed' if caller_locations&.none? do |loc|
+            loc.path&.match?(%r{google/protobuf/|rspec/})
+          end
         end
       end
 


### PR DESCRIPTION
## What was changed
Updated known_safe_mutex_validator to allow Mutex in RSpec mocks.

## Why?
When testing workflows with RSpec it is useful to write some expectations on workflows. 
As rspec mocks use mutex, workflow specs fail, even if workflow is not using any mutex.

https://github.com/rspec/rspec/blob/rspec-mocks-v3.13.5/rspec-mocks/lib/rspec/mocks/proxy.rb#L27