### PR TITLE
fix: no longer error on when using fiber executor on Ruby 4

### DIFF
--- a/temporalio/.yardopts
+++ b/temporalio/.yardopts
@@ -1,2 +1,3 @@
 --readme README.md
 --protected
+--exclude sig/

--- a/temporalio/lib/temporalio/internal/bridge.rb
+++ b/temporalio/lib/temporalio/internal/bridge.rb
@@ -25,11 +25,11 @@ module Temporalio
               'see https://github.com/temporalio/sdk-ruby/issues/162'
       end
 
-      def self.fibers_supported # rubocop:disable Naming/PredicateMethod
+      def self.fibers_supported
         # We do not allow fibers on < 3.3 due to a bug we still need to dig
         # into: https://github.com/temporalio/sdk-ruby/issues/162
         major, minor = RUBY_VERSION.split('.').take(2).map(&:to_i)
-        !major.nil? && major >= 3 && !minor.nil? && minor >= 3
+        !major.nil? && !minor.nil? && (major > 3 || (major == 3 && minor >= 3))
       end
     end
   end

--- a/temporalio/test/worker_activity_test.rb
+++ b/temporalio/test/worker_activity_test.rb
@@ -41,6 +41,21 @@ class WorkerActivityTest < Test
     assert_equal 'Greetings, Block!', execute_activity(activity, 'Block')
   end
 
+  class SimpleFiberActivity < Temporalio::Activity::Definition
+    activity_executor :fiber
+
+    def execute(name)
+      "Hello, #{name}!"
+    end
+  end
+
+  # Unconditionally assert fiber executor works for all supported Ruby versions support fibers
+  def test_simple_fiber_activity
+    Async do
+      assert_equal 'Hello, Fiber!', execute_activity(SimpleFiberActivity, 'Fiber')
+    end
+  end
+
   class FiberActivity < Temporalio::Activity::Definition
     attr_reader :waiting_notification, :result_notification
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
When adding Ruby 4 support we did not alter our `fibers_supported` check and were incorrectly claiming that Ruby 4 doesn't support fibers.

## Why?
Allow fiber activity executor to be used with Ruby 4.

## Checklist
<!--- add/delete as needed --->

1. Closes #416 

2. How was this tested:
Added a very small unit test that just attempt to run an activity with the fiber executor. Before the change to `fibers_supported` this failed on Ruby 4.

3. Any docs updates needed?
N/A