### PR TITLE
chore: use protobuf types over untyped

### DIFF
--- a/temporalio/sig/temporalio/client/interceptor.rbs
+++ b/temporalio/sig/temporalio/client/interceptor.rbs
@@ -449,7 +449,9 @@ module Temporalio
 
         def describe_workflow: (DescribeWorkflowInput input) -> WorkflowExecution::Description
 
-        def fetch_workflow_history_events: (FetchWorkflowHistoryEventsInput input) -> Enumerator[untyped, untyped]
+        def fetch_workflow_history_events: (
+          FetchWorkflowHistoryEventsInput input
+        ) -> Enumerator[Api::History::V1::HistoryEvent, Api::History::V1::HistoryEvent]
 
         def signal_workflow: (SignalWorkflowInput input) -> void
 
@@ -457,7 +459,7 @@ module Temporalio
 
         def start_workflow_update: (StartWorkflowUpdateInput input) -> WorkflowUpdateHandle
 
-        def poll_workflow_update: (PollWorkflowUpdateInput input) -> untyped
+        def poll_workflow_update: (PollWorkflowUpdateInput input) -> Api::Update::V1::Outcome
 
         def cancel_workflow: (CancelWorkflowInput input) -> void
 

--- a/temporalio/sig/temporalio/client/schedule.rbs
+++ b/temporalio/sig/temporalio/client/schedule.rbs
@@ -7,7 +7,7 @@ module Temporalio
       attr_reader state: State
 
       def self._from_proto: (
-        untyped raw_schedule,
+        Api::Schedule::V1::Schedule raw_schedule,
         Converters::DataConverter data_converter
       ) -> Schedule
 
@@ -18,7 +18,7 @@ module Temporalio
         ?state: State
       ) -> void
 
-      def _to_proto: (Converters::DataConverter data_converter) -> untyped
+      def _to_proto: (Converters::DataConverter data_converter) -> Api::Schedule::V1::Schedule
 
       def with: (**untyped) -> Schedule
 
@@ -26,11 +26,11 @@ module Temporalio
         attr_reader id: String
         attr_reader schedule: Schedule
         attr_reader info: Schedule::Info
-        attr_reader raw_description: untyped
+        attr_reader raw_description: Api::WorkflowService::V1::DescribeScheduleResponse
 
         def initialize: (
           id: String,
-          raw_description: untyped,
+          raw_description: Api::WorkflowService::V1::DescribeScheduleResponse,
           data_converter: Converters::DataConverter
         ) -> void
 
@@ -48,16 +48,16 @@ module Temporalio
         attr_reader created_at: Time
         attr_reader last_updated_at: Time?
 
-        def initialize: (raw_info: untyped) -> void
+        def initialize: (raw_info: Api::Schedule::V1::ScheduleInfo) -> void
       end
 
       module Action
         def self._from_proto: (
-          untyped raw_action,
+          Api::Schedule::V1::ScheduleAction raw_action,
           Converters::DataConverter data_converter
         ) -> Action
 
-        def _to_proto: (Converters::DataConverter data_converter) -> untyped
+        def _to_proto: (Converters::DataConverter data_converter) -> Api::Schedule::V1::ScheduleAction
 
         class StartWorkflow
           include Action
@@ -97,13 +97,13 @@ module Temporalio
           ) -> StartWorkflow
 
           def self._from_proto: (
-            untyped raw_info,
+            Api::Workflow::V1::NewWorkflowExecutionInfo raw_info,
             Converters::DataConverter data_converter
           ) -> StartWorkflow
 
           def with: (**untyped) -> StartWorkflow
 
-          def _to_proto: (Converters::DataConverter data_converter) -> untyped
+          def _to_proto: (Converters::DataConverter data_converter) -> Api::Schedule::V1::ScheduleAction
         end
       end
 
@@ -129,7 +129,7 @@ module Temporalio
           ?overlap: OverlapPolicy::enum?
         ) -> void
 
-        def _to_proto: -> untyped
+        def _to_proto: -> Api::Schedule::V1::BackfillRequest
       end
 
       module ActionExecution
@@ -139,7 +139,7 @@ module Temporalio
           attr_reader workflow_id: String
           attr_reader first_execution_run_id: String
 
-          def initialize: (raw_execution: untyped) -> void
+          def initialize: (raw_execution: Api::Common::V1::WorkflowExecution) -> void
         end
       end
 
