### PR TITLE
Add 'experimental' comments to Standalone Activities features

### DIFF
--- a/temporalio/lib/temporalio/activity/info.rb
+++ b/temporalio/lib/temporalio/activity/info.rb
@@ -85,7 +85,8 @@ module Temporalio
     #   class or it may break in incompatible ways.
     class Info
       # @return [Boolean] True if this activity was scheduled by a workflow execution; false for standalone activities.
-      #   WARNING: Standalone Activities are experimental.
+      #
+      # WARNING: Standalone Activities are experimental.
       def in_workflow?
         !workflow_id.nil?
       end

--- a/temporalio/lib/temporalio/activity/info.rb
+++ b/temporalio/lib/temporalio/activity/info.rb
@@ -35,6 +35,7 @@ module Temporalio
     #   @return [String] ID for the activity.
     # @!attribute activity_run_id
     #   @return [String, nil] Run ID for a standalone activity execution. nil for activities scheduled from a workflow.
+    #     WARNING: Standalone Activities are experimental.
     # @!attribute activity_type
     #   @return [String] Type name for the activity.
     # @!attribute attempt
@@ -84,6 +85,7 @@ module Temporalio
     #   class or it may break in incompatible ways.
     class Info
       # @return [Boolean] True if this activity was scheduled by a workflow execution; false for standalone activities.
+      #   WARNING: Standalone Activities are experimental.
       def in_workflow?
         !workflow_id.nil?
       end

--- a/temporalio/lib/temporalio/client.rb
+++ b/temporalio/lib/temporalio/client.rb
@@ -482,6 +482,8 @@ module Temporalio
     # Get a handle for an existing standalone activity. Useful when the activity was started elsewhere
     # (a different process, or by another client) and you have only its ID.
     #
+    # WARNING: Standalone Activities are experimental.
+    #
     # @param activity_id [String] ID for the activity.
     # @param activity_run_id [String, nil] Run ID for the activity execution. If nil, operations target the
     #   latest run of the given activity ID.
@@ -494,6 +496,8 @@ module Temporalio
     end
 
     # Start a standalone activity execution and return its handle.
+    #
+    # WARNING: Standalone Activities are experimental.
     #
     # @param activity [Class<Activity::Definition>, Activity::Definition, Activity::Definition::Info, Symbol, String]
     #   Activity definition, definition class or activity name.
@@ -514,7 +518,7 @@ module Temporalio
     # @param search_attributes [SearchAttributes, nil] Search attributes for the activity.
     # @param static_summary [String, nil] Fixed single-line summary for this activity execution.
     # @param static_details [String, nil] Fixed details for this activity execution. May be in markdown format.
-    # @param priority [Priority] Priority for the activity.
+    # @param priority [Priority] Priority for the activity. This is currently experimental.
     # @param arg_hints [Array<Object>, nil] Argument hints.
     # @param result_hint [Object, nil] Result hint.
     # @param rpc_options [RPCOptions, nil] Advanced RPC options.
@@ -570,6 +574,8 @@ module Temporalio
     # Start a standalone activity execution and wait for its result. Shortcut for
     # {start_activity} + {ActivityHandle#result}.
     #
+    # WARNING: Standalone Activities are experimental.
+    #
     # @param activity [Class<Activity::Definition>, Activity::Definition, Activity::Definition::Info, Symbol, String]
     #   Activity definition, definition class or activity name.
     # @param args [Array<Object>] Arguments to the activity.
@@ -589,7 +595,7 @@ module Temporalio
     # @param search_attributes [SearchAttributes, nil] Search attributes for the activity.
     # @param static_summary [String, nil] Fixed single-line summary for this activity execution.
     # @param static_details [String, nil] Fixed details for this activity execution. May be in markdown format.
-    # @param priority [Priority] Priority for the activity.
+    # @param priority [Priority] Priority for the activity. This is currently experimental.
     # @param arg_hints [Array<Object>, nil] Argument hints.
     # @param result_hint [Object, nil] Result hint.
     # @param rpc_options [RPCOptions, nil] Advanced RPC options.
@@ -642,6 +648,8 @@ module Temporalio
 
     # List standalone activities matching a visibility query.
     #
