### PR TITLE
fix: scheduler can no longer yield if protobuf mutex is held

### DIFF
--- a/temporalio/lib/temporalio/internal/google_protobuf.rb
+++ b/temporalio/lib/temporalio/internal/google_protobuf.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Temporalio
+  module Internal
+    module GoogleProtobuf
+      def self.in_call_stack?(locations)
+        locations&.any? { |loc| loc.path&.include?('google/protobuf/') }
+      end
+    end
+  end
+end

--- a/temporalio/lib/temporalio/internal/google_protobuf.rb
+++ b/temporalio/lib/temporalio/internal/google_protobuf.rb
@@ -4,7 +4,7 @@ module Temporalio
   module Internal
     module GoogleProtobuf
       def self.in_call_stack?(locations)
-        locations&.any? { |loc| loc.path&.include?('google/protobuf/') }
+        locations&.any? { |loc| loc.path&.include?('google/protobuf/') } || false
       end
     end
   end

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/scheduler.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/scheduler.rb
@@ -38,6 +38,10 @@ module Temporalio
                 fiber.resume
               end
 
+              # Thread-blocking fibers are not durable workflow yields. Wait for them to unblock before satisfying any
+              # wait condition so the condition sees the workflow after all runnable work has settled.
+              next if wait_for_thread_blocking_fiber
+
               # Find the _first_ resolvable wait condition and if there, resolve it, and loop again, otherwise return.
               # It is important that we both let fibers get all settled _before_ this and only allow a _single_ wait
               # condition to be satisfied before looping. This allows wait condition users to trust that the line of
@@ -57,11 +61,7 @@ module Temporalio
                 cond_fiber = deleted_cond.last
                 break
               end
-              unless cond_fiber
-                next if wait_for_thread_blocking_fiber
-
-                return
-              end
+              return unless cond_fiber
 
               cond_fiber.resume(cond_result)
             end
@@ -234,6 +234,7 @@ module Temporalio
 
           def wait_for_thread_blocking_fiber
             synchronize_thread_blocking_fibers do
+              return true unless @ready.empty?
               return false if @thread_blocking_fibers.empty?
 
               @thread_blocking_condition.wait(@thread_blocking_mutex) while @ready.empty? &&

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/scheduler.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/scheduler.rb
@@ -3,6 +3,7 @@
 require 'temporalio'
 require 'temporalio/cancellation'
 require 'temporalio/error'
+require 'temporalio/internal/google_protobuf'
 require 'temporalio/internal/worker/workflow_instance'
 require 'temporalio/workflow'
 require 'timeout'
@@ -19,6 +20,10 @@ module Temporalio
             @ready = []
             @wait_conditions = {}
             @wait_condition_counter = 0
+            @thread_blocking_fibers = {}
+            @thread_blocking_mutex = Mutex.new
+            @thread_blocking_condition = ConditionVariable.new
+            @workflow_thread = nil
           end
 
           def context
@@ -26,6 +31,7 @@ module Temporalio
           end
 
           def run_until_all_yielded
+            @workflow_thread = Thread.current
             loop do
               # Run all fibers until all yielded
               while (fiber = @ready.shift)
@@ -51,10 +57,16 @@ module Temporalio
                 cond_fiber = deleted_cond.last
                 break
               end
-              return unless cond_fiber
+              unless cond_fiber
+                next if wait_for_thread_blocking_fiber
+
+                return
+              end
 
               cond_fiber.resume(cond_result)
             end
+          ensure
+            @workflow_thread = nil
           end
 
           def wait_condition(cancellation:, &block)
@@ -110,8 +122,25 @@ module Temporalio
           # work inside of workflows. So we only implement the bare minimum.
           ###
 
-          def block(_blocker, timeout = nil)
+          def block(blocker, timeout = nil)
             # TODO(cretz): Make the blocker visible in the stack trace?
+
+            # Protobuf's object cache uses a process-local Mutex. We allowlist that Mutex use, but it is not a durable
+            # workflow yield: if it blocks the only runnable workflow fiber, the workflow task must remain blocked so
+            # deadlock detection can fail it instead of completing a partial command set.
+            if timeout.nil? && thread_blocking_protobuf_mutex_wait?(blocker)
+              fiber = Fiber.current
+              synchronize_thread_blocking_fibers { @thread_blocking_fibers[fiber] = true }
+              begin
+                Fiber.yield
+                return true
+              ensure
+                synchronize_thread_blocking_fibers do
+                  @thread_blocking_fibers.delete(fiber)
+                  @thread_blocking_condition.broadcast
+                end
+              end
+            end
 
             # We just yield because unblock will resume this. We will just wrap in timeout if needed.
             if timeout
@@ -189,7 +218,48 @@ module Temporalio
           end
 
           def unblock(_blocker, fiber)
-            @ready << fiber
+            synchronize_thread_blocking_fibers do
+              @thread_blocking_fibers.delete(fiber)
+              @ready << fiber
+              @thread_blocking_condition.broadcast
+            end
+          end
+
+          private
+
+          def thread_blocking_protobuf_mutex_wait?(blocker)
+            blocker.is_a?(::Mutex) &&
+              ::Temporalio::Internal::GoogleProtobuf.in_call_stack?(caller_locations)
+          end
+
+          def wait_for_thread_blocking_fiber
+            synchronize_thread_blocking_fibers do
+              return false if @thread_blocking_fibers.empty?
+
+              @thread_blocking_condition.wait(@thread_blocking_mutex) while @ready.empty? &&
+                                                                            !@thread_blocking_fibers.empty?
+              true
+            end
+          end
+
+          def synchronize_thread_blocking_fibers(&)
+            if Thread.current == @workflow_thread
+              with_workflow_scheduler_disabled do
+                @thread_blocking_mutex.synchronize(&)
+              end
+            else
+              @thread_blocking_mutex.synchronize(&)
+            end
+          end
+
+          def with_workflow_scheduler_disabled
+            previous_scheduler = Fiber.scheduler
+            @instance.illegal_call_tracing_disabled do
+              Fiber.set_scheduler(nil)
+              yield
+            ensure
+              Fiber.set_scheduler(previous_scheduler)
+            end
           end
         end
       end

