### PR TITLE
Fix for macOS OpenSSL cert validation issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,16 @@ jobs:
         with:
           submodules: recursive
 
+      # This is a temporary fix until Ruby 3.4.8 comes out.
+      #
+      # Per https://github.com/ruby/openssl/issues/949 (by way of
+      # https://github.com/rails/rails/issues/55886), newer Ruby + OpenSSL has an
+      # issue on macOS. This works around it until next Ruby release.
+      - name: Fixate OpenSSL (macos + 3.4 only)
+        if: ${{ matrix.os == 'macos-latest' && matrix.rubyVersion == '3.4' }}
+        shell: bash
+        run: echo "RUBY_CONFIGURE_OPTS=--with-openssl-dir=$(brew --prefix openssl@3.5)" >> $GITHUB_ENV
+
       - name: Setup Ruby and Rust
         uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:

--- a/temporalio/Gemfile
+++ b/temporalio/Gemfile
@@ -12,6 +12,9 @@ group :development do
   gem 'grpc', '~> 1.69'
   gem 'grpc-tools', '~> 1.69'
   gem 'minitest'
+  # Have to explicitly depend on openssl for macos issue in GH CI described at
+  # https://github.com/rails/rails/issues/55886 until 3.4.8 is released
+  gem 'openssl'
   # We are intentionally not pinning OTel versions here so that CI tests the latest. This also means that the OTel
   # contrib library also does not require specific versions, we are relying on the compatibility rigor of OTel.
   gem 'opentelemetry-api'

--- a/temporalio/rbs_collection.lock.yaml
+++ b/temporalio/rbs_collection.lock.yaml
@@ -37,10 +37,6 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: benchmark
-  version: '0'
-  source:
-    type: stdlib
 - name: bigdecimal
   version: '0'
   source:
@@ -117,6 +113,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: openssl
+  version: '0'
+  source:
+    type: stdlib
 - name: optparse
   version: '0'
   source:
@@ -142,6 +142,10 @@ gems:
   source:
     type: stdlib
 - name: singleton
+  version: '0'
+  source:
+    type: stdlib
+- name: socket
   version: '0'
   source:
     type: stdlib

--- a/temporalio/test/sig/test.rbs
+++ b/temporalio/test/sig/test.rbs
@@ -19,7 +19,7 @@ class Test < Minitest::Test
 
   def run_in_background: { (?) -> untyped } -> (Thread | Fiber)
 
-  def find_free_port: -> String
+  def find_free_port: -> Integer
   def assert_no_schedules: -> void
   def delete_schedules: (*String ids) -> void
 

--- a/temporalio/test/test.rb
+++ b/temporalio/test/test.rb
@@ -111,7 +111,7 @@ class Test < Minitest::Test
   end
 
   def find_free_port
-    socket = TCPServer.new('127.0.0.1', 0)
+    socket = TCPServer.new('127.0.0.1', 0) # steep:ignore
     port = socket.addr[1]
     socket.close
     port


### PR DESCRIPTION
## What was changed

There is an issue validating certs on macOS for Ruby 3.4. This works around the issue until Ruby 3.4.8 is released which will have the proper fix. Not linking other issues here in description, see comment in GH workflow file for more details.

Issue often appears like:

> SSL_connect returned=1 errno=0 peeraddr=23.215.0.136:443 state=error: certificate verify failed (unable to get certificate CRL) {attempt: 1, namespace: "default", run_id: "019a5f30-11ce-7a64-9d1b-f00847d4e753", task_queue: "tq-b314ee42-8a52-439c-be49-61c838faa3ce", workflow_id: "wf-aea0f2b7-ebae-4836-8a59-485d1c01487d", workflow_type: "UnsafeIOWorkflow"} (OpenSSL::SSL::SSLError)