+    # WARNING: Standalone Activities are experimental.
+    #
     # @param query [String] Visibility list filter.
     # @param rpc_options [RPCOptions, nil] Advanced RPC options.
     #
@@ -652,6 +660,8 @@ module Temporalio
     end
 
     # Count standalone activities matching a visibility query.
+    #
+    # WARNING: Standalone Activities are experimental.
     #
     # @param query [String] Visibility list filter.
     # @param rpc_options [RPCOptions, nil] Advanced RPC options.

--- a/temporalio/lib/temporalio/client/activity_execution.rb
+++ b/temporalio/lib/temporalio/client/activity_execution.rb
@@ -13,6 +13,8 @@ module Temporalio
   class Client
     # Info for a standalone activity execution. Returned by list_activities; extended by {Description}
     # for describe results.
+    #
+    # WARNING: Standalone Activities are experimental.
     class ActivityExecution
       # @return [Api::Activity::V1::ActivityExecutionListInfo, Api::Activity::V1::ActivityExecutionInfo]
       #   Underlying protobuf info.
@@ -70,6 +72,8 @@ module Temporalio
       end
 
       # Rich description of a standalone activity execution; returned by {ActivityHandle#describe}.
+      #
+      # WARNING: Standalone Activities are experimental.
       class Description < ActivityExecution
         # @return [Api::WorkflowService::V1::DescribeActivityExecutionResponse] Underlying protobuf response.
         attr_reader :raw_description

--- a/temporalio/lib/temporalio/client/activity_execution_count.rb
+++ b/temporalio/lib/temporalio/client/activity_execution_count.rb
@@ -3,6 +3,8 @@
 module Temporalio
   class Client
     # Result of a {Client#count_activities} call.
+    #
+    # WARNING: Standalone Activities are experimental.
     class ActivityExecutionCount
       # @return [Integer] Approximate number of activities matching the query. If the query had a group-by clause,
       #   this is the sum of all the counts in {groups}.
@@ -18,6 +20,8 @@ module Temporalio
       end
 
       # Aggregation group if the activity count query had a group-by clause.
+      #
+      # WARNING: Standalone Activities are experimental.
       class AggregationGroup
         # @return [Integer] Approximate number of activities matching the query for this group.
         attr_reader :count

--- a/temporalio/lib/temporalio/client/activity_execution_status.rb
+++ b/temporalio/lib/temporalio/client/activity_execution_status.rb
@@ -5,6 +5,8 @@ require 'temporalio/api'
 module Temporalio
   class Client
     # Status of a standalone activity execution.
+    #
+    # WARNING: Standalone Activities are experimental.
     module ActivityExecutionStatus
       UNSPECIFIED = Api::Enums::V1::ActivityExecutionStatus::ACTIVITY_EXECUTION_STATUS_UNSPECIFIED
       RUNNING = Api::Enums::V1::ActivityExecutionStatus::ACTIVITY_EXECUTION_STATUS_RUNNING

--- a/temporalio/lib/temporalio/client/activity_handle.rb
+++ b/temporalio/lib/temporalio/client/activity_handle.rb
@@ -9,6 +9,8 @@ module Temporalio
   class Client
     # Handle for interacting with a standalone activity. Usually created via {Client.activity_handle}
     # or {Client#start_activity}.
+    #
+    # WARNING: Standalone Activities are experimental.
     class ActivityHandle
       # @return [String] ID for the activity.
       attr_reader :id

--- a/temporalio/lib/temporalio/client/activity_id_reference.rb
+++ b/temporalio/lib/temporalio/client/activity_id_reference.rb
@@ -57,7 +57,8 @@ module Temporalio
       end
 
       # @return [Boolean] True if this reference is the standalone-form (activity_run_id without workflow_id).
-      #   WARNING: Standalone Activities are experimental.
+      #
+      # WARNING: Standalone Activities are experimental.
       def standalone?
         @workflow_id.nil?
       end

--- a/temporalio/lib/temporalio/client/activity_id_reference.rb
+++ b/temporalio/lib/temporalio/client/activity_id_reference.rb
@@ -29,6 +29,8 @@ module Temporalio
 
       # Construct a standalone activity reference.
       #