--- a/temporalio/lib/temporalio/worker/illegal_workflow_call_validator.rb
+++ b/temporalio/lib/temporalio/worker/illegal_workflow_call_validator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'temporalio/internal/google_protobuf'
+
 module Temporalio
   class Worker
     # Custom validator for validating illegal workflow calls.
@@ -44,7 +46,7 @@ module Temporalio
       def self.known_safe_mutex_validator
         @known_safe_mutex_validator ||= IllegalWorkflowCallValidator.new do
           # Only Google Protobuf use of Mutex is known to be safe, fail unless any caller location path has protobuf
-          raise 'disallowed' unless caller_locations&.any? { |loc| loc.path&.include?('google/protobuf/') }
+          raise 'disallowed' unless ::Temporalio::Internal::GoogleProtobuf.in_call_stack?(caller_locations)
         end
       end
 

--- a/temporalio/rbi/temporalio/internal/google_protobuf.rbi
+++ b/temporalio/rbi/temporalio/internal/google_protobuf.rbi
@@ -1,0 +1,8 @@
+# typed: true
+
+module Temporalio::Internal::GoogleProtobuf
+  extend T::Sig
+
+  sig { params(locations: T.untyped).returns(T::Boolean) }
+  def self.in_call_stack?(locations); end
+end

--- a/temporalio/rbi/temporalio/internal/google_protobuf.rbi
+++ b/temporalio/rbi/temporalio/internal/google_protobuf.rbi
@@ -3,6 +3,6 @@
 module Temporalio::Internal::GoogleProtobuf
   extend T::Sig
 
-  sig { params(locations: T.untyped).returns(T::Boolean) }
+  sig { params(locations: T.nilable(T::Array[Thread::Backtrace::Location])).returns(T::Boolean) }
   def self.in_call_stack?(locations); end
 end

--- a/temporalio/sig/temporalio/internal/google_protobuf.rbs
+++ b/temporalio/sig/temporalio/internal/google_protobuf.rbs
@@ -1,0 +1,7 @@
+module Temporalio
+  module Internal
+    module GoogleProtobuf
+      def self.in_call_stack?: (untyped locations) -> bool
+    end
+  end
+end

--- a/temporalio/sig/temporalio/internal/google_protobuf.rbs
+++ b/temporalio/sig/temporalio/internal/google_protobuf.rbs
@@ -1,7 +1,7 @@
 module Temporalio
   module Internal
     module GoogleProtobuf
-      def self.in_call_stack?: (untyped locations) -> bool
+      def self.in_call_stack?: (Array[Thread::Backtrace::Location] | nil locations) -> bool
     end
   end
 end

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance/scheduler.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance/scheduler.rbs
@@ -13,12 +13,38 @@ module Temporalio
 
           def stack_trace: -> String
 
+          def block: (untyped blocker, ?duration? timeout) -> bool
+
+          def close: -> void
+
+          def fiber: { -> untyped } -> Fiber
+
+          def fiber_interrupt: (Fiber fiber, Exception exception) -> void
+
+          def io_wait: (IO io, Integer events, duration? timeout) -> Integer
+
+          def kernel_sleep: (?duration? duration) -> untyped
+
+          def process_wait: (Integer pid, Integer flags) -> bot
+
           # Only needed to say block is required
           def timeout_after: [T] (
             duration? duration,
             singleton(Exception) exception_class,
             *Object? exception_args
           ) { -> T } -> T
+
+          def unblock: (untyped blocker, Fiber fiber) -> void
+
+          private
+
+          def thread_blocking_protobuf_mutex_wait?: (untyped blocker) -> bool
+
+          def wait_for_thread_blocking_fiber: -> bool
+
+          def synchronize_thread_blocking_fibers: [T] () { -> T } -> T
+
+          def with_workflow_scheduler_disabled: [T] () { -> T } -> T
         end
       end
     end

--- a/temporalio/test/deadlock_test.rb
+++ b/temporalio/test/deadlock_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'securerandom'
 require 'google/protobuf'
+require 'securerandom'
 require 'temporalio/testing'
 require 'temporalio/worker'
 require 'temporalio/workflow'
@@ -164,47 +164,49 @@ class DeadlockTest < Test
   end
 
   def test_protobuf_object_cache_mutex_does_not_complete_workflow_task_while_blocked
+    # @type var release_mutex: (^() -> void)?
     release_mutex = nil
     execute_workflow(
       ProtobufObjectCacheMutexWorkflow,
       activities: [BasicActivity]
     ) do |handle|
+      Timeout.timeout(10) { ProtobufObjectCacheMutexWorkflow::REACHED_PROTOBUF_CACHE.pop }
+      release_mutex = hold_protobuf_object_cache_mutex
+      ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = true
+      wait_for_protobuf_object_cache_mutex_waiter
+      (release_mutex || raise).call
+      release_mutex = nil
+
+      # @type var events: Array[untyped]
+      events = []
+      assert_eventually(timeout: 10.0) do
+        events = handle.fetch_history_events.to_a
+        assert events.any?(&:workflow_task_completed_event_attributes)
+      end
+
+      workflow_task_completed = events.find(&:workflow_task_completed_event_attributes)
+      activity_scheduled = events.find(&:activity_task_scheduled_event_attributes)
+      refute_nil(
+        activity_scheduled,
+        'Workflow task completed while a workflow fiber was blocked on the protobuf ObjectCache mutex'
+      )
+      assert_equal workflow_task_completed.event_id + 1, activity_scheduled.event_id
+    ensure
+      ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = true
+      release_mutex&.call
       begin