@@ -148,7 +148,7 @@ module Temporalio
         attr_reader started_at: Time
         attr_reader action: ActionExecution
 
-        def initialize: (raw_result: untyped) -> void
+        def initialize: (raw_result: Api::Schedule::V1::ScheduleActionResult) -> void
       end
 
       class Spec
@@ -161,7 +161,7 @@ module Temporalio
         attr_reader jitter: Float?
         attr_reader time_zone_name: String?
 
-        def self._from_proto: (untyped raw_spec) -> Spec
+        def self._from_proto: (Api::Schedule::V1::ScheduleSpec raw_spec) -> Spec
 
         def initialize: (
           ?calendars: Array[Calendar],
@@ -174,7 +174,7 @@ module Temporalio
           ?time_zone_name: String?
         ) -> void
 
-        def _to_proto: -> untyped
+        def _to_proto: -> Api::Schedule::V1::ScheduleSpec
 
         def with: (**untyped) -> Spec
 
@@ -188,7 +188,7 @@ module Temporalio
           attr_reader day_of_week: Array[Schedule::Range]
           attr_reader comment: String?
 
-          def self._from_proto: (untyped raw_cal) -> Calendar
+          def self._from_proto: (Api::Schedule::V1::StructuredCalendarSpec raw_cal) -> Calendar
 
           def initialize: (
             ?second: Array[Schedule::Range],
@@ -201,21 +201,21 @@ module Temporalio
             ?comment: String?
           ) -> void
 
-          def _to_proto: -> untyped
+          def _to_proto: -> Api::Schedule::V1::StructuredCalendarSpec
         end
 
         class Interval
           attr_reader every: duration
           attr_reader offset: duration?
 
-          def self._from_proto: (untyped raw_int) -> Interval
+          def self._from_proto: (Api::Schedule::V1::IntervalSpec raw_int) -> Interval
 
           def initialize: (
             every: duration,
             ?offset: duration?
           ) -> void
 
-          def _to_proto: -> untyped
+          def _to_proto: -> Api::Schedule::V1::IntervalSpec
         end
       end
 
@@ -230,11 +230,11 @@ module Temporalio
           ?Integer step
         ) -> Range
 
-        def self._from_proto: (untyped raw_range) -> Range
-        def self._from_protos: (Array[untyped] raw_ranges) -> Array[Range]
-        def self._to_protos: (Array[Range] ranges) -> Array[untyped]
+        def self._from_proto: (Api::Schedule::V1::Range raw_range) -> Range
+        def self._from_protos: (Google::Protobuf::RepeatedField raw_ranges) -> Array[Range]
+        def self._to_protos: (Array[Range] ranges) -> Array[Api::Schedule::V1::Range]
 
-        def _to_proto: -> untyped
+        def _to_proto: -> Api::Schedule::V1::Range
       end
 
       class Policy
@@ -242,7 +242,7 @@ module Temporalio
         attr_reader catchup_window: duration
         attr_reader pause_on_failure: bool
 
-        def self._from_proto: (untyped raw_policies) -> Policy
+        def self._from_proto: (Api::Schedule::V1::SchedulePolicies raw_policies) -> Policy
 
         def initialize: (
           ?overlap: OverlapPolicy::enum,
@@ -250,7 +250,7 @@ module Temporalio
           ?pause_on_failure: bool
         ) -> void
 
-        def _to_proto: -> untyped
+        def _to_proto: -> Api::Schedule::V1::SchedulePolicies
       end
 
       class State
@@ -259,7 +259,7 @@ module Temporalio
         attr_reader limited_actions: bool
         attr_reader remaining_actions: Integer
 
-        def self._from_proto: (untyped raw_state) -> State
+        def self._from_proto: (Api::Schedule::V1::ScheduleState raw_state) -> State
 
         def initialize: (
           ?note: String?,
@@ -268,7 +268,7 @@ module Temporalio
           ?remaining_actions: Integer
         ) -> void
 
-        def _to_proto: -> untyped
+        def _to_proto: -> Api::Schedule::V1::ScheduleState
       end
 
       class Update
@@ -290,12 +290,12 @@ module Temporalio
       module List
         class Description
           attr_reader id: String
