### PR TITLE
chore: add ramping percentage to worker deployment routing helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           TEMPORAL_CLOUD_MTLS_TEST_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
 
           # For API key tests
-          TEMPORAL_CLOUD_API_KEY_TEST_TARGET_HOST: us-east-1.aws.api.temporal.io:7233
+          TEMPORAL_CLOUD_API_KEY_TEST_TARGET_HOST: ca-central-1.aws.api.temporal.io:7233
           TEMPORAL_CLOUD_API_KEY_TEST_NAMESPACE: ${{ vars.TEMPORAL_CLIENT_NAMESPACE }}
           TEMPORAL_CLOUD_API_KEY_TEST_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
 

--- a/temporalio/test/sig/worker_workflow_versioning_test.rbs
+++ b/temporalio/test/sig/worker_workflow_versioning_test.rbs
@@ -4,5 +4,5 @@ class WorkerWorkflowVersioningTest < Test
   def set_current_deployment_version: (untyped client, String task_queue, Temporalio::WorkerDeploymentVersion version) -> untyped
   def set_ramping_version: (untyped client, String task_queue, Temporalio::WorkerDeploymentVersion version, Float rate) -> untyped
   def wait_for_workflow_running_on_version: (untyped handle, String expected_build_id) -> void
-  def wait_for_worker_deployment_routing_config_propagation: (untyped client, String deployment_name, String expected_current_build_id, ?String expected_ramping_build_id) -> void
+  def wait_for_worker_deployment_routing_config_propagation: (untyped client, String deployment_name, String expected_current_build_id, ?String expected_ramping_build_id, ?Float expected_ramping_percentage) -> void
 end

--- a/temporalio/test/worker_workflow_versioning_test.rb
+++ b/temporalio/test/worker_workflow_versioning_test.rb
@@ -138,6 +138,7 @@ class WorkerWorkflowVersioningTest < Test
         # Wait for worker v1 to be visible and set as current
         describe_resp = wait_until_worker_deployment_visible(env.client, worker_v1)
         set_current_deployment_version(env.client, describe_resp.conflict_token, worker_v1)
