### PR TITLE
chore: fix linux x86 build

### DIFF
--- a/.github/docker/rb-sys-protoc.Dockerfile
+++ b/.github/docker/rb-sys-protoc.Dockerfile
@@ -17,6 +17,14 @@ RUN case "$TARGETARCH" in \
 
 FROM ${BASE_IMAGE}
 
+ARG EXTRA_APT_PACKAGES=""
+
+RUN if [ -n "$EXTRA_APT_PACKAGES" ]; then \
+      apt-get update && \
+      apt-get install -y --no-install-recommends $EXTRA_APT_PACKAGES && \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
+
 COPY --from=protoc /opt/protoc/bin/protoc /usr/local/bin/protoc
 COPY --from=protoc /opt/protoc/include /usr/local/include
 

--- a/.github/docker/rb-sys-protoc.Dockerfile
+++ b/.github/docker/rb-sys-protoc.Dockerfile
@@ -17,27 +17,23 @@ RUN case "$TARGETARCH" in \
 
 FROM ${BASE_IMAGE}
 
-ARG EXTRA_APT_PACKAGES=""
-ARG DEFAULT_CC=""
-ARG DEFAULT_CXX=""
-ARG DEFAULT_AR=""
-ARG X86_64_UNKNOWN_LINUX_GNU_CC=""
-ARG X86_64_UNKNOWN_LINUX_GNU_CXX=""
-ARG X86_64_UNKNOWN_LINUX_GNU_LINKER=""
+ARG GCC_VERSION=""
 
-RUN if [ -n "$EXTRA_APT_PACKAGES" ]; then \
+RUN if [ -n "$GCC_VERSION" ]; then \
       apt-get update && \