-          attr_reader schedule: Schedule
-          attr_reader info: Info
-          attr_reader raw_entry: untyped
+          attr_reader schedule: Schedule?
+          attr_reader info: Info?
+          attr_reader raw_entry: Api::Schedule::V1::ScheduleListEntry
 
           def initialize: (
-            raw_entry: untyped,
+            raw_entry: Api::Schedule::V1::ScheduleListEntry,
             data_converter: Converters::DataConverter
           ) -> void
         end
@@ -305,7 +305,7 @@ module Temporalio
           attr_reader spec: Spec
           attr_reader state: State
 
-          def initialize: (raw_info: untyped) -> void
+          def initialize: (raw_info: Api::Schedule::V1::ScheduleListInfo) -> void
         end
 
         module Action
@@ -322,14 +322,14 @@ module Temporalio
           attr_reader recent_actions: Array[ActionResult]
           attr_reader next_action_times: Array[Time]
 
-          def initialize: (raw_info: untyped) -> void
+          def initialize: (raw_info: Api::Schedule::V1::ScheduleListInfo) -> void
         end
 
         class State
           attr_reader note: String?
           attr_reader paused: bool
 
-          def initialize: (raw_info: untyped) -> void
+          def initialize: (raw_info: Api::Schedule::V1::ScheduleListInfo) -> void
         end
       end
     end

--- a/temporalio/sig/temporalio/client/workflow_execution.rbs
+++ b/temporalio/sig/temporalio/client/workflow_execution.rbs
@@ -1,9 +1,9 @@
 module Temporalio
   class Client
     class WorkflowExecution
-      attr_reader raw_info: untyped
+      attr_reader raw_info: Api::Workflow::V1::WorkflowExecutionInfo
 
-      def initialize: (untyped raw_info, Converters::DataConverter data_converter) -> void
+      def initialize: (Api::Workflow::V1::WorkflowExecutionInfo raw_info, Converters::DataConverter data_converter) -> void
 
       def close_time: -> Time?
       def execution_time: -> Time?
@@ -20,9 +20,12 @@ module Temporalio
       def workflow_type: -> String
 
       class Description < WorkflowExecution
-        attr_reader raw_description: untyped
+        attr_reader raw_description: Api::WorkflowService::V1::DescribeWorkflowExecutionResponse
 
-        def initialize: (untyped raw_description, Converters::DataConverter data_converter) -> void
+        def initialize: (
+          Api::WorkflowService::V1::DescribeWorkflowExecutionResponse raw_description,
+          Converters::DataConverter data_converter
+        ) -> void
 
         def static_summary: -> String?
         def static_details: -> String?

--- a/temporalio/sig/temporalio/client/workflow_handle.rbs
+++ b/temporalio/sig/temporalio/client/workflow_handle.rbs
@@ -37,7 +37,7 @@ module Temporalio
         ?skip_archival: bool,
         ?specific_run_id: String?,
         ?rpc_options: RPCOptions?
-      ) -> Enumerator[untyped, untyped]
+      ) -> Enumerator[Api::History::V1::HistoryEvent, Api::History::V1::HistoryEvent]
 
       def signal: (
         Workflow::Definition::Signal | Symbol | String signal,

--- a/temporalio/sig/temporalio/client/workflow_update_handle.rbs
+++ b/temporalio/sig/temporalio/client/workflow_update_handle.rbs
@@ -11,7 +11,7 @@ module Temporalio
         id: String,
         workflow_id: String,
         workflow_run_id: String?,
-        known_outcome: untyped?,
+        known_outcome: Api::Update::V1::Outcome?,
         result_hint: Object?
       ) -> void
 

--- a/temporalio/sig/temporalio/converters/data_converter.rbs
+++ b/temporalio/sig/temporalio/converters/data_converter.rbs
@@ -25,8 +25,8 @@ module Temporalio
         ?hints: Array[Object]?
       ) -> Array[Object?]
 
-      def to_failure: (Exception error) -> untyped
-      def from_failure: (untyped failure) -> Exception
+      def to_failure: (Exception error) -> Api::Failure::V1::Failure
+      def from_failure: (Api::Failure::V1::Failure failure) -> Exception
     end
   end
 end

--- a/temporalio/sig/temporalio/converters/failure_converter.rbs
+++ b/temporalio/sig/temporalio/converters/failure_converter.rbs
@@ -5,8 +5,8 @@ module Temporalio
 
       def initialize: (?encode_common_attributes: bool) -> void
 