+        wait_for_worker_deployment_routing_config_propagation(env.client, deployment_name, worker_v1.build_id)
 
         # Start workflow 1 which will use the 1.0 worker on auto-upgrade
         handle1 = env.client.start_workflow(
@@ -150,6 +151,7 @@ class WorkerWorkflowVersioningTest < Test
         # Set v2 as current deployment
         describe_resp2 = wait_until_worker_deployment_visible(env.client, worker_v2)
         set_current_deployment_version(env.client, describe_resp2.conflict_token, worker_v2)
+        wait_for_worker_deployment_routing_config_propagation(env.client, deployment_name, worker_v2.build_id)
 
         # Start workflow 2 which will use the 2.0 worker on pinned
         handle2 = env.client.start_workflow(
@@ -162,6 +164,7 @@ class WorkerWorkflowVersioningTest < Test
         # Set v3 as current deployment
         describe_resp3 = wait_until_worker_deployment_visible(env.client, worker_v3)
         set_current_deployment_version(env.client, describe_resp3.conflict_token, worker_v3)
+        wait_for_worker_deployment_routing_config_propagation(env.client, deployment_name, worker_v3.build_id)
 
         # Start workflow 3 which will use the 3.0 worker on auto-upgrade
         handle3 = env.client.start_workflow(
@@ -242,6 +245,13 @@ class WorkerWorkflowVersioningTest < Test
           worker_v2,
           100.0
         ).conflict_token
+        wait_for_worker_deployment_routing_config_propagation(
+          env.client,
+          deployment_name,
+          worker_v1.build_id,
+          worker_v2.build_id,
+          100.0
+        )
 
         # Run workflows and verify they run on v2
         3.times do |i|
@@ -261,6 +271,13 @@ class WorkerWorkflowVersioningTest < Test
           worker_v2,
           0.0
         ).conflict_token
+        wait_for_worker_deployment_routing_config_propagation(
+          env.client,
+          deployment_name,
+          worker_v1.build_id,
+          worker_v2.build_id,
+          0.0
+        )
 
         3.times do |i|
           handle = env.client.start_workflow(
@@ -274,6 +291,13 @@ class WorkerWorkflowVersioningTest < Test
 
         # Set ramp to 50 and eventually verify workflows run on both versions
         set_ramping_version(env.client, conflict_token, worker_v2, 50.0)
+        wait_for_worker_deployment_routing_config_propagation(
+          env.client,
+          deployment_name,
+          worker_v1.build_id,
+          worker_v2.build_id,
+          50.0
+        )
         seen_results = Set.new
 
         # Keep running workflows until we've seen both versions
@@ -350,6 +374,7 @@ class WorkerWorkflowVersioningTest < Test
     worker.run do
       describe_resp = wait_until_worker_deployment_visible(env.client, worker_v1)
       set_current_deployment_version(env.client, describe_resp.conflict_token, worker_v1)
+      wait_for_worker_deployment_routing_config_propagation(env.client, deployment_name, worker_v1.build_id)
 
       handle = env.client.start_workflow(
         'cooldynamicworkflow',
@@ -435,6 +460,7 @@ class WorkerWorkflowVersioningTest < Test
     worker.run do
       describe_resp = wait_until_worker_deployment_visible(env.client, worker_v1)
       set_current_deployment_version(env.client, describe_resp.conflict_token, worker_v1)
+      wait_for_worker_deployment_routing_config_propagation(env.client, deployment_name, worker_v1.build_id)
 
       handle = env.client.start_workflow(
         NoVersioningAnnotationWorkflow,
@@ -597,6 +623,7 @@ class WorkerWorkflowVersioningTest < Test
       describe_resp = wait_until_worker_deployment_visible(env.client, worker_v1)
       # Set current deployment version
       set_current_deployment_version(env.client, describe_resp.conflict_token, worker_v1)
+      wait_for_worker_deployment_routing_config_propagation(env.client, deployment_name, worker_v1.build_id)
 
       # Start workflow with pinned versioning override
       handle = env.client.start_workflow(
@@ -798,7 +825,8 @@ class WorkerWorkflowVersioningTest < Test
         env.client,
         deployment_name,
         worker_v1.build_id,
-        worker_v2.build_id
+        worker_v2.build_id,
+        0.0
       )
 
       handle.signal(CanRampingVersionWorkflowV1.do_continue_as_new)
@@ -821,7 +849,8 @@ class WorkerWorkflowVersioningTest < Test
   end
 
   def wait_for_worker_deployment_routing_config_propagation(
-    client, deployment_name, expected_current_build_id, expected_ramping_build_id = ''
+    client, deployment_name, expected_current_build_id, expected_ramping_build_id = '',
+    expected_ramping_percentage = nil
   )
     assert_eventually do
       res = client.workflow_service.describe_worker_deployment(
@@ -839,6 +868,11 @@ class WorkerWorkflowVersioningTest < Test
 
       assert_equal expected_ramping_build_id,
                    routing_config.ramping_deployment_version&.build_id.to_s
+
+      unless expected_ramping_percentage.nil?
+        assert_equal expected_ramping_percentage,
+                     routing_config.ramping_version_percentage
+      end
 
       state = info.routing_config_update_state
       assert(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Leverage `wait_for_worker_deployment_routing_config_propagation` in all of our worker versioning tests to reduce flakes.

Add `expected_ramping_percentage` to our `wait_for_worker_deployment_routing_config_propagation` helper to avoid some flakes. 

## Why?
Had these tests flake for me on another PR.

Copying https://github.com/temporalio/sdk-typescript/pull/2089 which seems to have resolved flakes around the worker versioning tests.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI

3. Any docs updates needed?
N/A