+      # WARNING: Standalone Activities are experimental.
+      #
       # @param activity_id [String] ID for the activity.
       # @param activity_run_id [String, nil] Run ID for the activity execution. nil targets the latest run.
       # @return [ActivityIDReference] A reference suitable for {Client#async_activity_handle}.
@@ -55,6 +57,7 @@ module Temporalio
       end
 
       # @return [Boolean] True if this reference is the standalone-form (activity_run_id without workflow_id).
+      #   WARNING: Standalone Activities are experimental.
       def standalone?
         @workflow_id.nil?
       end

--- a/temporalio/lib/temporalio/client/interceptor.rb
+++ b/temporalio/lib/temporalio/client/interceptor.rb
@@ -259,7 +259,7 @@ module Temporalio
         :rpc_options
       )
 
-      # Input for {Outbound.start_activity}.
+      # Input for {Outbound.start_activity}. WARNING: Standalone Activities are experimental.
       StartActivityInput = Data.define(
         :activity,
         :args,
@@ -282,14 +282,14 @@ module Temporalio
         :rpc_options
       )
 
-      # Input for {Outbound.describe_activity}.
+      # Input for {Outbound.describe_activity}. WARNING: Standalone Activities are experimental.
       DescribeActivityInput = Data.define(
         :activity_id,
         :activity_run_id,
         :rpc_options
       )
 
-      # Input for {Outbound.cancel_activity}.
+      # Input for {Outbound.cancel_activity}. WARNING: Standalone Activities are experimental.
       CancelActivityInput = Data.define(
         :activity_id,
         :activity_run_id,
@@ -297,7 +297,7 @@ module Temporalio
         :rpc_options
       )
 
-      # Input for {Outbound.terminate_activity}.
+      # Input for {Outbound.terminate_activity}. WARNING: Standalone Activities are experimental.
       TerminateActivityInput = Data.define(
         :activity_id,
         :activity_run_id,
@@ -305,20 +305,20 @@ module Temporalio
         :rpc_options
       )
 
-      # Input for {Outbound.list_activities}.
+      # Input for {Outbound.list_activities}. WARNING: Standalone Activities are experimental.
       ListActivitiesInput = Data.define(
         :query,
         :rpc_options
       )
 
-      # Input for {Outbound.count_activities}.
+      # Input for {Outbound.count_activities}. WARNING: Standalone Activities are experimental.
       CountActivitiesInput = Data.define(
         :query,
         :rpc_options
       )
 
       # Input for {Outbound.fetch_activity_outcome}. Used by `ActivityHandle#result` for long-polling
-      # the activity outcome via `PollActivityExecution`.
+      # the activity outcome via `PollActivityExecution`. WARNING: Standalone Activities are experimental.
       FetchActivityOutcomeInput = Data.define(
         :activity_id,
         :activity_run_id,
@@ -536,6 +536,8 @@ module Temporalio
 
         # Called for every {Client.start_activity} and {Client.execute_activity} call.
         #
+        # WARNING: Standalone Activities are experimental.
+        #
         # @param input [StartActivityInput] Input.
         # @return [ActivityHandle] Activity handle.
         def start_activity(input)
@@ -543,6 +545,8 @@ module Temporalio
         end
 
         # Called for every {ActivityHandle.describe} call.
+        #
+        # WARNING: Standalone Activities are experimental.
         #
         # @param input [DescribeActivityInput] Input.
         # @return [ActivityExecution::Description] Activity description.
@@ -552,6 +556,8 @@ module Temporalio
 
         # Called for every {ActivityHandle.cancel} call.
         #
+        # WARNING: Standalone Activities are experimental.
+        #
         # @param input [CancelActivityInput] Input.
         def cancel_activity(input)
           next_interceptor.cancel_activity(input)
@@ -559,12 +565,16 @@ module Temporalio
 
         # Called for every {ActivityHandle.terminate} call.
         #
+        # WARNING: Standalone Activities are experimental.
+        #
         # @param input [TerminateActivityInput] Input.
         def terminate_activity(input)
           next_interceptor.terminate_activity(input)
         end
 
         # Called for every {Client.list_activities} call.
+        #
+        # WARNING: Standalone Activities are experimental.
         #
         # @param input [ListActivitiesInput] Input.
         # @return [Enumerator<ActivityExecution>] Activity executions.
@@ -574,6 +584,8 @@ module Temporalio
 
         # Called for every {Client.count_activities} call.
         #
+        # WARNING: Standalone Activities are experimental.
+        #
         # @param input [CountActivitiesInput] Input.
         # @return [ActivityExecutionCount] Activity count.
         def count_activities(input)
@@ -581,6 +593,8 @@ module Temporalio
         end
 
         # Called by {ActivityHandle.result} to long-poll the activity outcome.
+        #
+        # WARNING: Standalone Activities are experimental.
         #
         # @param input [FetchActivityOutcomeInput] Input.
         # @return [Api::Activity::V1::ActivityExecutionOutcome] Activity outcome.

--- a/temporalio/lib/temporalio/client/interceptor.rb
+++ b/temporalio/lib/temporalio/client/interceptor.rb
@@ -259,7 +259,9 @@ module Temporalio
         :rpc_options
       )
 
