### PR TITLE
fix: remove race from replay_workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Workflow activations containing continue-as-new suggestion reasons previously fa
 worker tried to call `to_i` on bridge enum symbols. Continue-as-new suggestion reasons are now 
 converted from bridge enum symbols to `Temporalio::SuggestContinueAsNewReason` integer enum values before being exposed to workflows.
 
+### Removed shutdown race in `replay_workflow`
+
+Fixed a race in `replay_workflow` where if a NDE was hit, worker shutdown could panic if it happens before async activation completion completes.
+
 ## [v1.5.0] - 2026-06-11
 
 ### Breaking Changes

--- a/temporalio/lib/temporalio/internal/worker/workflow_worker.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_worker.rb
@@ -154,10 +154,12 @@ module Temporalio
                 encode_activation_completion(runner, activation_completion)
               end
             end
+            false
           else
             @state.bridge_worker.async_complete_workflow_activation(
               activation_completion.run_id, activation_completion.to_proto, completion_complete_queue
             )
+            true
           end
         end
 

--- a/temporalio/lib/temporalio/internal/worker/workflow_worker.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_worker.rb
@@ -145,6 +145,8 @@ module Temporalio
           @state.logger.error(e)
         end
 
+        # Returns whether completion was submitted to the bridge
+        # rubocop:disable Naming/PredicateMethod
         def handle_activation_complete(runner:, activation_completion:, encoded:, completion_complete_queue:)
           if @payload_encoding_visitor && !encoded
             if Fiber.current_scheduler
@@ -162,6 +164,7 @@ module Temporalio
             true
           end
         end
+        # rubocop:enable Naming/PredicateMethod
 
         def on_shutdown_complete
           @state.evict_all

--- a/temporalio/lib/temporalio/worker/workflow_replayer.rb
+++ b/temporalio/lib/temporalio/worker/workflow_replayer.rb
@@ -271,6 +271,8 @@ module Temporalio
 
           # Create the runner
           @runner = Internal::Worker::MultiRunner.new(workers: [self], shutdown_signals: [])
+          @pending_workflow_activations = 0
+          @pending_workflow_activation_completions = 0
         end
 
         # Replay a workflow history.
@@ -295,11 +297,12 @@ module Temporalio
               history.workflow_id, Api::History::V1::History.new(events: history.events).to_proto
             )
 
-            # Process events until workflow complete
-            until @last_workflow_remove_job
+            # Process events until workflow complete and all completions submitted to core have finished.
+            until @last_workflow_remove_job && workflow_activation_work_drained?
               event = @runner.next_event
               case event
               when Internal::Worker::MultiRunner::Event::PollSuccess
+                @pending_workflow_activations += 1
                 @workflow_worker.handle_activation(
                   runner: @runner,
                   activation: Internal::Bridge::Api::WorkflowActivation::WorkflowActivation.decode(event.bytes),
@@ -308,14 +311,17 @@ module Temporalio
               when Internal::Worker::MultiRunner::Event::WorkflowActivationDecoded
                 @workflow_worker.handle_activation(runner: @runner, activation: event.activation, decoded: true)
               when Internal::Worker::MultiRunner::Event::WorkflowActivationComplete
-                @workflow_worker.handle_activation_complete(
+                if @workflow_worker.handle_activation_complete(
                   runner: @runner,
                   activation_completion: event.activation_completion,
                   encoded: event.encoded,
                   completion_complete_queue: event.completion_complete_queue
                 )
+                  @pending_workflow_activations -= 1
+                  @pending_workflow_activation_completions += 1
+                end
               when Internal::Worker::MultiRunner::Event::WorkflowActivationCompletionComplete
-              # Ignore
+                @pending_workflow_activation_completions -= 1
               else
                 raise "Unexpected event: #{event}"
               end
@@ -364,6 +370,12 @@ module Temporalio
         # @!visibility private
         def _wait_all_complete
           # Do nothing
+        end
+
+        private
+
+        def workflow_activation_work_drained?
+          @pending_workflow_activations.zero? && @pending_workflow_activation_completions.zero?
         end
       end
     end

--- a/temporalio/rbi/temporalio/internal/worker/workflow_worker.rbi
+++ b/temporalio/rbi/temporalio/internal/worker/workflow_worker.rbi
@@ -75,7 +75,7 @@ class Temporalio::Internal::Worker::WorkflowWorker
       activation_completion: Object,
       encoded: T::Boolean,
       completion_complete_queue: Queue
-    ).void
+    ).returns(T::Boolean)
   end
   def handle_activation_complete(runner:, activation_completion:, encoded:, completion_complete_queue:); end
 

--- a/temporalio/rbi/temporalio/worker/workflow_replayer.rbi
+++ b/temporalio/rbi/temporalio/worker/workflow_replayer.rbi
@@ -144,4 +144,9 @@ class Temporalio::Worker::WorkflowReplayer::ReplayWorker
     ).returns(Temporalio::Worker::WorkflowReplayer::ReplayResult)
   end
   def replay_workflow(history, raise_on_replay_failure: T.unsafe(nil)); end
+
+  private
+
+  sig { returns(T::Boolean) }
+  def workflow_activation_work_drained?; end
 end

--- a/temporalio/sig/temporalio/internal/worker/workflow_worker.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_worker.rbs
@@ -43,7 +43,7 @@ module Temporalio
           activation_completion: untyped,
           encoded: bool,
           completion_complete_queue: Queue
-        ) -> void
+        ) -> bool
 
         def on_shutdown_complete: -> void
 

--- a/temporalio/sig/temporalio/worker/workflow_replayer.rbs
+++ b/temporalio/sig/temporalio/worker/workflow_replayer.rbs
@@ -95,6 +95,10 @@ module Temporalio
         def _bridge_worker: -> Internal::Bridge::Worker
         def _initiate_shutdown: -> void
         def _wait_all_complete: -> void
+
+        private
+
+        def workflow_activation_work_drained?: -> bool
       end
     end
   end


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Prevent `replay_workflow` from exiting until all workflow activations and activation completion completes are accounted for.
In order to do this tracking we return whether or not `handle_activation_complete` submitted work to core.

This prevents worker shutdown from starting until all completions are accounted for.

## Why?
<!-- Tell your future self why have you made these changes -->
I saw this [flake](https://github.com/temporalio/sdk-ruby/actions/runs/28744912659/job/85234052993) on another PR.

Issue is that our workflow completions are handled async on the Rust side and hang onto a worker reference. This causes the `Arc::try_unwrap` in the worker shutdown path to fail.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added an explicit 1s sleep before we finalized the workflow activation completion:
https://github.com/temporalio/sdk-ruby/blob/f785b44adc00ebebb8546c9bef31aa4c6e49176b/temporalio/ext/src/worker.rs#L377

This allowed me to consistently trigger the flake we saw in CI. Applying the fixes in this branch with that injected delay produces no test failure.

Didn't add a regression test as synchronizing between Ruby <-> Rust to trigger this race is quite tricky. 

3. Any docs updates needed?
N/A
