### PR TITLE
feat: add has_last_result? to WorkflowInfo

### DIFF
--- a/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
@@ -133,6 +133,7 @@ module Temporalio
               last_result: if @init_job.last_completion_result
                              @payload_converter.from_payloads(@init_job.last_completion_result).first
                            end,
+              has_last_result?: !@init_job.last_completion_result.nil?,
               namespace: details.namespace,
               parent: if @init_job.parent_workflow_info
                         Workflow::Info::ParentInfo.new(

--- a/temporalio/lib/temporalio/workflow/info.rb
+++ b/temporalio/lib/temporalio/workflow/info.rb
@@ -11,6 +11,7 @@ module Temporalio
       :headers,
       :last_failure,
       :last_result,
+      :has_last_result?,
       :namespace,
       :parent,
       :priority,
@@ -44,6 +45,9 @@ module Temporalio
     #   @return [Exception, nil] Failure if this workflow run is a continuation of a failure.
     # @!attribute last_result
     #   @return [Object, nil] Successful result if this workflow is a continuation of a success.
+    # @!attribute has_last_result?
+    #   @return [Boolean] Successful result if this workflow is a continuation of a success.
+
     # @!attribute namespace
     #   @return [String] Namespace for the workflow.
     # @!attribute parent

--- a/temporalio/sig/temporalio/workflow/info.rbs
+++ b/temporalio/sig/temporalio/workflow/info.rbs
@@ -9,6 +9,7 @@ module Temporalio
       attr_reader headers: Hash[String, untyped]
       attr_reader last_failure: Exception?
       attr_reader last_result: Object?
+      attr_reader has_last_result?: bool
       attr_reader namespace: String
       attr_reader parent: ParentInfo?
       attr_reader priority: Temporalio::Priority
@@ -31,6 +32,7 @@ module Temporalio
         headers: Hash[String, untyped],
         last_failure: Exception?,
         last_result: Object?,
+        has_last_result?: bool,
         namespace: String,
         parent: ParentInfo?,
         priority: Temporalio::Priority?,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added `has_last_result?` to determine if there was a previous workflow result

## Why?
Adding `has_last_result?` allow to differentiate between no previous result and a `nil` previous result.

This was the same approach taken by the Python SDK https://github.com/temporalio/sdk-python/pull/1067 to differentiate between no previous result and a `nil`/`None` result. I think this makes sense, but unsure if there's a more idiomatic Ruby way of approaching this.

## Checklist
<!--- add/delete as needed --->

1. Closes #281 

2. How was this tested:
Added unit tests using `last_failure`, `last_result` and `has_last_result?`. These tests were adapted from the Python SDK tests.

3. Any docs updates needed?
I believe the YARD docs should be sufficient
