### PR TITLE
chore: remove race from SAA terminate interceptor test

### DIFF
--- a/temporalio/test/client_activity_interceptor_chain_test.rb
+++ b/temporalio/test/client_activity_interceptor_chain_test.rb
@@ -13,6 +13,14 @@ class ClientActivityInterceptorChainTest < Test
     end
   end
 
+  class SleepUntilCancelActivity < Temporalio::Activity::Definition
+    def execute
+      Temporalio::Activity::Context.current.heartbeat
+      sleep 0.1 until Temporalio::Activity::Context.current.cancellation.canceled?
+      raise Temporalio::Error::CanceledError, 'canceled'
+    end
+  end
+
   # Records the order of calls through the interceptor chain.
   class RecordingInterceptor
     include Temporalio::Client::Interceptor
@@ -107,9 +115,9 @@ class ClientActivityInterceptorChainTest < Test
     events = []
     interceptor = RecordingInterceptor.new('A', events)
     client = client_with_interceptors([interceptor])
-    with_activity_worker(client, [SimpleActivity]) do |task_queue|
+    with_activity_worker(client, [SleepUntilCancelActivity]) do |task_queue|
       handle = client.start_activity(
-        SimpleActivity,
+        SleepUntilCancelActivity,
         id: "act-#{SecureRandom.uuid}",
         task_queue: task_queue,
         start_to_close_timeout: 10


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Previously we were terminating an activity that immediately completed which was racey if we ended up starting and completing an activity before terminating it. We switch to an activity that just sleeps until it is cancelled.

## Why?
I witnessed this test flake on [another PR](https://github.com/temporalio/sdk-ruby/actions/runs/27216217194/job/80358309046?pr=410).
```
ClientActivityInterceptorChainTest#test_describe_terminate_interceptors_called:
RuntimeError: Neutered Exception Temporalio::Error::RPCError: invalid transition from Completed
    lib/temporalio/client/connection/service.rb:36:in `rescue in invoke_rpc'
    lib/temporalio/client/connection/service.rb:23:in `invoke_rpc'
    lib/temporalio/client/connection/workflow_service.rb:1720:in `terminate_activity_execution'
    lib/temporalio/internal/client/implementation.rb:1049:in `terminate_activity'
    lib/temporalio/client/interceptor.rb:564:in `terminate_activity'
    test/client_activity_interceptor_chain_test.rb:55:in `terminate_activity'
    lib/temporalio/client/activity_handle.rb:93:in `terminate'
    test/client_activity_interceptor_chain_test.rb:118:in `block in test_describe_terminate_interceptors_called'
    test/client_activity_interceptor_chain_test.rb:86:in `block in with_activity_worker'
    lib/temporalio/internal/worker/multi_runner.rb:42:in `block in apply_thread_or_fiber_block'
```

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
No flake in CI

3. Any docs updates needed?
N/A