-      # Input for {Outbound.start_activity}. WARNING: Standalone Activities are experimental.
+      # Input for {Outbound.start_activity}.
+      #
+      # WARNING: Standalone Activities are experimental.
       StartActivityInput = Data.define(
         :activity,
         :args,
@@ -282,14 +284,18 @@ module Temporalio
         :rpc_options
       )
 
-      # Input for {Outbound.describe_activity}. WARNING: Standalone Activities are experimental.
+      # Input for {Outbound.describe_activity}.
+      #
+      # WARNING: Standalone Activities are experimental.
       DescribeActivityInput = Data.define(
         :activity_id,
         :activity_run_id,
         :rpc_options
       )
 
-      # Input for {Outbound.cancel_activity}. WARNING: Standalone Activities are experimental.
+      # Input for {Outbound.cancel_activity}.
+      #
+      # WARNING: Standalone Activities are experimental.
       CancelActivityInput = Data.define(
         :activity_id,
         :activity_run_id,
@@ -297,7 +303,9 @@ module Temporalio
         :rpc_options
       )
 
-      # Input for {Outbound.terminate_activity}. WARNING: Standalone Activities are experimental.
+      # Input for {Outbound.terminate_activity}.
+      #
+      # WARNING: Standalone Activities are experimental.
       TerminateActivityInput = Data.define(
         :activity_id,
         :activity_run_id,
@@ -305,20 +313,26 @@ module Temporalio
         :rpc_options
       )
 
-      # Input for {Outbound.list_activities}. WARNING: Standalone Activities are experimental.
+      # Input for {Outbound.list_activities}.
+      #
+      # WARNING: Standalone Activities are experimental.
       ListActivitiesInput = Data.define(
         :query,
         :rpc_options
       )
 
-      # Input for {Outbound.count_activities}. WARNING: Standalone Activities are experimental.
+      # Input for {Outbound.count_activities}.
+      #
+      # WARNING: Standalone Activities are experimental.
       CountActivitiesInput = Data.define(
         :query,
         :rpc_options
       )
 
       # Input for {Outbound.fetch_activity_outcome}. Used by `ActivityHandle#result` for long-polling