-      apt-get install -y --no-install-recommends $EXTRA_APT_PACKAGES && \
+      apt-get install -y --no-install-recommends gcc-${GCC_VERSION} g++-${GCC_VERSION} && \
       rm -rf /var/lib/apt/lists/*; \
     fi
 
 RUN touch /etc/rubybashrc && \
-    if [ -n "$DEFAULT_CC" ]; then echo "export CC=$DEFAULT_CC" >> /etc/rubybashrc; fi && \
-    if [ -n "$DEFAULT_CXX" ]; then echo "export CXX=$DEFAULT_CXX" >> /etc/rubybashrc; fi && \
-    if [ -n "$DEFAULT_AR" ]; then echo "export AR=$DEFAULT_AR" >> /etc/rubybashrc; fi && \
-    if [ -n "$X86_64_UNKNOWN_LINUX_GNU_CC" ]; then echo "export CC_x86_64_unknown_linux_gnu=$X86_64_UNKNOWN_LINUX_GNU_CC" >> /etc/rubybashrc; fi && \
-    if [ -n "$X86_64_UNKNOWN_LINUX_GNU_CXX" ]; then echo "export CXX_x86_64_unknown_linux_gnu=$X86_64_UNKNOWN_LINUX_GNU_CXX" >> /etc/rubybashrc; fi && \
-    if [ -n "$X86_64_UNKNOWN_LINUX_GNU_LINKER" ]; then echo "export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=$X86_64_UNKNOWN_LINUX_GNU_LINKER" >> /etc/rubybashrc; fi
+    if [ -n "$GCC_VERSION" ]; then \
+      echo "export CC=gcc-${GCC_VERSION}" >> /etc/rubybashrc; \
+      echo "export CXX=g++-${GCC_VERSION}" >> /etc/rubybashrc; \
+      echo "export AR=gcc-ar-${GCC_VERSION}" >> /etc/rubybashrc; \
+      echo "export CC_x86_64_unknown_linux_gnu=gcc-${GCC_VERSION}" >> /etc/rubybashrc; \
+      echo "export CXX_x86_64_unknown_linux_gnu=g++-${GCC_VERSION}" >> /etc/rubybashrc; \
+      echo "export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc-${GCC_VERSION}" >> /etc/rubybashrc; \
+    fi
 
 COPY --from=protoc /opt/protoc/bin/protoc /usr/local/bin/protoc
 COPY --from=protoc /opt/protoc/include /usr/local/include

--- a/.github/docker/rb-sys-protoc.Dockerfile
+++ b/.github/docker/rb-sys-protoc.Dockerfile
@@ -18,12 +18,26 @@ RUN case "$TARGETARCH" in \
 FROM ${BASE_IMAGE}
 
 ARG EXTRA_APT_PACKAGES=""
+ARG DEFAULT_CC=""
+ARG DEFAULT_CXX=""
+ARG DEFAULT_AR=""
+ARG X86_64_UNKNOWN_LINUX_GNU_CC=""
+ARG X86_64_UNKNOWN_LINUX_GNU_CXX=""
+ARG X86_64_UNKNOWN_LINUX_GNU_LINKER=""
 
 RUN if [ -n "$EXTRA_APT_PACKAGES" ]; then \
       apt-get update && \
       apt-get install -y --no-install-recommends $EXTRA_APT_PACKAGES && \
       rm -rf /var/lib/apt/lists/*; \
     fi
+
+RUN touch /etc/rubybashrc && \
+    if [ -n "$DEFAULT_CC" ]; then echo "export CC=$DEFAULT_CC" >> /etc/rubybashrc; fi && \
+    if [ -n "$DEFAULT_CXX" ]; then echo "export CXX=$DEFAULT_CXX" >> /etc/rubybashrc; fi && \
+    if [ -n "$DEFAULT_AR" ]; then echo "export AR=$DEFAULT_AR" >> /etc/rubybashrc; fi && \
+    if [ -n "$X86_64_UNKNOWN_LINUX_GNU_CC" ]; then echo "export CC_x86_64_unknown_linux_gnu=$X86_64_UNKNOWN_LINUX_GNU_CC" >> /etc/rubybashrc; fi && \
+    if [ -n "$X86_64_UNKNOWN_LINUX_GNU_CXX" ]; then echo "export CXX_x86_64_unknown_linux_gnu=$X86_64_UNKNOWN_LINUX_GNU_CXX" >> /etc/rubybashrc; fi && \
+    if [ -n "$X86_64_UNKNOWN_LINUX_GNU_LINKER" ]; then echo "export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=$X86_64_UNKNOWN_LINUX_GNU_LINKER" >> /etc/rubybashrc; fi
 
 COPY --from=protoc /opt/protoc/bin/protoc /usr/local/bin/protoc
 COPY --from=protoc /opt/protoc/include /usr/local/include

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -1,6 +1,5 @@
 name: Build Gems
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -49,14 +49,32 @@ jobs:
           gem install rb_sys --no-document
           rb_sys_version="$(ruby -e 'require "rb_sys/version"; puts RbSys::VERSION')"
           extra_apt_packages=""
+          default_cc=""
+          default_cxx=""
+          default_ar=""
+          x86_64_unknown_linux_gnu_cc=""
+          x86_64_unknown_linux_gnu_cxx=""
+          x86_64_unknown_linux_gnu_linker=""
           if [[ "${{ matrix.rubyPlatform }}" == "x86_64-linux" ]]; then
             extra_apt_packages="gcc-10 g++-10"
+            default_cc="gcc-10"
+            default_cxx="g++-10"
+            default_ar="gcc-ar-10"
+            x86_64_unknown_linux_gnu_cc="gcc-10"
+            x86_64_unknown_linux_gnu_cxx="g++-10"
+            x86_64_unknown_linux_gnu_linker="gcc-10"
           fi
           custom_image="temporalio-rbsys/${{ matrix.rubyPlatform }}:${rb_sys_version}-protoc-${PROTOC_VERSION}"
           docker build \
             --platform linux/amd64 \
             --build-arg BASE_IMAGE="rbsys/${{ matrix.rubyPlatform }}:${rb_sys_version}" \
             --build-arg EXTRA_APT_PACKAGES="${extra_apt_packages}" \
+            --build-arg DEFAULT_CC="${default_cc}" \
+            --build-arg DEFAULT_CXX="${default_cxx}" \
+            --build-arg DEFAULT_AR="${default_ar}" \
+            --build-arg X86_64_UNKNOWN_LINUX_GNU_CC="${x86_64_unknown_linux_gnu_cc}" \
+            --build-arg X86_64_UNKNOWN_LINUX_GNU_CXX="${x86_64_unknown_linux_gnu_cxx}" \
+            --build-arg X86_64_UNKNOWN_LINUX_GNU_LINKER="${x86_64_unknown_linux_gnu_linker}" \
             --build-arg PROTOC_VERSION="${PROTOC_VERSION}" \
             -t "$custom_image" \
             -f ../.github/docker/rb-sys-protoc.Dockerfile \
@@ -70,13 +88,6 @@ jobs:
         id: cross-gem
         working-directory: ./temporalio
         run: |
-          # aws-lc-sys rejects the Ubuntu 20.04 GCC 9 toolchain in the
-          # current rb-sys x86_64 Linux image, so use GCC 10 in the
-          # derived image for that target.
-          if [[ "${{ matrix.rubyPlatform }}" == "x86_64-linux" ]]; then
-            export CC_x86_64_unknown_linux_gnu=gcc-10
-            export CXX_x86_64_unknown_linux_gnu=g++-10
-          fi
           RCD_IMAGE="${{ steps.build-rb-sys-dock-image.outputs.image }}" rb-sys-dock --platform "${{ matrix.rubyPlatform }}" --ruby-versions "3.3,3.4,4.0" --mount-toolchains --build
           echo "gem-path=$(find pkg -name '*-${{ matrix.rubyPlatform }}.gem')" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -1,5 +1,6 @@
 name: Build Gems
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -64,6 +65,13 @@ jobs:
         id: cross-gem
         working-directory: ./temporalio
         run: |
+          # aws-lc-sys rejects the Ubuntu 20.04 GCC 9 toolchain in the
+          # current rb-sys x86_64 Linux image, but clang-12 is already
+          # available there and passes the compiler self-check.
+          if [[ "${{ matrix.rubyPlatform }}" == "x86_64-linux" ]]; then
+            export CC_x86_64_unknown_linux_gnu=clang-12
+            export CXX_x86_64_unknown_linux_gnu=clang++-12
+          fi
           RCD_IMAGE="${{ steps.build-rb-sys-dock-image.outputs.image }}" rb-sys-dock --platform "${{ matrix.rubyPlatform }}" --ruby-versions "3.3,3.4,4.0" --mount-toolchains --build
           echo "gem-path=$(find pkg -name '*-${{ matrix.rubyPlatform }}.gem')" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -48,10 +48,15 @@ jobs:
         run: |
           gem install rb_sys --no-document
           rb_sys_version="$(ruby -e 'require "rb_sys/version"; puts RbSys::VERSION')"
+          extra_apt_packages=""
+          if [[ "${{ matrix.rubyPlatform }}" == "x86_64-linux" ]]; then
+            extra_apt_packages="gcc-10 g++-10"
+          fi
           custom_image="temporalio-rbsys/${{ matrix.rubyPlatform }}:${rb_sys_version}-protoc-${PROTOC_VERSION}"
           docker build \
             --platform linux/amd64 \
             --build-arg BASE_IMAGE="rbsys/${{ matrix.rubyPlatform }}:${rb_sys_version}" \
+            --build-arg EXTRA_APT_PACKAGES="${extra_apt_packages}" \
             --build-arg PROTOC_VERSION="${PROTOC_VERSION}" \
             -t "$custom_image" \
             -f ../.github/docker/rb-sys-protoc.Dockerfile \
@@ -66,11 +71,11 @@ jobs:
         working-directory: ./temporalio
         run: |
           # aws-lc-sys rejects the Ubuntu 20.04 GCC 9 toolchain in the
-          # current rb-sys x86_64 Linux image, but clang-12 is already
-          # available there and passes the compiler self-check.
+          # current rb-sys x86_64 Linux image, so use GCC 10 in the
+          # derived image for that target.
           if [[ "${{ matrix.rubyPlatform }}" == "x86_64-linux" ]]; then
-            export CC_x86_64_unknown_linux_gnu=clang-12
-            export CXX_x86_64_unknown_linux_gnu=clang++-12
+            export CC_x86_64_unknown_linux_gnu=gcc-10
+            export CXX_x86_64_unknown_linux_gnu=g++-10
           fi
           RCD_IMAGE="${{ steps.build-rb-sys-dock-image.outputs.image }}" rb-sys-dock --platform "${{ matrix.rubyPlatform }}" --ruby-versions "3.3,3.4,4.0" --mount-toolchains --build
           echo "gem-path=$(find pkg -name '*-${{ matrix.rubyPlatform }}.gem')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -18,7 +18,15 @@ jobs:
       matrix:
         # TODO(cretz): Enable x64-mingw-ucrt if we can figure out Windows issue, see
         # https://github.com/temporalio/sdk-ruby/issues/172
-        rubyPlatform: ["aarch64-linux", "aarch64-linux-musl", "x86_64-linux", "x86_64-linux-musl", "arm64-darwin", "x86_64-darwin"]
+        include:
+          - rubyPlatform: aarch64-linux
+          - rubyPlatform: aarch64-linux-musl
+          # aws-lc-rs fails to refuses to use GCC version included in image due to compiler bug
+          - rubyPlatform: x86_64-linux
+            gccVersion: "10"
+          - rubyPlatform: x86_64-linux-musl
+          - rubyPlatform: arm64-darwin
+          - rubyPlatform: x86_64-darwin
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -48,33 +56,11 @@ jobs:
         run: |
           gem install rb_sys --no-document
           rb_sys_version="$(ruby -e 'require "rb_sys/version"; puts RbSys::VERSION')"
-          extra_apt_packages=""
-          default_cc=""
-          default_cxx=""
-          default_ar=""
-          x86_64_unknown_linux_gnu_cc=""
-          x86_64_unknown_linux_gnu_cxx=""
-          x86_64_unknown_linux_gnu_linker=""
-          if [[ "${{ matrix.rubyPlatform }}" == "x86_64-linux" ]]; then
-            extra_apt_packages="gcc-10 g++-10"
-            default_cc="gcc-10"
-            default_cxx="g++-10"
-            default_ar="gcc-ar-10"
-            x86_64_unknown_linux_gnu_cc="gcc-10"
-            x86_64_unknown_linux_gnu_cxx="g++-10"
-            x86_64_unknown_linux_gnu_linker="gcc-10"
-          fi
           custom_image="temporalio-rbsys/${{ matrix.rubyPlatform }}:${rb_sys_version}-protoc-${PROTOC_VERSION}"
           docker build \
             --platform linux/amd64 \
             --build-arg BASE_IMAGE="rbsys/${{ matrix.rubyPlatform }}:${rb_sys_version}" \
-            --build-arg EXTRA_APT_PACKAGES="${extra_apt_packages}" \
-            --build-arg DEFAULT_CC="${default_cc}" \
-            --build-arg DEFAULT_CXX="${default_cxx}" \
-            --build-arg DEFAULT_AR="${default_ar}" \
-            --build-arg X86_64_UNKNOWN_LINUX_GNU_CC="${x86_64_unknown_linux_gnu_cc}" \
-            --build-arg X86_64_UNKNOWN_LINUX_GNU_CXX="${x86_64_unknown_linux_gnu_cxx}" \
-            --build-arg X86_64_UNKNOWN_LINUX_GNU_LINKER="${x86_64_unknown_linux_gnu_linker}" \
+            --build-arg GCC_VERSION="${{ matrix.gccVersion || '' }}" \
             --build-arg PROTOC_VERSION="${PROTOC_VERSION}" \
             -t "$custom_image" \
             -f ../.github/docker/rb-sys-protoc.Dockerfile \

--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - rubyPlatform: aarch64-linux
           - rubyPlatform: aarch64-linux-musl
-          # aws-lc-rs fails to refuses to use GCC version included in image due to compiler bug
+          # aws-lc-rs refuses to use GCC version included in image due to compiler bug
           - rubyPlatform: x86_64-linux
             gccVersion: "10"
           - rubyPlatform: x86_64-linux-musl


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Upgrade to GCC 10 when building the gem on Linux x86

## Why?
<!-- Tell your future self why have you made these changes -->
#409 ended up bringing in https://github.com/temporalio/sdk-rust/pull/1219 which brought in `aws-lc-rs` crate. This crate has an explicit check for a version of GCC that had a bug and will refuse to build if it is being used. (See https://github.com/aws/aws-lc-rs/issues/1093). We were hitting these failures when trying to build our gem [e.g.](https://github.com/temporalio/sdk-ruby/actions/runs/25062389319/job/73424111502)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
[It builds](https://github.com/temporalio/sdk-ruby/actions/runs/25069212675/job/73444596057?pr=427)

3. Any docs updates needed?
N/A
