### PR TITLE
fix: add priority as kwarg to schedule action

### DIFF
--- a/temporalio/lib/temporalio/client/schedule.rb
+++ b/temporalio/lib/temporalio/client/schedule.rb
@@ -3,6 +3,7 @@
 require 'temporalio/api'
 require 'temporalio/converters'
 require 'temporalio/internal/proto_utils'
+require 'temporalio/priority'
 require 'temporalio/retry_policy'
 require 'temporalio/search_attributes'
 
@@ -175,6 +176,7 @@ module Temporalio
           :retry_policy,
           :memo,
           :search_attributes,
+          :priority,
           :arg_hints,
           :headers
         )
@@ -209,6 +211,8 @@ module Temporalio
         #   @return [Hash<String, Object>, nil] Memo for the workflow.
         # @!attribute search_attributes
         #   @return [SearchAttributes, nil] Search attributes for the workflow.
+        # @!attribute priority
+        #   @return [Priority] Priority of the workflow. This is currently experimental.
         # @!attribute arg_hints
         #   @return [Array<Object>, nil] Converter hints for workflow arguments. This is only user-set (e.g. on create)
         #     and is not persisted and therefore will not be set when describing a workflow.
@@ -239,6 +243,7 @@ module Temporalio
             # @param retry_policy [RetryPolicy, nil] Retry policy for the workflow.
             # @param memo [Hash<String, Object>, nil] Memo for the workflow.
             # @param search_attributes [SearchAttributes, nil] Search attributes for the workflow.
+            # @param priority [Priority] Priority of the workflow. This is currently experimental.
             # @param headers [Hash<String, Object>, nil] Headers for the workflow.
             def new(
               workflow,
@@ -253,6 +258,7 @@ module Temporalio
               retry_policy: nil,
               memo: nil,
               search_attributes: nil,
+              priority: Priority.default,
               arg_hints: nil,
               headers: nil
             )
@@ -271,6 +277,7 @@ module Temporalio
                 retry_policy:,
                 memo:,
                 search_attributes:,
+                priority:,
                 arg_hints: arg_hints || defn_arg_hints,
                 headers:
               )
@@ -293,6 +300,7 @@ module Temporalio
               retry_policy: raw_info.retry_policy ? RetryPolicy._from_proto(raw_info.retry_policy) : nil,
               memo: Internal::ProtoUtils.memo_from_proto(raw_info.memo, data_converter),
               search_attributes: SearchAttributes._from_proto(raw_info.search_attributes),
+              priority: Priority._from_proto(raw_info.priority),
               headers: Internal::ProtoUtils.headers_from_proto(raw_info.header, data_converter)
             )
           end
@@ -312,6 +320,7 @@ module Temporalio
                 memo: Internal::ProtoUtils.memo_to_proto(memo, data_converter),
                 search_attributes: search_attributes&._to_proto,
                 header: Internal::ProtoUtils.headers_to_proto(headers, data_converter),
+                priority: priority._to_proto,
                 user_metadata: Internal::ProtoUtils.to_user_metadata(static_summary, static_details, data_converter)
               )
             )

--- a/temporalio/sig/temporalio/client/schedule.rbs
+++ b/temporalio/sig/temporalio/client/schedule.rbs
@@ -74,6 +74,7 @@ module Temporalio
           attr_reader retry_policy: RetryPolicy?
           attr_reader memo: Hash[String, Object?]?
           attr_reader search_attributes: SearchAttributes?
+          attr_reader priority: Priority
           attr_reader arg_hints: Array[Object]?
           attr_reader headers: Hash[String, Object?]?
 
@@ -90,6 +91,7 @@ module Temporalio
             ?retry_policy: RetryPolicy?,
             ?memo: Hash[String, Object?]?,
             ?search_attributes: SearchAttributes?,
+            ?priority: Priority,
             ?arg_hints: Array[Object]?,
             ?headers: Hash[String, Object?]?
           ) -> StartWorkflow

--- a/temporalio/test/client_schedule_test.rb
+++ b/temporalio/test/client_schedule_test.rb
@@ -22,7 +22,8 @@ class ClientScheduleTest < Test
       static_summary: 'my-summary',
       static_details: 'my-details',
       execution_timeout: 1.23,
-      memo: { 'memokey1' => 'memoval1' }
+      memo: { 'memokey1' => 'memoval1' },
+      priority: Temporalio::Priority.new(priority_key: 2, fairness_key: 'tenant-a', fairness_weight: 1.5)
     )
     schedule = Temporalio::Client::Schedule.new(
       action:,
@@ -79,6 +80,7 @@ class ClientScheduleTest < Test
     assert_equal 'my-details', desc_action.static_details
     assert_equal action.execution_timeout, desc_action.execution_timeout
     assert_equal({ 'memokey1' => 'memoval1' }, desc_action.memo)
+    assert_equal action.priority, desc_action.priority
     assert_equal({ 'memokey2' => 'memoval2' }, desc.memo)
     # We want to test the entire returned spec, policy, and state. But server
     # side spec turns the cron into a calendar, so we will replicate in our


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Surface `priority` when scheduling a workflow, this matches [other SDKs](https://python.temporal.io/temporalio.client.ScheduleActionStartWorkflow.html)

## Why?
Allow users to schedule a workflow with priority/fairness.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added assertion that this gets plumbed through in the schedule test.

3. Any docs updates needed?
N/A
