### PR TITLE
chore: pin rubocop

### DIFF
--- a/temporalio/Gemfile
+++ b/temporalio/Gemfile
@@ -25,7 +25,8 @@ group :development do
   gem 'rbs', '~> 3.10'
   gem 'rb_sys', '~> 0.9'
   gem 'rdoc'
-  gem 'rubocop'
+  # TODO: Unpin when https://github.com/rubocop/rubocop/pull/14838 is released
+  gem 'rubocop', '1.84.0'
   gem 'sqlite3'
   gem 'steep', '~> 1.10'
   gem 'yard'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Pinned rubocop until 1.84.2 is released as 1.84.1 breaks our CI

## Why?
Extracted from #381 in case we're holding off on merging that

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI

3. Any docs updates needed?
N/A
