### PR TITLE
Support binary values in gRPC metadata

### DIFF
--- a/temporalio/ext/src/client.rs
+++ b/temporalio/ext/src/client.rs
@@ -281,7 +281,7 @@ fn partition_grpc_headers(ruby: &Ruby, hash: RHash) -> Result<GrpcHeaders, Error
                     format!("Value for metadata key {key} must be ASCII-8BIT"),
                 ));
             }
-            binary_headers.insert(key, unsafe { value.as_slice() }.to_vec());
+            binary_headers.insert(key, unsafe { value.as_slice().to_vec() });
         } else {
             let value = value.to_string().map_err(|err| {
                 Error::new(


### PR DESCRIPTION
## What was changed

Need to support `-bin` values as binary values in gRPC

## Checklist

1. Closes #329