### PR TITLE
chore(test): heartbeat during saa test to avoid timeout

### DIFF
--- a/temporalio/test/client_activity_test.rb
+++ b/temporalio/test/client_activity_test.rb
@@ -24,8 +24,10 @@ class ClientActivityTest < Test
 
   class SlowActivity < Temporalio::Activity::Definition
     def execute
-      Temporalio::Activity::Context.current.heartbeat
-      sleep 0.1 until Temporalio::Activity::Context.current.cancellation.canceled?
+      until Temporalio::Activity::Context.current.cancellation.canceled?
+        Temporalio::Activity::Context.current.heartbeat
+        sleep 0.1
+      end
       raise Temporalio::Error::CanceledError, 'canceled'
     end
   end


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added heartbeating during SAA `SlowActivity` to avoid timing out. `test_cancel_running_activity_transitions_to_canceled` failed on another PR as the activity ended in a `timed_out` status over the expected `canceled` state.

Not 100% convinced heartbeating timeout was the cause of the test flake, but I don't think it hurts to add heartbeating.

## Why?
Saw this flake on another PR: https://github.com/temporalio/sdk-ruby/actions/runs/28758692840/job/85270064194

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Test continues to pass

3. Any docs updates needed?
N/A