-      def to_failure: (Exception error, DataConverter | PayloadConverter converter) -> untyped
-      def from_failure: (untyped failure, DataConverter | PayloadConverter converter) -> Exception
+      def to_failure: (Exception error, DataConverter | PayloadConverter converter) -> Api::Failure::V1::Failure
+      def from_failure: (Api::Failure::V1::Failure failure, DataConverter | PayloadConverter converter) -> Exception
     end
   end
 end

--- a/temporalio/sig/temporalio/converters/payload_codec.rbs
+++ b/temporalio/sig/temporalio/converters/payload_codec.rbs
@@ -1,8 +1,8 @@
 module Temporalio
   module Converters
     class PayloadCodec
-      def encode: (Enumerable[untyped] payloads) -> Array[untyped]
-      def decode: (Enumerable[untyped] payloads) -> Array[untyped]
+      def encode: (Enumerable[Api::Common::V1::Payload] payloads) -> Array[Api::Common::V1::Payload]
+      def decode: (Enumerable[Api::Common::V1::Payload] payloads) -> Array[Api::Common::V1::Payload]
     end
   end
 end

--- a/temporalio/sig/temporalio/converters/raw_value.rbs
+++ b/temporalio/sig/temporalio/converters/raw_value.rbs
@@ -1,9 +1,9 @@
 module Temporalio
   module Converters
     class RawValue
-      attr_reader payload: untyped
+      attr_reader payload: Api::Common::V1::Payload
 
-      def initialize: (untyped payload) -> void
+      def initialize: (Api::Common::V1::Payload payload) -> void
     end
   end
 end

--- a/temporalio/sig/temporalio/error.rbs
+++ b/temporalio/sig/temporalio/error.rbs
@@ -51,12 +51,12 @@ module Temporalio
       def initialize: (
         String message,
         code: Code::enum,
-        raw_grpc_status: String? | untyped
+        raw_grpc_status: String? | Api::Common::V1::GrpcStatus
       ) -> void
 
-      def grpc_status: -> untyped
+      def grpc_status: -> Api::Common::V1::GrpcStatus
 
-      private def create_grpc_status: -> untyped
+      private def create_grpc_status: -> Api::Common::V1::GrpcStatus
 
       module Code
         OK: 0

--- a/temporalio/sig/temporalio/internal/proto_utils.rbs
+++ b/temporalio/sig/temporalio/internal/proto_utils.rbs
@@ -1,46 +1,46 @@
 module Temporalio
   module Internal
     module ProtoUtils
-      def self.seconds_to_duration: (duration? seconds_numeric) -> untyped?
+      def self.seconds_to_duration: (duration? seconds_numeric) -> Google::Protobuf::Duration?
 
-      def self.duration_to_seconds: (untyped? duration) -> Float?
+      def self.duration_to_seconds: (Google::Protobuf::Duration? duration) -> Float?
 
-      def self.time_to_timestamp: (Time? time) -> untyped?
+      def self.time_to_timestamp: (Time? time) -> Google::Protobuf::Timestamp?
 
-      def self.timestamp_to_time: (untyped? timestamp) -> Time?
+      def self.timestamp_to_time: (Google::Protobuf::Timestamp? timestamp) -> Time?
 
       def self.memo_to_proto: (
         Hash[String | Symbol, Object?]? hash,
         Converters::DataConverter | Converters::PayloadConverter converter
-      ) -> untyped?
+      ) -> Api::Common::V1::Memo?
 
       def self.memo_to_proto_hash: (
         Hash[String | Symbol, Object?]? hash,
         Converters::DataConverter | Converters::PayloadConverter converter
-      ) -> Hash[String, untyped]?
+      ) -> Hash[String, Api::Common::V1::Payload]?
 
       def self.memo_from_proto: (
-        untyped? memo,
+        Api::Common::V1::Memo? memo,
         Converters::DataConverter | Converters::PayloadConverter converter
       ) -> Hash[String, Object?]?
 
       def self.headers_to_proto: (
         Hash[String, Object?]? hash,
         Converters::DataConverter | Converters::PayloadConverter converter
-      ) -> untyped?
+      ) -> Api::Common::V1::Header?
 
       def self.headers_to_proto_hash: (
         Hash[String, Object?]? hash,
         Converters::DataConverter | Converters::PayloadConverter converter
-      ) -> Hash[String, untyped]?
+      ) -> Hash[String, Api::Common::V1::Payload]?
 
       def self.headers_from_proto: (
-        untyped? headers,
+        Api::Common::V1::Header? headers,
         Converters::DataConverter | Converters::PayloadConverter converter
       ) -> Hash[String, Object?]?
 
       def self.headers_from_proto_map: (
-        Hash[String, untyped]? headers,
+        (Hash[String, Api::Common::V1::Payload] | Google::Protobuf::Map[String, Api::Common::V1::Payload])? headers,
         Converters::DataConverter | Converters::PayloadConverter converter
       ) -> Hash[String, Object?]?
 