-      # the activity outcome via `PollActivityExecution`. WARNING: Standalone Activities are experimental.
+      # the activity outcome via `PollActivityExecution`.
+      #
+      # WARNING: Standalone Activities are experimental.
       FetchActivityOutcomeInput = Data.define(
         :activity_id,
         :activity_run_id,

--- a/temporalio/lib/temporalio/client/pending_activity_state.rb
+++ b/temporalio/lib/temporalio/client/pending_activity_state.rb
@@ -5,6 +5,8 @@ require 'temporalio/api'
 module Temporalio
   class Client
     # More detailed breakdown of a running activity's state.
+    #
+    # WARNING: Standalone Activities are experimental.
     module PendingActivityState
       SCHEDULED = Api::Enums::V1::PendingActivityState::PENDING_ACTIVITY_STATE_SCHEDULED
       STARTED = Api::Enums::V1::PendingActivityState::PENDING_ACTIVITY_STATE_STARTED

--- a/temporalio/lib/temporalio/common_enums.rb
+++ b/temporalio/lib/temporalio/common_enums.rb
@@ -85,7 +85,9 @@ module Temporalio
   end
 
   # Controls behavior when an activity with the same ID was previously run and is now closed. Used with
-  # standalone activities started via {Client#start_activity}. WARNING: Standalone Activities are experimental.
+  # standalone activities started via {Client#start_activity}.
+  #
+  # WARNING: Standalone Activities are experimental.
   #
   # @see https://docs.temporal.io/activities
   module ActivityIDReusePolicy
@@ -100,7 +102,9 @@ module Temporalio
   end
 
   # Controls behavior when an activity with the same ID is currently running. Used with standalone
-  # activities started via {Client#start_activity}. WARNING: Standalone Activities are experimental.
+  # activities started via {Client#start_activity}.
+  #
+  # WARNING: Standalone Activities are experimental.
   #
   # @see https://docs.temporal.io/activities
   module ActivityIDConflictPolicy

--- a/temporalio/lib/temporalio/common_enums.rb
+++ b/temporalio/lib/temporalio/common_enums.rb
@@ -84,7 +84,8 @@ module Temporalio
       Api::Enums::V1::SuggestContinueAsNewReason::SUGGEST_CONTINUE_AS_NEW_REASON_TOO_MANY_UPDATES
   end
 
-  # Controls behavior when an activity with the same ID was previously run and is now closed.
+  # Controls behavior when an activity with the same ID was previously run and is now closed. Used with
+  # standalone activities started via {Client#start_activity}. WARNING: Standalone Activities are experimental.
   #
   # @see https://docs.temporal.io/activities
   module ActivityIDReusePolicy
@@ -98,7 +99,8 @@ module Temporalio
     REJECT_DUPLICATE = Api::Enums::V1::ActivityIdReusePolicy::ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE
   end
 
-  # Controls behavior when an activity with the same ID is currently running.
+  # Controls behavior when an activity with the same ID is currently running. Used with standalone
+  # activities started via {Client#start_activity}. WARNING: Standalone Activities are experimental.
   #
   # @see https://docs.temporal.io/activities
   module ActivityIDConflictPolicy

--- a/temporalio/lib/temporalio/common_enums.rb
+++ b/temporalio/lib/temporalio/common_enums.rb
@@ -84,8 +84,7 @@ module Temporalio
       Api::Enums::V1::SuggestContinueAsNewReason::SUGGEST_CONTINUE_AS_NEW_REASON_TOO_MANY_UPDATES
   end
 
-  # Controls behavior when an activity with the same ID was previously run and is now closed. Used with
-  # standalone activities started via {Client#start_activity}.
+  # Controls behavior when an activity with the same ID was previously run and is now closed.
   #
   # WARNING: Standalone Activities are experimental.
   #
@@ -101,8 +100,7 @@ module Temporalio
     REJECT_DUPLICATE = Api::Enums::V1::ActivityIdReusePolicy::ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE
   end
 
-  # Controls behavior when an activity with the same ID is currently running. Used with standalone
-  # activities started via {Client#start_activity}.
+  # Controls behavior when an activity with the same ID is currently running.
   #
   # WARNING: Standalone Activities are experimental.
   #

--- a/temporalio/lib/temporalio/error.rb
+++ b/temporalio/lib/temporalio/error.rb
@@ -42,6 +42,8 @@ module Temporalio
 
     # Error returned from {Client::ActivityHandle#result} when the activity did not complete successfully.
     # The specific activity failure can be accessed via `cause`.
+    #
+    # WARNING: Standalone Activities are experimental.
     class ActivityFailedError < Error
       # @!visibility private
       def initialize(message = 'Activity execution failed')

--- a/temporalio/lib/temporalio/error/failure.rb
+++ b/temporalio/lib/temporalio/error/failure.rb
@@ -30,6 +30,8 @@ module Temporalio
     end
 
     # Error raised by a client when a standalone activity execution has already started.
+    #
+    # WARNING: Standalone Activities are experimental.
     class ActivityAlreadyStartedError < Failure
       # @return [String] ID of the already-started activity.
       attr_reader :activity_id


### PR DESCRIPTION
Add "Standalone Activities are experimental" to all user-facing Standalone Activities features.