### PR TITLE
bugfix: Mark json value as binary before assigning to  field in payload

### DIFF
--- a/temporalio/lib/temporalio/converters/payload_converter/json_protobuf.rb
+++ b/temporalio/lib/temporalio/converters/payload_converter/json_protobuf.rb
@@ -22,7 +22,7 @@ module Temporalio
 
           Api::Common::V1::Payload.new(
             metadata: { 'encoding' => ENCODING, 'messageType' => value.class.descriptor.name },
-            data: value.to_json
+            data: value.to_json.b
           )
         end
 


### PR DESCRIPTION
## What was changed
Mark the JSON value as binary before assigning to `data` key in `Api::Common::V1::Payload`.

## Why?

Ruby protobuf uses ASCII-8BIT encoding for `bytes` fields in proto messages. The protobuf gem will attend to force the encoding from UTF8 to ASCII-8BIT when assigning the value, but when UTF8 has multi-byte characters (like an emdash), it fails.

LLM's _love_ the emdash, so when I was attempting to switch from coinbase's library to this one, I hit issues with the encoding problem. I had commented on this PR on Coinbase's PR which had the same exact problem: https://github.com/coinbase/temporal-ruby/pull/264

I added tests to demonstrate the problem, if you remove the `.b` in the changes you'll see them fail.
