### PR TITLE
Remove experimental warning for worker deployment versioning and envconfig

### DIFF
--- a/temporalio/lib/temporalio/client.rb
+++ b/temporalio/lib/temporalio/client.rb
@@ -298,7 +298,6 @@ module Temporalio
     # @param request_eager_start [Boolean] Potentially reduce the latency to start this workflow by encouraging the
     #   server to start it on a local worker running with this same client. This is currently experimental.
     # @param versioning_override [VersioningOverride, nil] Override the version of the workflow.
-    #   This is currently experimental.
     # @param priority [Priority] Priority of the workflow. This is currently experimental.
     # @param arg_hints [Array<Object>, nil] Overrides converter hints for arguments if any. If unset/nil and the
     #   workflow definition has arg hints, those are used by default.
@@ -392,7 +391,6 @@ module Temporalio
     # @param request_eager_start [Boolean] Potentially reduce the latency to start this workflow by encouraging the
     #   server to start it on a local worker running with this same client. This is currently experimental.
     # @param versioning_override [VersioningOverride, nil] Override the version of the workflow.
-    #   This is currently experimental.
     # @param priority [Priority] Priority for the workflow. This is currently experimental.
     # @param arg_hints [Array<Object>, nil] Overrides converter hints for arguments if any. If unset/nil and the
     #   workflow definition has arg hints, those are used by default.

--- a/temporalio/lib/temporalio/common_enums.rb
+++ b/temporalio/lib/temporalio/common_enums.rb
@@ -40,8 +40,6 @@ module Temporalio
   end
 
   # Specifies when a workflow might move from a worker of one Build Id to another.
-  #
-  # WARNING: Experimental API.
   module VersioningBehavior
     # Unspecified versioning behavior. By default, workers opting into worker versioning will
     # be required to specify a behavior.

--- a/temporalio/lib/temporalio/env_config.rb
+++ b/temporalio/lib/temporalio/env_config.rb
@@ -4,9 +4,7 @@ require 'pathname'
 require 'temporalio/internal/bridge'
 
 module Temporalio
-  # Environment and file-based configuration for Temporal clients
-  #
-  # WARNING: Experimental API.
+  # Environment and file-based configuration for Temporal clients.
   module EnvConfig
     # This module provides utilities to load Temporal client configuration from TOML files
     # and environment variables.

--- a/temporalio/lib/temporalio/versioning_override.rb
+++ b/temporalio/lib/temporalio/versioning_override.rb
@@ -5,8 +5,6 @@ require 'temporalio/worker_deployment_version'
 module Temporalio
   # Base class for version overrides that can be provided in start workflow options.
   # Used to control the versioning behavior of workflows started with this override.
-  #
-  # WARNING: Experimental API.
   class VersioningOverride
     # @!visibility private
     def _to_proto

--- a/temporalio/lib/temporalio/worker.rb
+++ b/temporalio/lib/temporalio/worker.rb
@@ -425,7 +425,6 @@ module Temporalio
     #   scheduler will fail. Instead of setting this to true, users are encouraged to use {Workflow::Unsafe.io_enabled}
     #   with a block for narrower enabling of IO.
     # @param deployment_options [DeploymentOptions, nil] Deployment options for the worker.
-    #   WARNING: This is an experimental feature and may change in the future.
     # @param workflow_task_poller_behavior [PollerBehavior] Specify the behavior of workflow task
     #   polling. Defaults to a 5-poller maximum.
     # @param activity_task_poller_behavior [PollerBehavior] Specify the behavior of activity task

--- a/temporalio/lib/temporalio/worker/deployment_options.rb
+++ b/temporalio/lib/temporalio/worker/deployment_options.rb
@@ -13,8 +13,6 @@ module Temporalio
 
     # Options for configuring the Worker Versioning feature.
     #
-    # WARNING: Deployment-based versioning is experimental and APIs may change.
-    #
     # @!attribute version
     #   @return [WorkerDeploymentVersion] The worker deployment version.
     # @!attribute use_worker_versioning

--- a/temporalio/lib/temporalio/worker_deployment_version.rb
+++ b/temporalio/lib/temporalio/worker_deployment_version.rb
@@ -9,8 +9,6 @@ module Temporalio
   )
 
   # Represents the version of a specific worker deployment.
-  #
-  # WARNING: Experimental API.
   class WorkerDeploymentVersion
     # Parse a version from a canonical string, which must be in the format
     # `<deployment_name>.<build_id>`. Deployment name must not have a `.` in it.

--- a/temporalio/lib/temporalio/workflow/definition.rb
+++ b/temporalio/lib/temporalio/workflow/definition.rb
@@ -110,8 +110,6 @@ module Temporalio
 
         # Set the versioning behavior of this workflow.
         #
-        # WARNING: This method is experimental and may change in future versions.
-        #
         # @param behavior [VersioningBehavior] The versioning behavior.
         def workflow_versioning_behavior(behavior)
           @versioning_behavior = behavior
@@ -732,7 +730,6 @@ module Temporalio
     # @!attribute versioning_behavior
     #   Dynamic equivalent of {Definition.workflow_versioning_behavior}.
     #   Will override any behavior set there if set.
-    #   WARNING: Deployment-based versioning is experimental and APIs may change.
     #   @return [VersioningBehavior, nil] The versioning behavior
     #
     # @return [VersioningBehavior, nil] The versioning behavior


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
DWISOTT:
- remove experimental warnings for worker deployment API
- remove experimental warnings for (client) environment configuration
- add deprecated warnings/markings to old worker deployment APIs

## Why?
Worker deployment versioning and envconfig are GA

1. Part of https://github.com/temporalio/features/issues/744

3. Any docs updates needed?
Yes?
