### PR TITLE
chore: update unsafe io test to look for closing html tag

### DIFF
--- a/temporalio/test/worker_workflow_test.rb
+++ b/temporalio/test/worker_workflow_test.rb
@@ -2391,11 +2391,11 @@ class WorkerWorkflowTest < Test
 
     # Allowed when enabled narrowly inside workflow
     res = execute_workflow(UnsafeIOWorkflow, true)
-    assert_includes res, '<html>'
+    assert_includes res, '</html>'
 
     # Allowed when enabled at worker level
     res = execute_workflow(UnsafeIOWorkflow, false, unsafe_workflow_io_enabled: true)
-    assert_includes res, '<html>'
+    assert_includes res, '</html>'
   end
 
   class MissingLocalActivityWorkflow < Temporalio::Workflow::Definition


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Update unsafe io test to look for closing tag in `example.com` HTML

## Why?
It appears that `example.com` changed the HTML to include `lang="en"` so the assertion now fails. See https://github.com/temporalio/sdk-ruby/pull/351, https://github.com/temporalio/sdk-ruby/pull/350

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
`unsafe_io` test should pass now

3. Any docs updates needed?
N/A
