### PR TITLE
chore: add GitHub Actions workaround for bundle install

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -68,6 +68,9 @@ jobs:
           cargo-cache: true
           cache-version: v1-source
 
+      - name: Fix gem directory permissions
+        run: chmod -R o-w "$RUNNER_TOOL_CACHE/Ruby" || true
+
       - name: Install bundle
         working-directory: ./temporalio
         run: bundle install


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Remove write permission on Ruby Gem directory

## Why?
At the moment we are unable to build our source gem on main: https://github.com/temporalio/sdk-ruby/actions/runs/22143148493/job/64021003210
This is due to a current issue with the GitHub Actions runner: https://github.com/actions/runner-images/issues/13647

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI: https://github.com/temporalio/sdk-ruby/actions/runs/22146255184/job/64024173178?pr=392

3. Any docs updates needed?
N/A