@@ -51,7 +51,7 @@ module Temporalio
 
       def self.convert_from_payload_array: (
         Converters::DataConverter | Converters::PayloadConverter converter,
-        Array[untyped] payloads,
+        Array[Api::Common::V1::Payload] | Google::Protobuf::RepeatedField payloads,
         hints: Array[Object]?
       ) -> Array[Object?]
 
@@ -59,7 +59,7 @@ module Temporalio
         Converters::DataConverter | Converters::PayloadConverter converter,
         Array[Object?] values,
         hints: Array[Object]?
-      ) -> Array[untyped]
+      ) -> Array[Api::Common::V1::Payload]
 
       def self.assert_non_reserved_name: (String | Symbol | nil name) -> void
       def self.reserved_name?: (String | Symbol | nil name) -> bool
@@ -68,16 +68,16 @@ module Temporalio
         String? summary,
         String? details,
         Converters::DataConverter | Converters::PayloadConverter converter
-      ) -> untyped
+      ) -> Api::Sdk::V1::UserMetadata?
 
       def self.from_user_metadata: (
-        untyped metadata,
+        Api::Sdk::V1::UserMetadata? metadata,
         Converters::DataConverter | Converters::PayloadConverter converter
       ) -> [String?, String?]
 
       class LazyMemo
         def initialize: (
-          untyped? raw_memo,
+          Api::Common::V1::Memo? raw_memo,
           Converters::DataConverter | Converters::PayloadConverter converter,
         ) -> void
 
@@ -85,7 +85,7 @@ module Temporalio
       end
 
       class LazySearchAttributes
-        def initialize: (untyped? raw_search_attributes) -> void
+        def initialize: (Api::Common::V1::SearchAttributes? raw_search_attributes) -> void
 
         def get: -> SearchAttributes?
       end

--- a/temporalio/sig/temporalio/priority.rbs
+++ b/temporalio/sig/temporalio/priority.rbs
@@ -6,11 +6,11 @@ module Temporalio
 
     def initialize: (?priority_key: Integer?, ?fairness_key: String?, ?fairness_weight: Float?) -> void
 
-    def self._from_proto: (untyped) -> Priority
+    def self._from_proto: (Api::Common::V1::Priority?) -> Priority
 
     def self.default: -> Priority
 
-    def _to_proto: -> untyped
+    def _to_proto: -> Api::Common::V1::Priority?
 
     def empty?: -> bool
   end

--- a/temporalio/sig/temporalio/retry_policy.rbs
+++ b/temporalio/sig/temporalio/retry_policy.rbs
@@ -6,7 +6,7 @@ module Temporalio
     attr_reader max_attempts: Integer
     attr_reader non_retryable_error_types: Array[String]?
 
-    def self._from_proto: (untyped raw_policy) -> RetryPolicy
+    def self._from_proto: (Api::Common::V1::RetryPolicy raw_policy) -> RetryPolicy
 
     def initialize: (
       ?initial_interval: duration,
@@ -16,6 +16,6 @@ module Temporalio
       ?non_retryable_error_types: Array[String]?
     ) -> void
 
-    def _to_proto: -> untyped
+    def _to_proto: -> Api::Common::V1::RetryPolicy
   end
 end

--- a/temporalio/sig/temporalio/search_attributes.rbs
+++ b/temporalio/sig/temporalio/search_attributes.rbs
@@ -18,18 +18,18 @@ module Temporalio
 
       def initialize: (Key key, Object? value) -> void
 
