### PR TITLE
chore: fix flake in test_custom_slot_supplier_blocking

### DIFF
--- a/temporalio/test/worker_test.rb
+++ b/temporalio/test/worker_test.rb
@@ -417,7 +417,9 @@ class WorkerTest < Test
     end
 
     # Confirm we canceled all waiting reservations
-    assert_equal waiting_contexts.size, supplier.canceled_contexts.size
+    assert_eventually do
+      assert_equal waiting_contexts.size, (supplier.canceled_contexts || []).size
+    end
     waiting_contexts.each { |w| assert_includes supplier.canceled_contexts, w }
   end
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Wrap the assertion that we receive a cancel for each waiting context in an `assert_eventually` block. The `canceled_contexts` are populated by a cancellation callbacks that are not necessarily completed before worker exit.

## Why?
Saw this flake in CI

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI

3. Any docs updates needed?
N/A
