### PR TITLE
Add replaying_history_events? to allow logging in queries and validators

### DIFF
--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
@@ -242,6 +242,10 @@ module Temporalio
             @instance.replaying
           end
 
+          def replaying_history_events?
+            @instance.replaying && !@instance.in_query_or_validator
+          end
+
           def search_attributes
             @instance.search_attributes
           end

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/replay_safe_logger.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/replay_safe_logger.rb
@@ -23,7 +23,8 @@ module Temporalio
           end
 
           def add(...)
-            if !@replay_safety_disabled && Temporalio::Workflow.in_workflow? && Temporalio::Workflow::Unsafe.replaying?
+            if !@replay_safety_disabled && Temporalio::Workflow.in_workflow? &&
+               Temporalio::Workflow::Unsafe.replaying_history_events?
               return true
             end
 

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/replay_safe_metric.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/replay_safe_metric.rb
@@ -9,7 +9,8 @@ module Temporalio
         # Wrapper for a metric that does not log on replay.
         class ReplaySafeMetric < SimpleDelegator
           def record(value, additional_attributes: nil)
-            return if Temporalio::Workflow.in_workflow? && Temporalio::Workflow::Unsafe.replaying?
+            return if Temporalio::Workflow.in_workflow? &&
+                      Temporalio::Workflow::Unsafe.replaying_history_events?
 
             super
           end

--- a/temporalio/lib/temporalio/workflow.rb
+++ b/temporalio/lib/temporalio/workflow.rb
@@ -533,9 +533,16 @@ module Temporalio
     # Unsafe module contains only-in-workflow methods that are considered unsafe. These should not be used unless the
     # consequences are understood.
     module Unsafe
-      # @return [Boolean] True if the workflow is replaying, false otherwise. Most code should not check this value.
+      # @return [Boolean] True if the workflow is replaying (including during queries and update validators), false
+      #   otherwise. Most code should not check this value.
       def self.replaying?
         Workflow._current.replaying?
+      end
+
+      # @return [Boolean] True if the workflow is replaying history events (excluding queries and update validators),
+      #   false otherwise. Most code should not check this value.
+      def self.replaying_history_events?
+        Workflow._current.replaying_history_events?
       end
 
       # Run a block of code with illegal call tracing disabled. Users should be cautious about using this as it can

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance.rbs
@@ -34,6 +34,7 @@ module Temporalio
         attr_reader update_handlers: Hash[String?, Workflow::Definition::Update]
         attr_reader context_frozen: bool
         attr_reader assert_valid_local_activity: ^(String) -> void
+        attr_reader in_query_or_validator: bool
 
         attr_accessor io_enabled: bool
         attr_accessor current_details: String?
@@ -76,7 +77,7 @@ module Temporalio
 
         def failure_exception?: (Exception err) -> bool
 
-        def with_context_frozen: [T] { -> T } -> T
+        def with_context_frozen: [T] (in_query_or_validator: bool) { -> T } -> T
 
         def convert_handler_args: (
           payload_array: Array[untyped],

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance/context.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance/context.rbs
@@ -91,6 +91,8 @@ module Temporalio
 
           def replaying?: -> bool
 
+          def replaying_history_events?: -> bool
+
           def search_attributes: -> SearchAttributes
 
           def signal_handlers: -> HandlerHash[Workflow::Definition::Signal]

--- a/temporalio/sig/temporalio/workflow.rbs
+++ b/temporalio/sig/temporalio/workflow.rbs
@@ -153,6 +153,8 @@ module Temporalio
     module Unsafe
       def self.replaying?: -> bool
 
+      def self.replaying_history_events?: -> bool
+
       def self.illegal_call_tracing_disabled: [T] { -> T } -> T
 
       def self.io_enabled: [T] { -> T } -> T


### PR DESCRIPTION
## What was changed

Added `Workflow::Unsafe.replaying_history_events?` to distinguish replaying historical events from handling live read operations (queries/update validators). Updated replay-safe logger and metrics to allow logs and metrics during queries and validators.