-      def _to_proto_pair: -> [String, untyped]
+      def _to_proto_pair: -> [String, Api::Common::V1::Payload]
     end
 
     def self._from_proto: (
-      untyped proto,
+      Api::Common::V1::SearchAttributes? proto,
       ?disable_mutations: bool,
       ?never_nil: bool
     ) -> SearchAttributes?
 
-    def self._value_from_payload: (untyped payload) -> Object?
+    def self._value_from_payload: (Api::Common::V1::Payload payload) -> Object?
 
-    def self._to_proto_pair: (Key key, Object? value) -> [String, untyped]
+    def self._to_proto_pair: (Key key, Object? value) -> [String, Api::Common::V1::Payload]
 
     def initialize: (SearchAttributes existing) -> void
                   | (Hash[Key, Object] existing) -> void
@@ -58,9 +58,9 @@ module Temporalio
 
     def _raw_hash: -> Hash[Key, Object]
 
-    def _to_proto: -> untyped
+    def _to_proto: -> Api::Common::V1::SearchAttributes
 
-    def _to_proto_hash: -> Hash[String, untyped]
+    def _to_proto_hash: -> Hash[String, Api::Common::V1::Payload]
 
     def _assert_mutations_enabled: -> void
 

--- a/temporalio/sig/temporalio/testing/workflow_environment.rbs
+++ b/temporalio/sig/temporalio/testing/workflow_environment.rbs
@@ -104,9 +104,9 @@ module Temporalio
 
       def current_time: -> Time
 
-      def create_nexus_endpoint: (name: String, task_queue: String) -> untyped
+      def create_nexus_endpoint: (name: String, task_queue: String) -> Api::Nexus::V1::Endpoint
 
-      def delete_nexus_endpoint: (untyped endpoint) -> nil
+      def delete_nexus_endpoint: (Api::Nexus::V1::Endpoint endpoint) -> nil
 
       def auto_time_skipping_disabled: [T] { -> T } -> T
 

--- a/temporalio/sig/temporalio/versioning_override.rbs
+++ b/temporalio/sig/temporalio/versioning_override.rbs
@@ -1,17 +1,17 @@
 module Temporalio
   class VersioningOverride
-    def _to_proto: -> untyped
+    def _to_proto: -> Api::Workflow::V1::VersioningOverride
 
     class Pinned < VersioningOverride
         attr_reader version: WorkerDeploymentVersion
 
         def initialize: (WorkerDeploymentVersion version) -> void
-        def _to_proto: -> untyped
+        def _to_proto: -> Api::Workflow::V1::VersioningOverride
     end
 
     class AutoUpgrade < VersioningOverride
         def initialize: -> void
-        def _to_proto: -> untyped
+        def _to_proto: -> Api::Workflow::V1::VersioningOverride
     end
   end
 end

--- a/temporalio/sig/temporalio/worker_deployment_version.rbs
+++ b/temporalio/sig/temporalio/worker_deployment_version.rbs
@@ -5,13 +5,13 @@ module Temporalio
 
     def self.from_canonical_string: (String canonical) -> WorkerDeploymentVersion
 
-    def self._from_bridge: (untyped bridge) -> WorkerDeploymentVersion?
+    def self._from_bridge: (Internal::Bridge::Worker::WorkerDeploymentVersion? bridge) -> WorkerDeploymentVersion?
 
     def initialize: (deployment_name: String, build_id: String) -> void
 
     def to_canonical_string: -> String
 
     def _to_bridge_options: -> Internal::Bridge::Worker::WorkerDeploymentVersion
-    def _to_proto: -> untyped
+    def _to_proto: -> Api::Deployment::V1::WorkerDeploymentVersion
   end
 end

--- a/temporalio/sig/temporalio/workflow_history.rbs
+++ b/temporalio/sig/temporalio/workflow_history.rbs
@@ -2,9 +2,9 @@ module Temporalio
   class WorkflowHistory
     def self.from_history_json: (String json) -> WorkflowHistory
 
-    attr_reader events: Array[untyped]
+    attr_reader events: Array[Api::History::V1::HistoryEvent]
     
-    def initialize: (Array[untyped] events) -> void
+    def initialize: (Array[Api::History::V1::HistoryEvent] events) -> void
 
     def workflow_id: -> String
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Move from using `untyped` for protobuf messages in our handwritten RBS files to the actual message types.

## Why?
With #414 we now have these types so `untyped` is no longer necessary.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
`bundle exec rake steep`

3. Any docs updates needed?
N/A
