### PR TITLE
Disable durable scheduler for more OTel calls

### DIFF
--- a/temporalio/sig/temporalio/contrib/open_telemetry.rbs
+++ b/temporalio/sig/temporalio/contrib/open_telemetry.rbs
@@ -29,6 +29,7 @@ module Temporalio
         class WorkflowInbound < Worker::Interceptor::Workflow::Inbound
           def initialize: (TracingInterceptor root, Worker::Interceptor::Workflow::Inbound next_interceptor) -> void
 
+          def _attach_context: (Hash[String, untyped] headers) -> void
           def _links_from_headers: (Hash[String, untyped] headers) -> Array[untyped]
         end
 


### PR DESCRIPTION
## What was changed

We already disable durable scheduler for the obvious possibly-non-deterministic OTel calls, but sadly some libraries (like [DataDog](https://github.com/DataDog/dd-trace-rb/blob/f88393d0571806b9980bb2cf5066eba60cfea177/lib/datadog/opentelemetry/api/context.rb#L184)) monkey patch `Context.current` which may make illegal calls, and accessing current context is done for most OTel calls.

So this issue disables durable scheduler for more OTel work and adds a test for a monkey patch of `Context.current` that does illegal things

## Checklist

1. Closes #359