-        Timeout.timeout(10) { ProtobufObjectCacheMutexWorkflow::REACHED_PROTOBUF_CACHE.pop }
-        release_mutex = hold_protobuf_object_cache_mutex
-        ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = true
-        wait_for_protobuf_object_cache_mutex_waiter
-        release_mutex.call
-        release_mutex = nil
-
-        events = nil
-        assert_eventually(timeout: 10) do
-          events = handle.fetch_history_events.to_a
-          assert events.any?(&:workflow_task_completed_event_attributes)
-        end
-
-        workflow_task_completed = events.find(&:workflow_task_completed_event_attributes)
-        activity_scheduled = events.find(&:activity_task_scheduled_event_attributes)
-        refute_nil(
-          activity_scheduled,
-          'Workflow task completed while a workflow fiber was blocked on the protobuf ObjectCache mutex'
-        )
-        assert_equal workflow_task_completed.event_id + 1, activity_scheduled.event_id
-      ensure
-        ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = true
-        release_mutex&.call
-        begin
-          handle.terminate
-        rescue Temporalio::Error::RPCError
-          # Ignore cleanup races if the workflow closed before terminate arrived.
-        end
+        handle.terminate
+      rescue Temporalio::Error::RPCError
+        # Ignore cleanup races if the workflow closed before terminate arrived.
       end
     end
   end
 
   def test_protobuf_object_cache_mutex_does_not_emit_partial_command_batch
     task_queue = "tq-#{SecureRandom.uuid}"
+    # @type var release_mutex: (^() -> void)?
     release_mutex = nil
+    # @type var handle: untyped
     handle = nil
     scheduler_drained = Queue.new
     SchedulerDrainProbe.queue = scheduler_drained
@@ -217,54 +219,54 @@ class DeadlockTest < Test
     )
 
     worker.run do
