### PR TITLE
fix(priority): accept priority on WithStartWorkflowOperation

### DIFF
--- a/temporalio/lib/temporalio/client/with_start_workflow_operation.rb
+++ b/temporalio/lib/temporalio/client/with_start_workflow_operation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'temporalio/common_enums'
+require 'temporalio/priority'
 
 module Temporalio
   class Client
@@ -24,6 +25,7 @@ module Temporalio
         :memo,
         :search_attributes,
         :start_delay,
+        :priority,
         :arg_hints,
         :result_hint,
         :headers
@@ -40,6 +42,8 @@ module Temporalio
       #
       # Note, for {Client.start_update_with_start_workflow} and {Client.execute_update_with_start_workflow},
       # `id_conflict_policy` is required.
+      #
+      # @param priority [Priority] Priority of the workflow that may be started. This is currently experimental.
       def initialize(
         workflow,
         *args,
@@ -57,6 +61,7 @@ module Temporalio
         memo: nil,
         search_attributes: nil,
         start_delay: nil,
+        priority: Priority.default,
         arg_hints: nil,
         result_hint: nil,
         headers: {}
@@ -80,6 +85,7 @@ module Temporalio
           memo:,
           search_attributes:,
           start_delay:,
+          priority:,
           arg_hints: arg_hints || defn_arg_hints,
           result_hint: result_hint || defn_result_hint,
           headers:

--- a/temporalio/lib/temporalio/internal/client/implementation.rb
+++ b/temporalio/lib/temporalio/internal/client/implementation.rb
@@ -327,7 +327,8 @@ module Temporalio
             user_metadata: ProtoUtils.to_user_metadata(
               start_options.static_summary, start_options.static_details, @client.data_converter
             ),
-            header: ProtoUtils.headers_to_proto(start_options.headers, @client.data_converter)
+            header: ProtoUtils.headers_to_proto(start_options.headers, @client.data_converter),
+            priority: start_options.priority._to_proto
           )
         end
 

--- a/temporalio/sig/temporalio/client/with_start_workflow_operation.rbs
+++ b/temporalio/sig/temporalio/client/with_start_workflow_operation.rbs
@@ -18,6 +18,7 @@ module Temporalio
         attr_reader memo: Hash[String | Symbol, Object?]?
         attr_reader search_attributes: SearchAttributes?
         attr_reader start_delay: duration?
+        attr_reader priority: Priority
         attr_reader arg_hints: Array[Object]?
         attr_reader result_hint: Object?
         attr_reader headers: Hash[String, Object?]
@@ -39,6 +40,7 @@ module Temporalio
           memo: Hash[String | Symbol, Object?]?,
           search_attributes: SearchAttributes?,
           start_delay: duration?,
+          priority: Priority,
           arg_hints: Array[Object]?,
           result_hint: Object?,
           headers: Hash[String, Object?]
@@ -64,6 +66,7 @@ module Temporalio
         ?memo: Hash[String | Symbol, Object?]?,
         ?search_attributes: SearchAttributes?,
         ?start_delay: duration?,
+        ?priority: Priority,
         ?arg_hints: Array[Object]?,
         ?result_hint: Object?,
         ?headers: Hash[String, Object?]

--- a/temporalio/test/worker_workflow_handler_test.rb
+++ b/temporalio/test/worker_workflow_handler_test.rb
@@ -714,7 +714,8 @@ class WorkerWorkflowHandlerTest < Test
       id = "wf-#{SecureRandom.uuid}"
       start_workflow_operation = Temporalio::Client::WithStartWorkflowOperation.new(
         UpdateWithStartWorkflow, 123,
-        id:, task_queue: worker.task_queue, id_conflict_policy: Temporalio::WorkflowIDConflictPolicy::FAIL
+        id:, task_queue: worker.task_queue, id_conflict_policy: Temporalio::WorkflowIDConflictPolicy::FAIL,
+        priority: Temporalio::Priority.new(priority_key: 2, fairness_key: 'update-start', fairness_weight: 0.7)
       )
       # Run and confirm result of update is pre-workflow-execute
       assert_equal 456, env.client.execute_update_with_start_workflow(
@@ -723,6 +724,11 @@ class WorkerWorkflowHandlerTest < Test
       # Confirm query is total
       handle = start_workflow_operation.workflow_handle
       assert_equal 579, handle.query(UpdateWithStartWorkflow.counter)
+      started_event = handle.fetch_history_events.find(&:workflow_execution_started_event_attributes)
+      priority = started_event.workflow_execution_started_event_attributes.priority
+      assert_equal 2, priority.priority_key
+      assert_equal 'update-start', priority.fairness_key
+      assert_in_delta 0.7, priority.fairness_weight, 0.001
 
       # Update with start 5 more times
       5.times do
@@ -902,7 +908,8 @@ class WorkerWorkflowHandlerTest < Test
       id = "wf-#{SecureRandom.uuid}"
       start_workflow_operation = Temporalio::Client::WithStartWorkflowOperation.new(
         SignalWithStartWorkflow, 'workflow-start',
-        id:, task_queue: worker.task_queue
+        id:, task_queue: worker.task_queue,
+        priority: Temporalio::Priority.new(priority_key: 4, fairness_key: 'signal-start', fairness_weight: 1.3)
       )
       handle = env.client.signal_with_start_workflow(
         SignalWithStartWorkflow.add_event, 'signal', start_workflow_operation:
@@ -911,6 +918,11 @@ class WorkerWorkflowHandlerTest < Test
       assert_same handle, start_workflow_operation.workflow_handle
       # Confirm signal event came first
       assert_equal %w[signal workflow-start], handle.query(SignalWithStartWorkflow.events)
+      started_event = handle.fetch_history_events.find(&:workflow_execution_started_event_attributes)
+      priority = started_event.workflow_execution_started_event_attributes.priority
+      assert_equal 4, priority.priority_key
+      assert_equal 'signal-start', priority.fairness_key
+      assert_in_delta 1.3, priority.fairness_weight, 0.001
 
       # Signal with start 3 more times
       3.times do |i|


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
TSIA, basically #431 but applied to `WithStartWorkflowOperation`

## Why?
Parity with Python SDK, general feature completeness

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Updated existing tests to provide priority to these calls and verify they make it through to history. 

3. Any docs updates needed?
N/A
