### PR TITLE
VLN-464: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -5,6 +5,10 @@ on:
       - main
       - "releases/*"
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build-platform-gems:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
       - "releases/*"
 
+permissions:
+  contents: read
+
 jobs:
   build-lint-test:
     strategy:

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -3,6 +3,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-bench:
     runs-on: ubuntu-latest-4-cores


### PR DESCRIPTION
## Summary

- `.github/workflows/build-gems.yml`: Added a workflow-level permissions block granting read access to repository contents and write access to GitHub Actions so artifact upload/download continues to work while limiting other scopes.
- `.github/workflows/ci.yml`: Declared workflow-level permissions limiting the GITHUB_TOKEN to read-only access for repository contents, which is sufficient for checkout and downloading protoc assets.
- `.github/workflows/run-bench.yml`: Added workflow-level permissions restricting the GITHUB_TOKEN to read-only repository contents since the job only checks out code and runs benches.