-      begin
-        handle = env.client.start_workflow(
-          ProtobufObjectCachePartialCommandsWorkflow,
-          id: "wf-#{SecureRandom.uuid}",
-          task_queue:
+      handle = env.client.start_workflow(
+        ProtobufObjectCachePartialCommandsWorkflow,
+        id: "wf-#{SecureRandom.uuid}",
+        task_queue:
+      )
+      Timeout.timeout(10) { ProtobufObjectCachePartialCommandsWorkflow::REACHED_PROTOBUF_CACHE.pop }
+      release_mutex = hold_protobuf_object_cache_mutex
+      ProtobufObjectCachePartialCommandsWorkflow.protobuf_mutex_held = true
+      wait_for_protobuf_object_cache_mutex_waiter
+      Timeout.timeout(10.0) { scheduler_drained.pop }
+      (release_mutex || raise).call
+      release_mutex = nil
+
+      # @type var events: Array[untyped]
+      events = []
+      assert_eventually(timeout: 10.0) do
+        events = handle.fetch_history_events.to_a
+        assert(events.any? do |event|
+          %i[
+            EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+            EVENT_TYPE_WORKFLOW_TASK_FAILED
+          ].include?(event.event_type)
+        end)
+      end
+
+      first_completed_index = events.index { |event| event.event_type == :EVENT_TYPE_WORKFLOW_TASK_COMPLETED }
+      first_failed_index = events.index { |event| event.event_type == :EVENT_TYPE_WORKFLOW_TASK_FAILED }
+      unless first_failed_index && (!first_completed_index || first_failed_index < first_completed_index)
+        refute_nil first_completed_index, "History event types: #{events.map(&:event_type).inspect}"
+        completed_index = first_completed_index || raise
+        scheduled_count = (events[(completed_index + 1)..] || []).take_while do |event|
+          event.event_type == :EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+        end.size
+        assert_equal(
+          ProtobufObjectCachePartialCommandsWorkflow::ACTIVITY_COUNT,
+          scheduled_count,
+          'Workflow task completed with a partial activity schedule command batch while a workflow fiber was ' \
+          'blocked on the protobuf ObjectCache mutex'
         )
-        Timeout.timeout(10) { ProtobufObjectCachePartialCommandsWorkflow::REACHED_PROTOBUF_CACHE.pop }
-        release_mutex = hold_protobuf_object_cache_mutex
-        ProtobufObjectCachePartialCommandsWorkflow.protobuf_mutex_held = true
-        wait_for_protobuf_object_cache_mutex_waiter
-        Timeout.timeout(10) { scheduler_drained.pop }
-        release_mutex.call
-        release_mutex = nil
-
-        events = nil
-        assert_eventually(timeout: 10) do
-          events = handle.fetch_history_events.to_a
-          assert(events.any? do |event|
-            %i[
-              EVENT_TYPE_WORKFLOW_TASK_COMPLETED
-              EVENT_TYPE_WORKFLOW_TASK_FAILED
-            ].include?(event.event_type)
-          end)
-        end
-
-        first_completed_index = events.index { |event| event.event_type == :EVENT_TYPE_WORKFLOW_TASK_COMPLETED }
-        first_failed_index = events.index { |event| event.event_type == :EVENT_TYPE_WORKFLOW_TASK_FAILED }
-        unless first_failed_index && (!first_completed_index || first_failed_index < first_completed_index)
-          refute_nil first_completed_index, "History event types: #{events.map(&:event_type).inspect}"
-          scheduled_count = (events[(first_completed_index + 1)..] || []).take_while do |event|
-            event.event_type == :EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
-          end.size
-          assert_equal(
-            ProtobufObjectCachePartialCommandsWorkflow::ACTIVITY_COUNT,
-            scheduled_count,
-            'Workflow task completed with a partial activity schedule command batch while a workflow fiber was ' \
-            'blocked on the protobuf ObjectCache mutex'
-          )
-        end
-      ensure
-        SchedulerDrainProbe.queue = nil
-        ProtobufObjectCachePartialCommandsWorkflow.protobuf_mutex_held = true
-        release_mutex&.call
-        begin
-          handle&.terminate
-        rescue Temporalio::Error::RPCError
-          # Ignore cleanup races if the workflow closed before terminate arrived.
-        end
+      end
+    ensure
+      SchedulerDrainProbe.queue = nil
+      ProtobufObjectCachePartialCommandsWorkflow.protobuf_mutex_held = true
+      release_mutex&.call
+      begin
+        handle&.terminate
+      rescue Temporalio::Error::RPCError
+        # Ignore cleanup races if the workflow closed before terminate arrived.
       end
     end
   end
@@ -292,7 +294,7 @@ class DeadlockTest < Test
   end
 
   def wait_for_protobuf_object_cache_mutex_waiter
-    assert_eventually(timeout: 10, interval: 0.01) do
+    assert_eventually(timeout: 10.0, interval: 0.01) do
       assert(
         Thread.list.any? do |thread|
           next false if thread == Thread.current

--- a/temporalio/test/deadlock_test.rb
+++ b/temporalio/test/deadlock_test.rb
@@ -1,12 +1,30 @@
 # frozen_string_literal: true
 
 require 'securerandom'
+require 'google/protobuf'
 require 'temporalio/testing'
 require 'temporalio/worker'
 require 'temporalio/workflow'
 require 'test'
 
 class DeadlockTest < Test
+  module SchedulerDrainProbe
+    class << self
+      attr_accessor :queue
+    end
+
+    def run_until_all_yielded
+      super
+    ensure
+      queue = SchedulerDrainProbe.queue
+      @instance.illegal_call_tracing_disabled { queue << true } if queue
+    end
+  end
+
+  unless Temporalio::Internal::Worker::WorkflowInstance::Scheduler.ancestors.include?(SchedulerDrainProbe)
+    Temporalio::Internal::Worker::WorkflowInstance::Scheduler.prepend(SchedulerDrainProbe)
+  end
+
   class BasicActivity < Temporalio::Activity::Definition
     def execute(value)
       value
@@ -45,6 +63,58 @@ class DeadlockTest < Test
       Temporalio::Workflow.sleep(0.1)
       Temporalio::Workflow.wait_condition { false }
     end
+  end
+
+  class ProtobufObjectCacheMutexWorkflow < Temporalio::Workflow::Definition
+    REACHED_PROTOBUF_CACHE = Queue.new
+
+    class << self
+      attr_accessor :protobuf_mutex_held
+    end
+
+    def execute
+      Temporalio::Workflow::Future.new do
+        Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled { REACHED_PROTOBUF_CACHE << true }
+        nil until self.class.protobuf_mutex_held
+        Google::Protobuf::Internal::OBJECT_CACHE.try_add(Object.new, Object.new)
+        Temporalio::Workflow.execute_activity(BasicActivity, 'done', start_to_close_timeout: 10)
+      end.wait
+    end
+  end
+
+  class ProtobufObjectCachePartialCommandsWorkflow < Temporalio::Workflow::Definition
+    ACTIVITY_COUNT = 6
+    BLOCK_AFTER_ACTIVITY_COUNT = 3
+    REACHED_PROTOBUF_CACHE = Queue.new
+
+    class << self
+      attr_accessor :protobuf_mutex_held
+    end
+
+    def execute
+      futures = []
+      ACTIVITY_COUNT.times do |index|
+        if index == BLOCK_AFTER_ACTIVITY_COUNT
+          Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled { REACHED_PROTOBUF_CACHE << true }
+          Temporalio::Workflow.wait_condition(cancellation: nil) { true }
+          nil until self.class.protobuf_mutex_held
+          Google::Protobuf::Internal::OBJECT_CACHE.try_add(Object.new, Object.new)
+        end
+        futures << Temporalio::Workflow::Future.new do
+          Temporalio::Workflow.execute_activity(BasicActivity, index, start_to_close_timeout: 10)
+        end
+      end
+      Temporalio::Workflow::Future.all_of(*futures).wait
+    end
+  end
+
+  def setup
+    super
+    ProtobufObjectCacheMutexWorkflow::REACHED_PROTOBUF_CACHE.clear
+    ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = false
+    ProtobufObjectCachePartialCommandsWorkflow::REACHED_PROTOBUF_CACHE.clear
+    ProtobufObjectCachePartialCommandsWorkflow.protobuf_mutex_held = false
+    SchedulerDrainProbe.queue = nil
   end
 
   def test_deadlock_in_future_fails_workflow_task_and_replays_on_new_worker
@@ -91,5 +161,149 @@ class DeadlockTest < Test
     end
   ensure
     handle&.terminate
+  end
+
+  def test_protobuf_object_cache_mutex_does_not_complete_workflow_task_while_blocked
+    release_mutex = nil
+    execute_workflow(
+      ProtobufObjectCacheMutexWorkflow,
+      activities: [BasicActivity]
+    ) do |handle|
+      begin
+        Timeout.timeout(10) { ProtobufObjectCacheMutexWorkflow::REACHED_PROTOBUF_CACHE.pop }
+        release_mutex = hold_protobuf_object_cache_mutex
+        ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = true
+        wait_for_protobuf_object_cache_mutex_waiter
+        release_mutex.call
+        release_mutex = nil
+
+        events = nil
+        assert_eventually(timeout: 10) do
+          events = handle.fetch_history_events.to_a
+          assert events.any?(&:workflow_task_completed_event_attributes)
+        end
+
+        workflow_task_completed = events.find(&:workflow_task_completed_event_attributes)
+        activity_scheduled = events.find(&:activity_task_scheduled_event_attributes)
+        refute_nil(
+          activity_scheduled,
+          'Workflow task completed while a workflow fiber was blocked on the protobuf ObjectCache mutex'
+        )
+        assert_equal workflow_task_completed.event_id + 1, activity_scheduled.event_id
+      ensure
+        ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = true
+        release_mutex&.call
+        begin
+          handle.terminate
+        rescue Temporalio::Error::RPCError
+          # Ignore cleanup races if the workflow closed before terminate arrived.
+        end
+      end
+    end
+  end
+
+  def test_protobuf_object_cache_mutex_does_not_emit_partial_command_batch
+    task_queue = "tq-#{SecureRandom.uuid}"
+    release_mutex = nil
+    handle = nil
+    scheduler_drained = Queue.new
+    SchedulerDrainProbe.queue = scheduler_drained
+    worker = Temporalio::Worker.new(
+      client: env.client,
+      task_queue:,
+      workflows: [ProtobufObjectCachePartialCommandsWorkflow],
+      activities: [BasicActivity],
+      workflow_executor: Temporalio::Worker::WorkflowExecutor::ThreadPool.new(max_threads: 1)
+    )
+
+    worker.run do
+      begin
+        handle = env.client.start_workflow(
+          ProtobufObjectCachePartialCommandsWorkflow,
+          id: "wf-#{SecureRandom.uuid}",
+          task_queue:
+        )
+        Timeout.timeout(10) { ProtobufObjectCachePartialCommandsWorkflow::REACHED_PROTOBUF_CACHE.pop }
+        release_mutex = hold_protobuf_object_cache_mutex
+        ProtobufObjectCachePartialCommandsWorkflow.protobuf_mutex_held = true
+        wait_for_protobuf_object_cache_mutex_waiter
+        Timeout.timeout(10) { scheduler_drained.pop }
+        release_mutex.call
+        release_mutex = nil
+
+        events = nil
+        assert_eventually(timeout: 10) do
+          events = handle.fetch_history_events.to_a
+          assert(events.any? do |event|
+            %i[
+              EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+              EVENT_TYPE_WORKFLOW_TASK_FAILED
+            ].include?(event.event_type)
+          end)
+        end
+
+        first_completed_index = events.index { |event| event.event_type == :EVENT_TYPE_WORKFLOW_TASK_COMPLETED }
+        first_failed_index = events.index { |event| event.event_type == :EVENT_TYPE_WORKFLOW_TASK_FAILED }
+        unless first_failed_index && (!first_completed_index || first_failed_index < first_completed_index)
+          refute_nil first_completed_index, "History event types: #{events.map(&:event_type).inspect}"
+          scheduled_count = (events[(first_completed_index + 1)..] || []).take_while do |event|
+            event.event_type == :EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+          end.size
+          assert_equal(
+            ProtobufObjectCachePartialCommandsWorkflow::ACTIVITY_COUNT,
+            scheduled_count,
+            'Workflow task completed with a partial activity schedule command batch while a workflow fiber was ' \
+            'blocked on the protobuf ObjectCache mutex'
+          )
+        end
+      ensure
+        SchedulerDrainProbe.queue = nil
+        ProtobufObjectCachePartialCommandsWorkflow.protobuf_mutex_held = true
+        release_mutex&.call
+        begin
+          handle&.terminate
+        rescue Temporalio::Error::RPCError
+          # Ignore cleanup races if the workflow closed before terminate arrived.
+        end
+      end
+    end
+  end
+
+  def hold_protobuf_object_cache_mutex
+    mutex = Google::Protobuf::Internal::OBJECT_CACHE.instance_variable_get(:@mutex)
+    acquired = Queue.new
+    release = Queue.new
+    released = false
+    holder = Thread.new do
+      mutex.synchronize do
+        acquired << true
+        release.pop
+      end
+    end
+    acquired.pop
+
+    lambda do
+      unless released
+        released = true
+        release << true
+      end
+      holder.join
+    end
+  end
+
+  def wait_for_protobuf_object_cache_mutex_waiter
+    assert_eventually(timeout: 10, interval: 0.01) do
+      assert(
+        Thread.list.any? do |thread|
+          next false if thread == Thread.current
+
+          thread.backtrace_locations&.any? do |location|
+            location.path.end_with?('/google/protobuf/internal/object_cache.rb') &&
+              location.label.include?('synchronize')
+          end
+        end,
+        'Expected a workflow thread to block on protobuf ObjectCache mutex'
+      )
+    end
   end
 end

--- a/temporalio/test/deadlock_test.rb
+++ b/temporalio/test/deadlock_test.rb
@@ -65,23 +65,6 @@ class DeadlockTest < Test
     end
   end
 
-  class ProtobufObjectCacheMutexWorkflow < Temporalio::Workflow::Definition
-    REACHED_PROTOBUF_CACHE = Queue.new
-
-    class << self
-      attr_accessor :protobuf_mutex_held
-    end
-
-    def execute
-      Temporalio::Workflow::Future.new do
-        Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled { REACHED_PROTOBUF_CACHE << true }
-        nil until self.class.protobuf_mutex_held
-        Google::Protobuf::Internal::OBJECT_CACHE.try_add(Object.new, Object.new)
-        Temporalio::Workflow.execute_activity(BasicActivity, 'done', start_to_close_timeout: 10)
-      end.wait
-    end
-  end
-
   class ProtobufObjectCachePartialCommandsWorkflow < Temporalio::Workflow::Definition
     ACTIVITY_COUNT = 6
     BLOCK_AFTER_ACTIVITY_COUNT = 3
@@ -110,8 +93,6 @@ class DeadlockTest < Test
 
   def setup
     super
-    ProtobufObjectCacheMutexWorkflow::REACHED_PROTOBUF_CACHE.clear
-    ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = false
     ProtobufObjectCachePartialCommandsWorkflow::REACHED_PROTOBUF_CACHE.clear
     ProtobufObjectCachePartialCommandsWorkflow.protobuf_mutex_held = false
     SchedulerDrainProbe.queue = nil
@@ -161,45 +142,6 @@ class DeadlockTest < Test
     end
   ensure
     handle&.terminate
-  end
-
-  def test_protobuf_object_cache_mutex_does_not_complete_workflow_task_while_blocked
-    # @type var release_mutex: (^() -> void)?
-    release_mutex = nil
-    execute_workflow(
-      ProtobufObjectCacheMutexWorkflow,
-      activities: [BasicActivity]
-    ) do |handle|
-      Timeout.timeout(10) { ProtobufObjectCacheMutexWorkflow::REACHED_PROTOBUF_CACHE.pop }
-      release_mutex = hold_protobuf_object_cache_mutex
-      ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = true
-      wait_for_protobuf_object_cache_mutex_waiter
-      (release_mutex || raise).call
-      release_mutex = nil
-
-      # @type var events: Array[untyped]
-      events = []
-      assert_eventually(timeout: 10.0) do
-        events = handle.fetch_history_events.to_a
-        assert events.any?(&:workflow_task_completed_event_attributes)
-      end
-
-      workflow_task_completed = events.find(&:workflow_task_completed_event_attributes)
-      activity_scheduled = events.find(&:activity_task_scheduled_event_attributes)
-      refute_nil(
-        activity_scheduled,
-        'Workflow task completed while a workflow fiber was blocked on the protobuf ObjectCache mutex'
-      )
-      assert_equal workflow_task_completed.event_id + 1, activity_scheduled.event_id
-    ensure
-      ProtobufObjectCacheMutexWorkflow.protobuf_mutex_held = true
-      release_mutex&.call
-      begin
-        handle.terminate
-      rescue Temporalio::Error::RPCError
-        # Ignore cleanup races if the workflow closed before terminate arrived.
-      end
-    end
   end
 
   def test_protobuf_object_cache_mutex_does_not_emit_partial_command_batch

--- a/temporalio/test/google/protobuf/scheduler_mutex_wait.rb
+++ b/temporalio/test/google/protobuf/scheduler_mutex_wait.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ProtobufSchedulerMutexWait
+  def self.synchronize(mutex, &)
+    mutex.synchronize(&)
+  end
+end

--- a/temporalio/test/google/protobuf/scheduler_mutex_wait.rb
+++ b/temporalio/test/google/protobuf/scheduler_mutex_wait.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# This util is here specifically to ensure that "google/protobuf" is in the call stack.
 module ProtobufSchedulerMutexWait
   def self.synchronize(mutex, &)
     mutex.synchronize(&)

--- a/temporalio/test/sig/deadlock_test.rbs
+++ b/temporalio/test/sig/deadlock_test.rbs
@@ -1,0 +1,41 @@
+class DeadlockTest < Test
+  module SchedulerDrainProbe
+    attr_accessor self.queue: Queue?
+
+    def run_until_all_yielded: -> void
+  end
+
+  class BasicActivity < Temporalio::Activity::Definition
+    def execute: (untyped value) -> untyped
+  end
+
+  class DeadlockTimeoutOverrideExecutor < Temporalio::Worker::WorkflowExecutor::ThreadPool
+    def initialize: (Float deadlock_timeout) -> void
+  end
+
+  class DeadlockTimeoutInFutureWorkflow < Temporalio::Workflow::Definition
+    def execute: -> void
+  end
+
+  class ProtobufObjectCacheMutexWorkflow < Temporalio::Workflow::Definition
+    REACHED_PROTOBUF_CACHE: Queue
+
+    attr_accessor self.protobuf_mutex_held: bool
+
+    def execute: -> untyped
+  end
+
+  class ProtobufObjectCachePartialCommandsWorkflow < Temporalio::Workflow::Definition
+    ACTIVITY_COUNT: Integer
+    BLOCK_AFTER_ACTIVITY_COUNT: Integer
+    REACHED_PROTOBUF_CACHE: Queue
+
+    attr_accessor self.protobuf_mutex_held: bool
+
+    def execute: -> untyped
+  end
+
+  def hold_protobuf_object_cache_mutex: -> ^() -> void
+
+  def wait_for_protobuf_object_cache_mutex_waiter: -> void
+end

--- a/temporalio/test/sig/deadlock_test.rbs
+++ b/temporalio/test/sig/deadlock_test.rbs
@@ -17,14 +17,6 @@ class DeadlockTest < Test
     def execute: -> void
   end
 
-  class ProtobufObjectCacheMutexWorkflow < Temporalio::Workflow::Definition
-    REACHED_PROTOBUF_CACHE: Queue
-
-    attr_accessor self.protobuf_mutex_held: bool
-
-    def execute: -> untyped
-  end
-
   class ProtobufObjectCachePartialCommandsWorkflow < Temporalio::Workflow::Definition
     ACTIVITY_COUNT: Integer
     BLOCK_AFTER_ACTIVITY_COUNT: Integer

--- a/temporalio/test/sig/worker/workflow_instance_scheduler_test.rbs
+++ b/temporalio/test/sig/worker/workflow_instance_scheduler_test.rbs
@@ -1,0 +1,52 @@
+module Worker
+  class WorkflowInstanceSchedulerTest < Test
+    class FakeWorkflowInstance
+      attr_reader context: Object
+
+      def initialize: -> void
+
+      def context_frozen: -> false
+
+      def illegal_call_tracing_disabled: [T] () { -> T } -> T
+    end
+
+    class SchedulerThread
+      def initialize: (Temporalio::Internal::Worker::WorkflowInstance::Scheduler scheduler) -> void
+
+      def call: [T] () { -> T } -> T
+
+      def async_call: [T] () { -> T } -> Queue
+
+      def wait_result: (Queue result) -> untyped
+
+      def stop: -> untyped
+
+      def scheduler_state: -> String
+    end
+
+    private
+
+    def new_scheduler: -> Temporalio::Internal::Worker::WorkflowInstance::Scheduler
+
+    def held_mutex: -> [Mutex, ^() -> void]
+
+    def assert_thread_blocking_fiber_count: (
+      Temporalio::Internal::Worker::WorkflowInstance::Scheduler scheduler,
+      Integer expected_count
+    ) -> void
+
+    def thread_blocking_fiber_count: (
+      Temporalio::Internal::Worker::WorkflowInstance::Scheduler scheduler
+    ) -> Integer
+
+    def thread_blocking_fibers: (
+      Temporalio::Internal::Worker::WorkflowInstance::Scheduler scheduler
+    ) -> Array[Fiber]
+
+    def unblock_thread_blocking_fibers: (
+      Temporalio::Internal::Worker::WorkflowInstance::Scheduler scheduler
+    ) -> void
+
+    def drain_queue: (Queue queue) -> Array[untyped]
+  end
+end

--- a/temporalio/test/worker/workflow_instance_scheduler_test.rb
+++ b/temporalio/test/worker/workflow_instance_scheduler_test.rb
@@ -179,7 +179,7 @@ module Worker
     private
 
     def new_scheduler
-      Temporalio::Internal::Worker::WorkflowInstance::Scheduler.new(FakeWorkflowInstance.new)
+      Temporalio::Internal::Worker::WorkflowInstance::Scheduler.new(FakeWorkflowInstance.new) # steep:ignore
     end
 
     def held_mutex
@@ -206,7 +206,7 @@ module Worker
     end
 
     def assert_thread_blocking_fiber_count(scheduler, expected_count)
-      assert_eventually(timeout: 2, interval: 0.01) do
+      assert_eventually(timeout: 2.0, interval: 0.01) do
         assert_equal expected_count, thread_blocking_fiber_count(scheduler)
       end
     end

--- a/temporalio/test/worker/workflow_instance_scheduler_test.rb
+++ b/temporalio/test/worker/workflow_instance_scheduler_test.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require 'temporalio/internal/worker/workflow_instance/scheduler'
+require 'test'
+
+# The path is intentional: scheduler protobuf mutex detection keys off google/protobuf backtrace frames.
+require_relative '../google/protobuf/scheduler_mutex_wait'
+
+module Worker
+  class WorkflowInstanceSchedulerTest < Test
+    class FakeWorkflowInstance
+      attr_reader :context
+
+      def initialize
+        @context = Object.new
+      end
+
+      define_method(:context_frozen) { false }
+
+      def illegal_call_tracing_disabled
+        yield
+      end
+    end
+
+    def test_protobuf_mutex_wait_blocks_scheduler_drain_until_scheduler_unblocks_fiber
+      scheduler = new_scheduler
+      scheduler_thread = SchedulerThread.new(scheduler)
+      mutex, release_mutex = held_mutex
+      after_mutex = Queue.new
+
+      scheduler_thread.call do
+        scheduler.fiber do
+          ProtobufSchedulerMutexWait.synchronize(mutex) { after_mutex << true }
+        end
+      end
+
+      drain_result = scheduler_thread.async_call do
+        scheduler.run_until_all_yielded
+      end
+      assert_thread_blocking_fiber_count(scheduler, 1)
+      assert_empty after_mutex
+      assert_empty drain_result
+
+      blocked_fiber = thread_blocking_fibers(scheduler).first
+      release_mutex.call
+      scheduler.unblock(mutex, blocked_fiber)
+      scheduler_thread.wait_result(drain_result)
+      assert_equal true, after_mutex.pop(true)
+      assert_thread_blocking_fiber_count(scheduler, 0)
+    ensure
+      release_mutex&.call
+      unblock_thread_blocking_fibers(scheduler) if scheduler
+      scheduler_thread&.stop
+    end
+
+    def test_regular_mutex_wait_remains_durable_scheduler_yield
+      scheduler = new_scheduler
+      scheduler_thread = SchedulerThread.new(scheduler)
+      mutex, release_mutex = held_mutex
+      after_mutex = Queue.new
+
+      scheduler_thread.call do
+        scheduler.fiber do
+          mutex.synchronize { after_mutex << true }
+        end
+      end
+
+      scheduler_thread.call do
+        scheduler.run_until_all_yielded
+      end
+      assert_empty after_mutex
+      assert_thread_blocking_fiber_count(scheduler, 0)
+
+      release_mutex.call
+      scheduler_thread.call do
+        scheduler.run_until_all_yielded
+      end
+      assert_equal true, after_mutex.pop(true)
+    ensure
+      release_mutex&.call
+      unblock_thread_blocking_fibers(scheduler) if scheduler
+      scheduler_thread&.stop
+    end
+
+    class SchedulerThread
+      def initialize(scheduler)
+        @scheduler = scheduler
+        @commands = Queue.new
+        @thread = Thread.new do
+          previous_scheduler = Fiber.scheduler
+          Fiber.set_scheduler(scheduler)
+          loop do
+            command, result = @commands.pop
+            break if command == :stop
+
+            begin
+              result << [:success, command.call]
+            rescue Exception => e # rubocop:disable Lint/RescueException
+              result << [:error, e]
+            end
+          end
+        ensure
+          Fiber.set_scheduler(previous_scheduler)
+        end
+      end
+
+      def call(&)
+        wait_result(async_call(&))
+      end
+
+      def async_call(&block)
+        result = Queue.new
+        @commands << [block, result]
+        result
+      end
+
+      def wait_result(result)
+        status, value = Timeout.timeout(2) { result.pop }
+        raise value if status == :error
+
+        value
+      rescue Timeout::Error
+        raise "Scheduler command did not finish: #{scheduler_state}\n#{@thread.backtrace&.join("\n")}"
+      end
+
+      def stop
+        @commands << [:stop, Queue.new]
+        raise 'Scheduler thread did not stop' unless @thread.join(2)
+
+        @thread.value
+      end
+
+      def scheduler_state
+        mutex = @scheduler.instance_variable_get(:@thread_blocking_mutex)
+        mutex.synchronize do
+          ready = @scheduler.instance_variable_get(:@ready).size
+          blocking = @scheduler.instance_variable_get(:@thread_blocking_fibers).size
+          "ready=#{ready} blocking=#{blocking}"
+        end
+      end
+    end
+
+    private
+
+    def new_scheduler
+      Temporalio::Internal::Worker::WorkflowInstance::Scheduler.new(FakeWorkflowInstance.new)
+    end
+
+    def held_mutex
+      mutex = Mutex.new
+      acquired = Queue.new
+      release = Queue.new
+      released = false
+      holder = Thread.new do
+        mutex.synchronize do
+          acquired << true
+          release.pop
+        end
+      end
+      acquired.pop
+
+      release_mutex = lambda do
+        unless released
+          released = true
+          release << true
+        end
+        holder.join
+      end
+      [mutex, release_mutex]
+    end
+
+    def assert_thread_blocking_fiber_count(scheduler, expected_count)
+      assert_eventually(timeout: 2, interval: 0.01) do
+        assert_equal expected_count, thread_blocking_fiber_count(scheduler)
+      end
+    end
+
+    def thread_blocking_fiber_count(scheduler)
+      thread_blocking_fibers(scheduler).size
+    end
+
+    def thread_blocking_fibers(scheduler)
+      mutex = scheduler.instance_variable_get(:@thread_blocking_mutex)
+      mutex.synchronize do
+        scheduler.instance_variable_get(:@thread_blocking_fibers).keys
+      end
+    end
+
+    def unblock_thread_blocking_fibers(scheduler)
+      thread_blocking_fibers(scheduler).each { |fiber| scheduler.unblock(nil, fiber) }
+    end
+  end
+end

--- a/temporalio/test/worker/workflow_instance_scheduler_test.rb
+++ b/temporalio/test/worker/workflow_instance_scheduler_test.rb
@@ -82,6 +82,42 @@ module Worker
       scheduler_thread&.stop
     end
 
+    def test_thread_blocking_fiber_settles_before_wait_condition_resolution
+      scheduler = new_scheduler
+      scheduler_thread = SchedulerThread.new(scheduler)
+      mutex, release_mutex = held_mutex
+      events = Queue.new
+
+      scheduler_thread.call do
+        scheduler.fiber do
+          ProtobufSchedulerMutexWait.synchronize(mutex) { events << :protobuf_unblocked }
+        end
+        scheduler.fiber do
+          scheduler.wait_condition(cancellation: nil) { true }
+          events << :wait_condition_resumed
+        end
+      end
+
+      drain_result = scheduler_thread.async_call do
+        scheduler.run_until_all_yielded
+      end
+      assert_thread_blocking_fiber_count(scheduler, 1)
+      assert_empty drain_queue(events)
+      assert_empty drain_result
+
+      blocked_fiber = thread_blocking_fibers(scheduler).first
+      release_mutex.call
+      scheduler.unblock(mutex, blocked_fiber)
+      scheduler_thread.wait_result(drain_result)
+
+      assert_equal %i[protobuf_unblocked wait_condition_resumed], drain_queue(events)
+      assert_thread_blocking_fiber_count(scheduler, 0)
+    ensure
+      release_mutex&.call
+      unblock_thread_blocking_fibers(scheduler) if scheduler
+      scheduler_thread&.stop
+    end
+
     class SchedulerThread
       def initialize(scheduler)
         @scheduler = scheduler
@@ -188,6 +224,12 @@ module Worker
 
     def unblock_thread_blocking_fibers(scheduler)
       thread_blocking_fibers(scheduler).each { |fiber| scheduler.unblock(nil, fiber) }
+    end
+
+    def drain_queue(queue)
+      values = []
+      values << queue.pop(true) until queue.empty?
+      values
     end
   end
 end

--- a/temporalio/test/worker/workflow_instance_scheduler_test.rb
+++ b/temporalio/test/worker/workflow_instance_scheduler_test.rb
@@ -179,7 +179,14 @@ module Worker
     private
 
     def new_scheduler
-      Temporalio::Internal::Worker::WorkflowInstance::Scheduler.new(FakeWorkflowInstance.new) # steep:ignore
+      block = proc do
+        Temporalio::Internal::Worker::WorkflowInstance::Scheduler.new(FakeWorkflowInstance.new) # steep:ignore
+      end
+      if defined?(SigApplicator)
+        SigApplicator.suppress_errors { block.call }
+      else
+        block.call
+      end
     end
 
     def held_mutex


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
`Scheduler#run_until_all_yielded` will no longer return if the Google protobuf mutex is held.

This is done by inspecting `block` calls to see if the blocker is a mutex with `google/protobuf` in the path. This is more fragile than desired (as shown by how we test this behavior), but is already how we allowlist this mutex usage in `IllegalWorkflowCallValidator` so we are at least consistent in what we allow.

These `block` calls that come from the `protobuf` mutex will be tracked additionally and any `Fiber` that is blocked because of this will prevent us from considering that all ready fibers have been resumed.

## Why?
We special case allow mutex usage from `protobuf` in the workflow as it is "safe" usage (as in it cannot cause non-determinism, it guards a cache to avoid unnecessary allocations). This is still not fully safe as if the workflow future is blocked waiting for this call, `Scheduler#run_until_all_yielded` can return even if there is additional work to do for this activation once the protobuf mutex is acquired. This resulted in "partial" workflow activations that could not be replayed consistently.

The issue is that the mutex used by protobuf is process wide so a worker that executes both activities and workflows will have the workflow threads fight with the activity threads for the mutex. This along with general CPU pressure could increase the chance of this mutex having contention.

We cannot warm this cache as it is backed by [WeakMap](https://docs.ruby-lang.org/en/3.3/ObjectSpace/WeakMap.html).

## Checklist
<!--- add/delete as needed --->

1. Closes #464 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added some fairly forced regression tests. Added some unit tests for our scheduler directly since those are the most worrisome changes.

3. Any docs updates needed?
N/A
