### PR TITLE
Add patch activation callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ to docs, or any other relevant information.
 ### Added
 
 - Exposed `Temporalio::Workflow::ContinueAsNewError#backoff_start_interval`, to allow the new workflow to start after a delay.
+- Added the experimental `Temporalio::Worker` `patch_activation_callback:` option, allowing workers to decide whether a first non-replay `Temporalio::Workflow.patched` call should activate a patch during rolling deployments.
 
 ### Fixed
 
@@ -81,4 +82,3 @@ correctly receives `Temporalio::Error::WorkflowUpdateFailedError`. (#454)
 but defers dispatch to a worker until the delay elapses. Retry attempts do not re-apply the delay.
 `ScheduleToStart` and `ScheduleToClose` timeout clocks begin counting after the delay
 elapses; `StartToClose` and `Heartbeat` are unaffected. Currently experimental.
-

--- a/README.md
+++ b/README.md
@@ -660,7 +660,8 @@ from workflows including:
 * `all_handlers_finished?` - Returns true when all signal and update handlers are done. Useful as
   `Temporalio::Workflow.wait_condition { Temporalio::Workflow.all_handlers_finished? }` for making sure not to return
   from the primary workflow method until all handlers are done.
-* `patched` and `deprecate_patch` - Support for patch-based versioning inside the workflow.
+* `patched` and `deprecate_patch` - Support for patch-based versioning inside the workflow. Workers can set
+  `patch_activation_callback:` to decide whether a newly introduced patch should activate during rolling deployments.
 * `continue_as_new_suggested` - Returns true when the server recommends performing a continue as new.
 * `current_update_info` - Returns `Temporalio::Workflow::UpdateInfo` if the current code is inside an update, or nil
   otherwise.

--- a/temporalio/Cargo.lock
+++ b/temporalio/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "antithesis_sdk"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
 dependencies = [
  "libc",
  "libloading",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -159,29 +159,30 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.14"
+version = "0.13.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+checksum = "6c0e6249c249b8916c98ebae7bc06216c8dcab3002f32872b4abe642d17063b1"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
  "regex",
 ]
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -191,21 +192,22 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -284,26 +286,6 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -317,8 +299,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
- "shlex",
+ "rustc-hash 2.1.3",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -339,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -349,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling",
  "ident_case",
@@ -364,18 +346,18 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bzip2"
@@ -394,21 +376,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -433,20 +409,20 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "num-traits",
  "serde",
@@ -492,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -514,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -676,7 +652,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.3",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -805,18 +781,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -824,27 +800,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -998,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1033,9 +1009,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"
@@ -1119,19 +1095,18 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1192,9 +1167,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs_extra"
@@ -1286,9 +1264,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1315,7 +1293,7 @@ checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags",
  "debugid",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1361,25 +1339,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1408,9 +1384,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1475,9 +1451,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1520,9 +1496,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1535,7 +1511,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1543,16 +1518,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1596,12 +1570,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1609,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1622,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1636,15 +1611,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1656,15 +1631,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1700,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1731,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1745,29 +1720,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1789,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ittapi"
@@ -1815,27 +1771,32 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1859,21 +1820,22 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1884,12 +1846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,15 +1853,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1925,30 +1881,27 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
 name = "linkme"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1963,9 +1916,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1978,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2046,9 +1999,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
@@ -2089,9 +2042,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2299,7 +2252,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2339,7 +2292,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2404,18 +2357,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2429,22 +2382,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2482,9 +2423,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -2503,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2589,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2599,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -2620,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -2633,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -2688,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "memchr",
@@ -2731,16 +2672,16 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2751,17 +2692,18 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2773,23 +2715,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2819,9 +2761,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2829,13 +2771,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2878,15 +2820,24 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2904,20 +2855,20 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.124"
+version = "0.9.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85c4188462601e2aa1469def389c17228566f82ea72f137ed096f21591bc489"
+checksum = "45ca28513560e56cfb79a62b1fce363c73af170a182024ce880c77ee9429920a"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.124"
+version = "0.9.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568068db4102230882e6d4ae8de6632e224ca75fe5970f6e026a04e91ed635d3"
+checksum = "ce04b2c55eff3a21aaa623fcc655d94373238e72cac6b3e1a3641ff31649f99a"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "lazy_static",
  "proc-macro2",
  "quote",
@@ -2937,15 +2888,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -2982,15 +2924,15 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.17.1",
  "log",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.3",
  "smallvec",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3011,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -3063,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -3158,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -3170,9 +3112,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3208,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3224,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3236,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3246,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -3285,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -3344,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -3390,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3403,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3455,6 +3397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,15 +3414,31 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3493,18 +3457,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3530,9 +3494,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3575,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3603,7 +3567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3633,7 +3597,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "prost-wkt-types",
- "rand 0.10.0",
+ "rand 0.10.2",
  "rstest",
  "tempfile",
  "temporalio-common",
@@ -3681,7 +3645,7 @@ dependencies = [
  "temporalio-protos",
  "thiserror 2.0.18",
  "tokio",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tracing",
  "tracing-core",
@@ -3818,8 +3782,8 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-wkt-types",
- "rand 0.10.0",
- "reqwest 0.13.2",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
  "rstest",
  "semver",
  "serde",
@@ -3861,7 +3825,7 @@ dependencies = [
  "temporalio-common-wasm",
  "temporalio-macros",
  "thiserror 2.0.18",
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3960,9 +3924,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3995,9 +3959,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4012,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4072,17 +4036,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4096,39 +4060,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -4164,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4176,9 +4140,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -4187,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4222,20 +4186,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4307,9 +4271,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
 dependencies = [
  "dissimilar",
  "glob",
@@ -4318,7 +4282,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -4341,9 +4305,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -4354,9 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4377,9 +4341,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4431,11 +4395,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4479,27 +4443,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4510,23 +4465,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4534,9 +4485,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4547,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -4569,16 +4520,6 @@ dependencies = [
  "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
  "wat",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -4603,24 +4544,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -4650,18 +4579,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
@@ -4687,9 +4604,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
  "bitflags",
  "indexmap",
@@ -4966,31 +4883,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "252.0.0"
+version = "253.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+checksum = "d3264542f8965c5d84fb1085d924bfba9a6314bb228eff13a2de14d7627664d0"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.252.0",
+ "wasm-encoder 0.253.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.252.0"
+version = "1.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+checksum = "4bfc5ce906144200c972ec617470aa35bd847472e170b26dde3e80541c674055"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5008,9 +4925,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5168,29 +5085,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5204,50 +5103,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5261,27 +5128,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5290,28 +5139,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
 name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -5320,34 +5151,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5356,46 +5163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5405,20 +5182,11 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro 0.51.0",
 ]
 
 [[package]]
@@ -5428,18 +5196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 dependencies = [
  "bitflags",
- "wit-bindgen-rust-macro 0.57.1",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.244.0",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -5455,22 +5212,6 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata 0.244.0",
- "wit-bindgen-core 0.51.0",
- "wit-component 0.244.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5007dae772945b7a5003d69d90a3a4a78929d41f19d004e980c4259a6af4484"
@@ -5480,24 +5221,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata 0.247.0",
- "wit-bindgen-core 0.57.1",
- "wit-component 0.247.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core 0.51.0",
- "wit-bindgen-rust 0.51.0",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
@@ -5511,27 +5237,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core 0.57.1",
- "wit-bindgen-rust 0.57.1",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata 0.244.0",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -5548,27 +5255,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.247.0",
- "wasm-metadata 0.247.0",
+ "wasm-metadata",
  "wasmparser 0.247.0",
  "wit-parser 0.247.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5611,9 +5300,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -5627,9 +5316,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5638,9 +5327,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5650,18 +5339,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5670,18 +5359,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5691,15 +5380,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5708,9 +5397,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5719,9 +5408,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5730,9 +5419,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.5.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "bzip2",
  "crc32fast",
@@ -5746,9 +5435,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/temporalio/extra/proto_gen.rb
+++ b/temporalio/extra/proto_gen.rb
@@ -241,9 +241,18 @@ class ProtoGen
         'sig/temporalio/api/workflowservice'
       ]
     )
-    File.write('rbi/temporalio/api/cloud/cloudservice.rbi', generated_empty_module_rbi('Temporalio::Api::Cloud::CloudService'))
-    File.write('rbi/temporalio/api/operatorservice.rbi', generated_empty_module_rbi('Temporalio::Api::OperatorService'))
-    File.write('rbi/temporalio/api/workflowservice.rbi', generated_empty_module_rbi('Temporalio::Api::WorkflowService'))
+    File.write(
+      'rbi/temporalio/api/cloud/cloudservice.rbi',
+      generated_empty_module_rbi('Temporalio::Api::Cloud::CloudService')
+    )
+    File.write(
+      'rbi/temporalio/api/operatorservice.rbi',
+      generated_empty_module_rbi('Temporalio::Api::OperatorService')
+    )
+    File.write(
+      'rbi/temporalio/api/workflowservice.rbi',
+      generated_empty_module_rbi('Temporalio::Api::WorkflowService')
+    )
     File.write(
       'sig/temporalio/api/cloud/cloudservice.rbs',
       generated_empty_module_rbs(%w[Temporalio Api Cloud CloudService])

--- a/temporalio/lib/temporalio/client.rb
+++ b/temporalio/lib/temporalio/client.rb
@@ -142,16 +142,16 @@ module Temporalio
 
                            # Root next call
                            next_call_called = false
-                           next_call = proc do |options|
+                           next_call = proc do |call_options|
                              raise 'next_call called more than once' if next_call_called
 
                              next_call_called = true
-                             block&.call(options)
+                             block&.call(call_options)
                              base_connection
                            end
                            # Go backwards, building up new next_call invocations on plugins
-                           next_call = plugins.reverse_each.reduce(next_call) do |next_call, plugin|
-                             proc { |options| plugin.connect_client(options, next_call) }
+                           next_call = plugins.reverse_each.reduce(next_call) do |inner_next_call, plugin|
+                             proc { |call_options| plugin.connect_client(call_options, inner_next_call) }
                            end
                            # Do call
                            final_connection = next_call.call(options)

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
@@ -100,7 +100,9 @@ module Temporalio
           @current_history_length = 0
           @current_history_size = 0
           @replaying = false
+          @context_frozen = false
           @in_query_or_validator = false
+          @random_disabled = false
           @workflow_failure_exception_types = details.workflow_failure_exception_types
           @signal_handlers = HandlerHash.new(
             details.definition.signals,

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
@@ -61,7 +61,7 @@ module Temporalio
                     :current_deployment_version,
                     :current_history_length, :current_history_size, :replaying, :random,
                     :signal_handlers, :query_handlers, :update_handlers, :context_frozen, :assert_valid_local_activity,
-                    :in_query_or_validator
+                    :in_query_or_validator, :random_disabled, :patch_activation_callback
         attr_accessor :io_enabled, :current_details
 
         def initialize(details)
@@ -77,6 +77,7 @@ module Temporalio
           @scheduler = Scheduler.new(self)
           @payload_converter = details.payload_converter
           @failure_converter = details.failure_converter
+          @patch_activation_callback = details.patch_activation_callback
           @disable_eager_activity_execution = details.disable_eager_activity_execution
           @pending_activities = {} # Keyed by sequence, value is fiber to resume with proto result
           @pending_timers = {} # Keyed by sequence, value is fiber to resume with proto result
@@ -292,7 +293,12 @@ module Temporalio
           patch_id = patch_id.to_s
           @patches_memoized ||= {}
           @patches_memoized.fetch(patch_id) do
-            patched = !replaying || @patches_notified.include?(patch_id)
+            # Only fresh, non-replay patches can consult rollout policy; replay and deprecation must follow history.
+            patched = if deprecated || replaying || @patches_notified.include?(patch_id)
+                        !replaying || @patches_notified.include?(patch_id)
+                      else
+                        patch_activated?(patch_id)
+                      end
             @patches_memoized[patch_id] = patched
             if patched
               add_command(
@@ -303,6 +309,20 @@ module Temporalio
             end
             patched
           end
+        end
+
+        def patch_activated?(patch_id)
+          return true unless patch_activation_callback
+
+          patched = with_context_frozen(in_query_or_validator: false, random_disabled: true) do
+            patch_activation_callback.call(Temporalio::Worker::PatchActivationInput.new(
+                                             workflow_info: info,
+                                             patch_id:
+                                           ))
+          end
+          return patched if patched == true || patched == false
+
+          raise TypeError, 'Patch activation callback must return true or false'
         end
 
         def metric_meter
@@ -686,13 +706,18 @@ module Temporalio
             @definition_options.failure_exception_types&.any? { |cls| err.is_a?(cls) }
         end
 
-        def with_context_frozen(in_query_or_validator:, &)
+        def with_context_frozen(in_query_or_validator:, random_disabled: false, &)
+          previous_context_frozen = @context_frozen
+          previous_in_query_or_validator = @in_query_or_validator
+          previous_random_disabled = @random_disabled
           @context_frozen = true
           @in_query_or_validator = in_query_or_validator
+          @random_disabled = random_disabled
           yield
         ensure
-          @context_frozen = false
-          @in_query_or_validator = false
+          @context_frozen = previous_context_frozen
+          @in_query_or_validator = previous_in_query_or_validator
+          @random_disabled = previous_random_disabled
         end
 
         def convert_handler_args(payload_array:, defn:)

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
@@ -248,6 +248,8 @@ module Temporalio
           end
 
           def random
+            raise Workflow::InvalidWorkflowStateError, 'Cannot use random in this context' if @instance.random_disabled
+
             @instance.random
           end
 

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/details.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/details.rb
@@ -9,7 +9,7 @@ module Temporalio
           attr_reader :namespace, :task_queue, :definition, :initial_activation, :logger, :metric_meter,
                       :payload_converter, :failure_converter, :interceptors, :disable_eager_activity_execution,
                       :illegal_calls, :workflow_failure_exception_types, :unsafe_workflow_io_enabled,
-                      :assert_valid_local_activity
+                      :patch_activation_callback, :assert_valid_local_activity
 
           def initialize(
             namespace:,
@@ -25,6 +25,7 @@ module Temporalio
             illegal_calls:,
             workflow_failure_exception_types:,
             unsafe_workflow_io_enabled:,
+            patch_activation_callback:,
             assert_valid_local_activity:
           )
             @namespace = namespace
@@ -40,6 +41,7 @@ module Temporalio
             @illegal_calls = illegal_calls
             @workflow_failure_exception_types = workflow_failure_exception_types
             @unsafe_workflow_io_enabled = unsafe_workflow_io_enabled
+            @patch_activation_callback = patch_activation_callback
             @assert_valid_local_activity = assert_valid_local_activity
           end
         end

--- a/temporalio/lib/temporalio/internal/worker/workflow_worker.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_worker.rb
@@ -74,6 +74,7 @@ module Temporalio
           workflow_failure_exception_types:,
           workflow_payload_codec_thread_pool:,
           unsafe_workflow_io_enabled:,
+          patch_activation_callback:,
           debug_mode:,
           assert_valid_local_activity:, on_eviction: nil
         )
@@ -118,6 +119,7 @@ module Temporalio
               t
             end.freeze,
             unsafe_workflow_io_enabled:,
+            patch_activation_callback:,
             assert_valid_local_activity:
           )
           @state.on_eviction = on_eviction if on_eviction
@@ -199,7 +201,7 @@ module Temporalio
           attr_reader :workflow_definitions, :bridge_worker, :logger, :metric_meter, :data_converter, :deadlock_timeout,
                       :illegal_calls, :namespace, :task_queue, :disable_eager_activity_execution,
                       :workflow_interceptors, :workflow_failure_exception_types, :unsafe_workflow_io_enabled,
-                      :assert_valid_local_activity
+                      :patch_activation_callback, :assert_valid_local_activity
 
           attr_writer :on_eviction
 
@@ -207,7 +209,7 @@ module Temporalio
             workflow_definitions:, bridge_worker:, logger:, metric_meter:, data_converter:, deadlock_timeout:,
             illegal_calls:, namespace:, task_queue:, disable_eager_activity_execution:,
             workflow_interceptors:, workflow_failure_exception_types:, unsafe_workflow_io_enabled:,
-            assert_valid_local_activity:
+            patch_activation_callback:, assert_valid_local_activity:
           )
             @workflow_definitions = workflow_definitions
             @bridge_worker = bridge_worker
@@ -222,6 +224,7 @@ module Temporalio
             @workflow_interceptors = workflow_interceptors
             @workflow_failure_exception_types = workflow_failure_exception_types
             @unsafe_workflow_io_enabled = unsafe_workflow_io_enabled
+            @patch_activation_callback = patch_activation_callback
             @assert_valid_local_activity = assert_valid_local_activity
 
             @running_workflows = {}

--- a/temporalio/lib/temporalio/worker.rb
+++ b/temporalio/lib/temporalio/worker.rb
@@ -28,6 +28,17 @@ module Temporalio
   # {run_all} is used for a collection of workers. These can wait until a block is complete or a {Cancellation} is
   # canceled.
   class Worker
+    # Input for the experimental `patch_activation_callback:` worker option.
+    #
+    # @!attribute [r] workflow_info
+    #   @return [Workflow::Info] Information about the workflow execution calling {Workflow.patched}.
+    # @!attribute [r] patch_id
+    #   @return [String] Patch ID passed to {Workflow.patched}.
+    PatchActivationInput = Data.define(
+      :workflow_info,
+      :patch_id
+    )
+
     Options = Data.define(
       :client,
       :task_queue,
@@ -57,6 +68,7 @@ module Temporalio
       :workflow_payload_codec_thread_pool,
       :unsafe_workflow_io_enabled,
       :deployment_options,
+      :patch_activation_callback,
       :workflow_task_poller_behavior,
       :activity_task_poller_behavior,
       :debug_mode
@@ -430,6 +442,9 @@ module Temporalio
     #   scheduler will fail. Instead of setting this to true, users are encouraged to use {Workflow::Unsafe.io_enabled}
     #   with a block for narrower enabling of IO.
     # @param deployment_options [DeploymentOptions, nil] Deployment options for the worker.
+    # @param patch_activation_callback [Proc, nil] Experimental callback to decide whether the first non-replay call to
+    #   {Workflow.patched} for a patch ID should activate that patch. The callback receives a {PatchActivationInput} and
+    #   must return `true` to activate the patch or `false` to leave it inactive.
     # @param workflow_task_poller_behavior [PollerBehavior] Specify the behavior of workflow task
     #   polling. Defaults to a 5-poller maximum.
     # @param activity_task_poller_behavior [PollerBehavior] Specify the behavior of activity task
@@ -466,6 +481,7 @@ module Temporalio
       workflow_payload_codec_thread_pool: nil,
       unsafe_workflow_io_enabled: false,
       deployment_options: Worker.default_deployment_options,
+      patch_activation_callback: nil,
       workflow_task_poller_behavior: PollerBehavior::SimpleMaximum.new(max_concurrent_workflow_task_polls),
       activity_task_poller_behavior: PollerBehavior::SimpleMaximum.new(max_concurrent_activity_task_polls),
       debug_mode: %w[true 1].include?(ENV['TEMPORAL_DEBUG'].to_s.downcase)
@@ -501,6 +517,7 @@ module Temporalio
         workflow_payload_codec_thread_pool:,
         unsafe_workflow_io_enabled:,
         deployment_options:,
+        patch_activation_callback:,
         workflow_task_poller_behavior:,
         activity_task_poller_behavior:,
         debug_mode:
@@ -569,8 +586,10 @@ module Temporalio
       )
 
       # Collect interceptors from client and params
-      @activity_interceptors = (@options.client.options.interceptors + @options.interceptors).grep(Interceptor::Activity)
-      @workflow_interceptors = (@options.client.options.interceptors + @options.interceptors).grep(Interceptor::Workflow)
+      @activity_interceptors =
+        (@options.client.options.interceptors + @options.interceptors).grep(Interceptor::Activity)
+      @workflow_interceptors =
+        (@options.client.options.interceptors + @options.interceptors).grep(Interceptor::Workflow)
 
       # Cancellation for the whole worker
       @worker_shutdown_cancellation = Cancellation.new
@@ -596,6 +615,7 @@ module Temporalio
           workflow_failure_exception_types: @options.workflow_failure_exception_types,
           workflow_payload_codec_thread_pool: @options.workflow_payload_codec_thread_pool,
           unsafe_workflow_io_enabled: @options.unsafe_workflow_io_enabled,
+          patch_activation_callback: @options.patch_activation_callback,
           debug_mode: @options.debug_mode,
           assert_valid_local_activity: ->(activity) { _assert_valid_local_activity(activity) }
         )

--- a/temporalio/lib/temporalio/worker/workflow_executor/thread_pool.rb
+++ b/temporalio/lib/temporalio/worker/workflow_executor/thread_pool.rb
@@ -216,6 +216,7 @@ module Temporalio
                 illegal_calls: worker_state.illegal_calls,
                 workflow_failure_exception_types: worker_state.workflow_failure_exception_types,
                 unsafe_workflow_io_enabled: worker_state.unsafe_workflow_io_enabled,
+                patch_activation_callback: worker_state.patch_activation_callback,
                 assert_valid_local_activity: worker_state.assert_valid_local_activity
               )
             )

--- a/temporalio/lib/temporalio/worker/workflow_replayer.rb
+++ b/temporalio/lib/temporalio/worker/workflow_replayer.rb
@@ -264,6 +264,7 @@ module Temporalio
             workflow_failure_exception_types: options.workflow_failure_exception_types,
             workflow_payload_codec_thread_pool: options.workflow_payload_codec_thread_pool,
             unsafe_workflow_io_enabled: options.unsafe_workflow_io_enabled,
+            patch_activation_callback: nil,
             debug_mode: options.debug_mode,
             on_eviction: proc { |_, remove_job| @last_workflow_remove_job = remove_job }, # steep:ignore
             assert_valid_local_activity: ->(_) {}

--- a/temporalio/lib/temporalio/workflow.rb
+++ b/temporalio/lib/temporalio/workflow.rb
@@ -344,6 +344,9 @@ module Temporalio
     # same ID and workflow are memoized. Use {deprecate_patch} when all workflows are done and will never be queried
     # again. The old code path can be removed at that time too.
     #
+    # Workers can set `patch_activation_callback:` to delay activating a newly introduced patch during rolling
+    # deployments. That callback is only used when the patch marker would otherwise be created for the first time.
+    #
     # @param patch_id [Symbol, String] Patch ID.
     # @return [Boolean] True if this should take the newer patch, false if it should take the old path.
     def self.patched(patch_id)

--- a/temporalio/lib/temporalio/workflow/nexus_operation_cancellation_type.rb
+++ b/temporalio/lib/temporalio/workflow/nexus_operation_cancellation_type.rb
@@ -9,13 +9,15 @@ module Temporalio
     # WARNING: Nexus support is experimental.
     module NexusOperationCancellationType
       # Wait for cancellation to complete (default).
-      WAIT_CANCELLATION_COMPLETED = Internal::Bridge::Api::Nexus::NexusOperationCancellationType::WAIT_CANCELLATION_COMPLETED
+      WAIT_CANCELLATION_COMPLETED =
+        Internal::Bridge::Api::Nexus::NexusOperationCancellationType::WAIT_CANCELLATION_COMPLETED
       # Abandon the operation without sending a cancellation request.
       ABANDON = Internal::Bridge::Api::Nexus::NexusOperationCancellationType::ABANDON
       # Send a cancellation request but do not wait for confirmation.
       TRY_CANCEL = Internal::Bridge::Api::Nexus::NexusOperationCancellationType::TRY_CANCEL
       # Wait for the server to confirm the cancellation request was delivered.
-      WAIT_CANCELLATION_REQUESTED = Internal::Bridge::Api::Nexus::NexusOperationCancellationType::WAIT_CANCELLATION_REQUESTED
+      WAIT_CANCELLATION_REQUESTED =
+        Internal::Bridge::Api::Nexus::NexusOperationCancellationType::WAIT_CANCELLATION_REQUESTED
     end
   end
 end

--- a/temporalio/rbi/temporalio/internal/worker/workflow_instance.rbi
+++ b/temporalio/rbi/temporalio/internal/worker/workflow_instance.rbi
@@ -107,6 +107,12 @@ class Temporalio::Internal::Worker::WorkflowInstance
   attr_reader :in_query_or_validator
 
   sig { returns(T::Boolean) }
+  attr_reader :random_disabled
+
+  sig { returns(T.nilable(T.proc.params(input: Temporalio::Worker::PatchActivationInput).returns(T::Boolean))) }
+  attr_reader :patch_activation_callback
+
+  sig { returns(T::Boolean) }
   attr_accessor :io_enabled
 
   sig { returns(T.nilable(String)) }
@@ -138,6 +144,9 @@ class Temporalio::Internal::Worker::WorkflowInstance
 
   sig { params(patch_id: T.any(Symbol, String), deprecated: T::Boolean).returns(T::Boolean) }
   def patch(patch_id:, deprecated:); end
+
+  sig { params(patch_id: String).returns(T::Boolean) }
+  def patch_activated?(patch_id); end
 
   sig { returns(Temporalio::Metric::Meter) }
   def metric_meter; end
@@ -179,10 +188,14 @@ class Temporalio::Internal::Worker::WorkflowInstance
 
   sig do
     type_parameters(:T)
-      .params(in_query_or_validator: T::Boolean, block: T.proc.returns(T.type_parameter(:T)))
+      .params(
+        in_query_or_validator: T::Boolean,
+        random_disabled: T::Boolean,
+        block: T.proc.returns(T.type_parameter(:T))
+      )
       .returns(T.type_parameter(:T))
   end
-  def with_context_frozen(in_query_or_validator:, &block); end
+  def with_context_frozen(in_query_or_validator:, random_disabled: T.unsafe(nil), &block); end
 
   sig do
     params(

--- a/temporalio/rbi/temporalio/internal/worker/workflow_instance/details.rbi
+++ b/temporalio/rbi/temporalio/internal/worker/workflow_instance/details.rbi
@@ -42,6 +42,9 @@ class Temporalio::Internal::Worker::WorkflowInstance::Details
   sig { returns(T::Boolean) }
   attr_reader :unsafe_workflow_io_enabled
 
+  sig { returns(T.nilable(T.proc.params(input: Temporalio::Worker::PatchActivationInput).returns(T::Boolean))) }
+  attr_reader :patch_activation_callback
+
   sig { returns(T.proc.params(arg0: String).void) }
   attr_reader :assert_valid_local_activity
 
@@ -60,6 +63,7 @@ class Temporalio::Internal::Worker::WorkflowInstance::Details
       illegal_calls: T::Hash[String, Object],
       workflow_failure_exception_types: T::Array[T.class_of(Exception)],
       unsafe_workflow_io_enabled: T::Boolean,
+      patch_activation_callback: T.nilable(T.proc.params(input: Temporalio::Worker::PatchActivationInput).returns(T::Boolean)),
       assert_valid_local_activity: T.proc.params(arg0: String).void
     ).void
   end
@@ -77,6 +81,7 @@ class Temporalio::Internal::Worker::WorkflowInstance::Details
     illegal_calls:,
     workflow_failure_exception_types:,
     unsafe_workflow_io_enabled:,
+    patch_activation_callback:,
     assert_valid_local_activity:
   ); end
 end

--- a/temporalio/rbi/temporalio/internal/worker/workflow_worker.rbi
+++ b/temporalio/rbi/temporalio/internal/worker/workflow_worker.rbi
@@ -35,6 +35,7 @@ class Temporalio::Internal::Worker::WorkflowWorker
       workflow_failure_exception_types: T::Array[T.class_of(Exception)],
       workflow_payload_codec_thread_pool: T.nilable(Temporalio::Worker::ThreadPool),
       unsafe_workflow_io_enabled: T::Boolean,
+      patch_activation_callback: T.nilable(T.proc.params(input: Temporalio::Worker::PatchActivationInput).returns(T::Boolean)),
       debug_mode: T::Boolean,
       assert_valid_local_activity: T.proc.params(arg0: String).void,
       on_eviction: T.nilable(T.proc.params(arg0: String, arg1: Object).void)
@@ -55,6 +56,7 @@ class Temporalio::Internal::Worker::WorkflowWorker
     workflow_failure_exception_types:,
     workflow_payload_codec_thread_pool:,
     unsafe_workflow_io_enabled:,
+    patch_activation_callback:,
     debug_mode:,
     assert_valid_local_activity:,
     on_eviction: T.unsafe(nil)
@@ -136,6 +138,9 @@ class Temporalio::Internal::Worker::WorkflowWorker::State
   sig { returns(T::Boolean) }
   attr_reader :unsafe_workflow_io_enabled
 
+  sig { returns(T.nilable(T.proc.params(input: Temporalio::Worker::PatchActivationInput).returns(T::Boolean))) }
+  attr_reader :patch_activation_callback
+
   sig { returns(T.proc.params(arg0: String).void) }
   attr_reader :assert_valid_local_activity
 
@@ -157,6 +162,7 @@ class Temporalio::Internal::Worker::WorkflowWorker::State
       workflow_interceptors: T::Array[Temporalio::Worker::Interceptor::Workflow],
       workflow_failure_exception_types: T::Array[T.class_of(Exception)],
       unsafe_workflow_io_enabled: T::Boolean,
+      patch_activation_callback: T.nilable(T.proc.params(input: Temporalio::Worker::PatchActivationInput).returns(T::Boolean)),
       assert_valid_local_activity: T.proc.params(arg0: String).void
     ).void
   end
@@ -174,6 +180,7 @@ class Temporalio::Internal::Worker::WorkflowWorker::State
     workflow_interceptors:,
     workflow_failure_exception_types:,
     unsafe_workflow_io_enabled:,
+    patch_activation_callback:,
     assert_valid_local_activity:
   ); end
 

--- a/temporalio/rbi/temporalio/worker.rbi
+++ b/temporalio/rbi/temporalio/worker.rbi
@@ -36,6 +36,7 @@ class Temporalio::Worker
       workflow_payload_codec_thread_pool: T.nilable(Temporalio::Worker::ThreadPool),
       unsafe_workflow_io_enabled: T::Boolean,
       deployment_options: Temporalio::Worker::DeploymentOptions,
+      patch_activation_callback: T.nilable(T.proc.params(input: Temporalio::Worker::PatchActivationInput).returns(T::Boolean)),
       workflow_task_poller_behavior: Temporalio::Worker::PollerBehavior,
       activity_task_poller_behavior: Temporalio::Worker::PollerBehavior,
       debug_mode: T::Boolean
@@ -70,6 +71,7 @@ class Temporalio::Worker
     workflow_payload_codec_thread_pool: T.unsafe(nil),
     unsafe_workflow_io_enabled: T.unsafe(nil),
     deployment_options: T.unsafe(nil),
+    patch_activation_callback: T.unsafe(nil),
     workflow_task_poller_behavior: T.unsafe(nil),
     activity_task_poller_behavior: T.unsafe(nil),
     debug_mode: T.unsafe(nil)
@@ -134,6 +136,22 @@ class Temporalio::Worker
     sig { returns(T::Hash[String, T.any(Symbol, T::Array[T.any(Symbol, IllegalWorkflowCallValidator)], IllegalWorkflowCallValidator)]) }
     def default_illegal_workflow_calls; end
   end
+end
+
+class Temporalio::Worker::PatchActivationInput < ::Data
+  extend T::Sig
+
+  sig { returns(Temporalio::Workflow::Info) }
+  def workflow_info; end
+
+  sig { returns(String) }
+  def patch_id; end
+
+  sig { params(workflow_info: Temporalio::Workflow::Info, patch_id: String).void }
+  def initialize(workflow_info:, patch_id:); end
+
+  sig { params(kwargs: T.untyped).returns(Temporalio::Worker::PatchActivationInput) }
+  def with(**kwargs); end
 end
 
 class Temporalio::Worker::Options < ::Data
@@ -219,6 +237,9 @@ class Temporalio::Worker::Options < ::Data
 
   sig { returns(T::Boolean) }
   def unsafe_workflow_io_enabled; end
+
+  sig { returns(T.nilable(T.proc.params(input: Temporalio::Worker::PatchActivationInput).returns(T::Boolean))) }
+  def patch_activation_callback; end
 
   sig { returns(Temporalio::Worker::PollerBehavior) }
   def workflow_task_poller_behavior; end

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance.rbs
@@ -39,6 +39,8 @@ module Temporalio
         attr_reader context_frozen: bool
         attr_reader assert_valid_local_activity: ^(String) -> void
         attr_reader in_query_or_validator: bool
+        attr_reader random_disabled: bool
+        attr_reader patch_activation_callback: Proc?
 
         attr_accessor io_enabled: bool
         attr_accessor current_details: String?
@@ -61,6 +63,8 @@ module Temporalio
 
         def patch: (patch_id: Symbol | String, deprecated: bool) -> bool
 
+        def patch_activated?: (String patch_id) -> bool
+
         def metric_meter: -> Temporalio::Metric::Meter
 
         def create_instance: -> Temporalio::Workflow::Definition
@@ -81,7 +85,7 @@ module Temporalio
 
         def failure_exception?: (Exception err) -> bool
 
-        def with_context_frozen: [T] (in_query_or_validator: bool) { -> T } -> T
+        def with_context_frozen: [T] (in_query_or_validator: bool, ?random_disabled: bool) { -> T } -> T
 
         def convert_handler_args: (
           payload_array: Array[untyped],

--- a/temporalio/sig/temporalio/internal/worker/workflow_instance/details.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_instance/details.rbs
@@ -16,6 +16,7 @@ module Temporalio
           attr_reader illegal_calls: Hash[String, :all | Hash[Symbol, TrueClass | Temporalio::Worker::IllegalWorkflowCallValidator] | Temporalio::Worker::IllegalWorkflowCallValidator]
           attr_reader workflow_failure_exception_types: Array[singleton(Exception)]
           attr_reader unsafe_workflow_io_enabled: bool
+          attr_reader patch_activation_callback: Proc?
           attr_reader assert_valid_local_activity: ^(String) -> void
 
           def initialize: (
@@ -32,6 +33,7 @@ module Temporalio
             illegal_calls: Hash[String, :all | Hash[Symbol, TrueClass | Temporalio::Worker::IllegalWorkflowCallValidator] | Temporalio::Worker::IllegalWorkflowCallValidator],
             workflow_failure_exception_types: Array[singleton(Exception)],
             unsafe_workflow_io_enabled: bool,
+            patch_activation_callback: Proc?,
             assert_valid_local_activity: ^(String) -> void
           ) -> void
         end

--- a/temporalio/sig/temporalio/internal/worker/workflow_worker.rbs
+++ b/temporalio/sig/temporalio/internal/worker/workflow_worker.rbs
@@ -27,6 +27,7 @@ module Temporalio
           workflow_failure_exception_types: Array[singleton(Exception)],
           workflow_payload_codec_thread_pool: Temporalio::Worker::ThreadPool?,
           unsafe_workflow_io_enabled: bool,
+          patch_activation_callback: Proc?,
           debug_mode: bool,
           ?on_eviction: (^(String run_id, untyped cache_remove_job) -> void)?,
           assert_valid_local_activity: ^(String) -> void
@@ -65,6 +66,7 @@ module Temporalio
           attr_reader workflow_interceptors: Array[Temporalio::Worker::Interceptor::Workflow]
           attr_reader workflow_failure_exception_types: Array[singleton(Exception)]
           attr_reader unsafe_workflow_io_enabled: bool
+          attr_reader patch_activation_callback: Proc?
           attr_reader assert_valid_local_activity: ^(String) -> void
 
           attr_writer on_eviction: ^(String run_id, untyped cache_remove_job) -> void
@@ -83,6 +85,7 @@ module Temporalio
             workflow_interceptors: Array[Temporalio::Worker::Interceptor::Workflow],
             workflow_failure_exception_types: Array[singleton(Exception)],
             unsafe_workflow_io_enabled: bool,
+            patch_activation_callback: Proc?,
             assert_valid_local_activity: ^(String) -> void
           ) -> void
 

--- a/temporalio/sig/temporalio/worker.rbs
+++ b/temporalio/sig/temporalio/worker.rbs
@@ -1,5 +1,12 @@
 module Temporalio
   class Worker
+    class PatchActivationInput
+      attr_reader workflow_info: Workflow::Info
+      attr_reader patch_id: String
+
+      def initialize: (workflow_info: Workflow::Info, patch_id: String) -> void
+      def with: (**Object kwargs) -> PatchActivationInput
+    end
 
     class Options
       attr_reader client: Client
@@ -32,6 +39,7 @@ module Temporalio
       attr_reader workflow_task_poller_behavior: PollerBehavior
       attr_reader activity_task_poller_behavior: PollerBehavior
       attr_reader deployment_options: Worker::DeploymentOptions
+      attr_reader patch_activation_callback: Proc?
       attr_reader debug_mode: bool
 
       def initialize: (
@@ -65,6 +73,7 @@ module Temporalio
         workflow_task_poller_behavior: PollerBehavior,
         activity_task_poller_behavior: PollerBehavior,
         deployment_options: Worker::DeploymentOptions,
+        patch_activation_callback: Proc?,
         debug_mode: bool
       ) -> void
 
@@ -128,6 +137,7 @@ module Temporalio
       ?workflow_task_poller_behavior: PollerBehavior,
       ?activity_task_poller_behavior: PollerBehavior,
       ?deployment_options: Worker::DeploymentOptions,
+      ?patch_activation_callback: Proc?,
       ?debug_mode: bool
     ) -> void
 

--- a/temporalio/test/converters/payload_converter_test.rb
+++ b/temporalio/test/converters/payload_converter_test.rb
@@ -86,7 +86,9 @@ module Converters
       # Make a new converter with all default converters except json proto so
       # that binary proto takes precedent
       converter = Temporalio::Converters::PayloadConverter::Composite.new(
-        *Temporalio::Converters::PayloadConverter.default.converters.values.grep_v(Temporalio::Converters::PayloadConverter::JSONProtobuf)
+        *Temporalio::Converters::PayloadConverter.default.converters.values.grep_v(
+          Temporalio::Converters::PayloadConverter::JSONProtobuf
+        )
       )
 
       proto = Temporalio::Api::Common::V1::WorkflowExecution.new(workflow_id: 'id1')

--- a/temporalio/test/sig/worker/workflow_instance_test.rbs
+++ b/temporalio/test/sig/worker/workflow_instance_test.rbs
@@ -1,0 +1,7 @@
+module Worker
+  class WorkflowInstanceTest < Test
+    private
+
+    def workflow_instance: -> Temporalio::Internal::Worker::WorkflowInstance
+  end
+end

--- a/temporalio/test/sig/workflow_utils.rbs
+++ b/temporalio/test/sig/workflow_utils.rbs
@@ -20,6 +20,7 @@ module WorkflowUtils
     ?interceptors: Array[Temporalio::Worker::Interceptor::Activity | Temporalio::Worker::Interceptor::Workflow],
     ?on_worker_run: Proc?,
     ?unsafe_workflow_io_enabled: bool,
+    ?patch_activation_callback: Proc?,
     ?priority: Temporalio::Priority,
     ?start_workflow_client: Temporalio::Client,
     ?tuner: Temporalio::Worker::Tuner
@@ -45,6 +46,7 @@ module WorkflowUtils
     ?interceptors: Array[Temporalio::Worker::Interceptor::Activity | Temporalio::Worker::Interceptor::Workflow],
     ?on_worker_run: Proc?,
     ?unsafe_workflow_io_enabled: bool,
+    ?patch_activation_callback: Proc?,
     ?priority: Temporalio::Priority,
     ?start_workflow_client: Temporalio::Client,
     ?tuner: Temporalio::Worker::Tuner

--- a/temporalio/test/worker/workflow_instance_test.rb
+++ b/temporalio/test/worker/workflow_instance_test.rb
@@ -51,9 +51,11 @@ module Worker
           failure_converter: data_converter.failure_converter,
           interceptors: [],
           disable_eager_activity_execution: false,
-          illegal_calls: Temporalio::Internal::Worker::WorkflowInstance::IllegalCallTracer.frozen_validated_illegal_calls({}),
+          illegal_calls:
+            Temporalio::Internal::Worker::WorkflowInstance::IllegalCallTracer.frozen_validated_illegal_calls({}),
           workflow_failure_exception_types: [],
           unsafe_workflow_io_enabled: false,
+          patch_activation_callback: nil,
           assert_valid_local_activity: ->(_) {}
         )
       )

--- a/temporalio/test/worker/workflow_instance_test.rb
+++ b/temporalio/test/worker/workflow_instance_test.rb
@@ -20,45 +20,8 @@ module Worker
     end
 
     def test_continue_as_new_suggestion_reasons_are_visible_as_workflow_enum_ints
+      instance = workflow_instance
       data_converter = Temporalio::Converters::DataConverter.default
-      initial_activation = Temporalio::Internal::Bridge::Api::WorkflowActivation::WorkflowActivation.new(
-        run_id: 'run-id',
-        timestamp: Google::Protobuf::Timestamp.new(seconds: Time.now.to_i),
-        history_length: 1,
-        history_size_bytes: 1,
-        jobs: [
-          Temporalio::Internal::Bridge::Api::WorkflowActivation::WorkflowActivationJob.new(
-            initialize_workflow: Temporalio::Internal::Bridge::Api::WorkflowActivation::InitializeWorkflow.new(
-              workflow_type: 'ContinueAsNewSuggestionWorkflow',
-              workflow_id: 'workflow-id',
-              randomness_seed: 1,
-              start_time: Google::Protobuf::Timestamp.new(seconds: Time.now.to_i),
-              workflow_task_timeout: Google::Protobuf::Duration.new(seconds: 10)
-            )
-          )
-        ]
-      )
-
-      instance = Temporalio::Internal::Worker::WorkflowInstance.new(
-        Temporalio::Internal::Worker::WorkflowInstance::Details.new(
-          namespace: 'namespace',
-          task_queue: 'task-queue',
-          definition: Temporalio::Workflow::Definition::Info.from_class(ContinueAsNewSuggestionWorkflow),
-          initial_activation:,
-          logger: Logger.new(nil),
-          metric_meter: Temporalio::Runtime.default.metric_meter,
-          payload_converter: data_converter.payload_converter,
-          failure_converter: data_converter.failure_converter,
-          interceptors: [],
-          disable_eager_activity_execution: false,
-          illegal_calls:
-            Temporalio::Internal::Worker::WorkflowInstance::IllegalCallTracer.frozen_validated_illegal_calls({}),
-          workflow_failure_exception_types: [],
-          unsafe_workflow_io_enabled: false,
-          patch_activation_callback: nil,
-          assert_valid_local_activity: ->(_) {}
-        )
-      )
 
       completion = instance.activate(
         Temporalio::Internal::Bridge::Api::WorkflowActivation::WorkflowActivation.new(
@@ -85,6 +48,69 @@ module Worker
           Temporalio::SuggestContinueAsNewReason::TOO_MANY_HISTORY_EVENTS
         ]
       ], result
+    end
+
+    def test_frozen_context_flags_are_initialized_and_restored
+      instance = workflow_instance
+
+      assert_equal false, instance.context_frozen
+      assert_equal false, instance.random_disabled
+      instance.send(:with_context_frozen, in_query_or_validator: true, random_disabled: true) do
+        assert_equal true, instance.context_frozen
+        assert_equal true, instance.random_disabled
+        instance.send(:with_context_frozen, in_query_or_validator: false, random_disabled: false) do
+          assert_equal true, instance.context_frozen
+          assert_equal false, instance.random_disabled
+        end
+        assert_equal true, instance.context_frozen
+        assert_equal true, instance.random_disabled
+      end
+      assert_equal false, instance.context_frozen
+      assert_equal false, instance.random_disabled
+    end
+
+    private
+
+    def workflow_instance
+      data_converter = Temporalio::Converters::DataConverter.default
+      initial_activation = Temporalio::Internal::Bridge::Api::WorkflowActivation::WorkflowActivation.new(
+        run_id: 'run-id',
+        timestamp: Google::Protobuf::Timestamp.new(seconds: Time.now.to_i),
+        history_length: 1,
+        history_size_bytes: 1,
+        jobs: [
+          Temporalio::Internal::Bridge::Api::WorkflowActivation::WorkflowActivationJob.new(
+            initialize_workflow: Temporalio::Internal::Bridge::Api::WorkflowActivation::InitializeWorkflow.new(
+              workflow_type: 'ContinueAsNewSuggestionWorkflow',
+              workflow_id: 'workflow-id',
+              randomness_seed: 1,
+              start_time: Google::Protobuf::Timestamp.new(seconds: Time.now.to_i),
+              workflow_task_timeout: Google::Protobuf::Duration.new(seconds: 10)
+            )
+          )
+        ]
+      )
+
+      Temporalio::Internal::Worker::WorkflowInstance.new(
+        Temporalio::Internal::Worker::WorkflowInstance::Details.new(
+          namespace: 'namespace',
+          task_queue: 'task-queue',
+          definition: Temporalio::Workflow::Definition::Info.from_class(ContinueAsNewSuggestionWorkflow),
+          initial_activation:,
+          logger: Logger.new(nil),
+          metric_meter: Temporalio::Runtime.default.metric_meter,
+          payload_converter: data_converter.payload_converter,
+          failure_converter: data_converter.failure_converter,
+          interceptors: [],
+          disable_eager_activity_execution: false,
+          illegal_calls:
+            Temporalio::Internal::Worker::WorkflowInstance::IllegalCallTracer.frozen_validated_illegal_calls({}),
+          workflow_failure_exception_types: [],
+          unsafe_workflow_io_enabled: false,
+          patch_activation_callback: nil,
+          assert_valid_local_activity: ->(_) {}
+        )
+      )
     end
   end
 end

--- a/temporalio/test/worker_workflow_priority_test.rb
+++ b/temporalio/test/worker_workflow_priority_test.rb
@@ -60,14 +60,15 @@ class WorkerWorkflowPriorityTest < Test
       result = handle.result
       raise 'child workflow failed' unless result == 'Done!'
 
-      act_actual, act_expected, act_fairness_actual, act_fairness_expected, act_weight_actual, act_weight_expected = Temporalio::Workflow.execute_activity(
-        ActivityWithPriority,
-        5,
-        'high',
-        1.5,
-        start_to_close_timeout: 5,
-        priority: Temporalio::Priority.new(priority_key: 5, fairness_key: 'high', fairness_weight: 1.5)
-      )
+      act_actual, act_expected, act_fairness_actual, act_fairness_expected, act_weight_actual, act_weight_expected =
+        Temporalio::Workflow.execute_activity(
+          ActivityWithPriority,
+          5,
+          'high',
+          1.5,
+          start_to_close_timeout: 5,
+          priority: Temporalio::Priority.new(priority_key: 5, fairness_key: 'high', fairness_weight: 1.5)
+        )
       raise "Activity expected priority #{act_expected}, got #{act_actual}" if act_actual != act_expected
       if act_fairness_actual != act_fairness_expected
         raise "Activity expected fairness_key #{act_fairness_expected}, got #{act_fairness_actual}"

--- a/temporalio/test/worker_workflow_test.rb
+++ b/temporalio/test/worker_workflow_test.rb
@@ -1626,6 +1626,64 @@ class WorkerWorkflowTest < Test
     end
   end
 
+  class PatchActivationWorkflow < Temporalio::Workflow::Definition
+    def execute(patch_id, sleep_after_first)
+      first = Temporalio::Workflow.patched(patch_id)
+      Temporalio::Workflow.sleep(0.001) if sleep_after_first
+      second = Temporalio::Workflow.patched(patch_id)
+      [first, second]
+    end
+  end
+
+  class PatchActivationDeprecateWorkflow < Temporalio::Workflow::Definition
+    def execute(patch_id)
+      Temporalio::Workflow.deprecate_patch(patch_id)
+      Temporalio::Workflow.patched(patch_id)
+    end
+  end
+
+  class PatchActivationRolloutWorkflow < Temporalio::Workflow::Definition
+    workflow_query_attr_reader :state
+
+    def initialize
+      @releases = 0
+      @state = 'new-0'
+    end
+
+    def execute
+      Temporalio::Workflow.patched('rollout-patch')
+      Temporalio::Workflow.wait_condition { @releases >= 1 }
+      @state = 'new-1'
+      Temporalio::Workflow.patched('rollout-patch') ? 'new' : 'old'
+    end
+
+    workflow_signal
+    def release
+      @releases += 1
+    end
+  end
+
+  class PatchActivationOldRolloutWorkflow < Temporalio::Workflow::Definition
+    workflow_name :PatchActivationRolloutWorkflow
+    workflow_query_attr_reader :state
+
+    def initialize
+      @releases = 0
+      @state = 'old-0'
+    end
+
+    def execute
+      Temporalio::Workflow.wait_condition { @releases >= 1 }
+      @state = 'old-1'
+      'old'
+    end
+
+    workflow_signal
+    def release
+      @releases += 1
+    end
+  end
+
   def test_patch
     task_queue = "tq-#{SecureRandom.uuid}"
     activities = [PatchPreActivity, PatchPostActivity]
@@ -1671,6 +1729,216 @@ class WorkerWorkflowTest < Test
         env.client.workflow_handle(patched_id).query(PatchWorkflow.activity_result)
       end
       assert_includes err.message, 'Nondeterminism'
+    end
+  end
+
+  def test_patch_activation_callback
+    workflow_id = "wf-#{SecureRandom.uuid}"
+    calls = []
+    result = execute_workflow(
+      PatchActivationWorkflow,
+      :my_patch,
+      false,
+      id: workflow_id,
+      patch_activation_callback: proc do |input|
+        calls << input
+        true
+      end
+    )
+
+    assert_equal [true, true], result
+    assert_equal 1, calls.size
+    assert_equal workflow_id, calls.first.workflow_info.workflow_id
+    assert_equal 'my_patch', calls.first.patch_id
+  end
+
+  def test_patch_activation_callback_can_decline_patch
+    calls = 0
+    execute_workflow(
+      PatchActivationWorkflow,
+      'my-patch',
+      false,
+      patch_activation_callback: proc do |_input|
+        calls += 1
+        false
+      end
+    ) do |handle|
+      assert_equal [false, false], handle.result
+      assert_equal 1, calls
+      assert_empty handle.fetch_history_events.select(&:marker_recorded_event_attributes)
+    end
+  end
+
+  def test_patch_activation_default_still_activates_patch
+    execute_workflow(PatchActivationWorkflow, 'my-patch', false) do |handle|
+      assert_equal [true, true], handle.result
+      refute_empty handle.fetch_history_events.select(&:marker_recorded_event_attributes)
+    end
+  end
+
+  def test_patch_activation_callback_not_called_on_replay_or_after_memoization
+    calls = 0
+    result = execute_workflow(
+      PatchActivationWorkflow,
+      'my-patch',
+      true,
+      max_cached_workflows: 0,
+      patch_activation_callback: proc do |_input|
+        calls += 1
+        false
+      end
+    )
+
+    assert_equal [false, false], result
+    assert_equal 1, calls
+  end
+
+  def test_patch_activation_callback_not_called_for_deprecate_patch
+    result = execute_workflow(
+      PatchActivationDeprecateWorkflow,
+      'my-patch',
+      patch_activation_callback: proc { |_input| raise 'unexpected patch activation callback' }
+    )
+
+    assert_equal true, result
+  end
+
+  def test_patch_activation_callback_must_return_boolean
+    execute_workflow(
+      PatchActivationWorkflow,
+      'my-patch',
+      false,
+      patch_activation_callback: proc { |_input| }
+    ) do |handle|
+      assert_eventually_task_fail(handle:, message_contains: 'Patch activation callback must return true or false')
+    end
+  end
+
+  def test_patch_activation_callback_runs_in_frozen_context
+    execute_workflow(
+      PatchActivationWorkflow,
+      'make_command',
+      false,
+      patch_activation_callback: proc do |_input|
+        Temporalio::Workflow.upsert_memo({ foo: 'bar' })
+        true
+      end
+    ) do |handle|
+      assert_eventually_task_fail(handle:, message_contains: 'Cannot add commands in this context')
+    end
+
+    execute_workflow(
+      PatchActivationWorkflow,
+      'fiber_schedule',
+      false,
+      patch_activation_callback: proc do |_input|
+        Fiber.schedule { 'foo' }
+        true
+      end
+    ) do |handle|
+      assert_eventually_task_fail(handle:, message_contains: 'Cannot schedule fibers in this context')
+    end
+
+    execute_workflow(
+      PatchActivationWorkflow,
+      'wait_condition',
+      false,
+      patch_activation_callback: proc do |_input|
+        Temporalio::Workflow.wait_condition { true }
+        true
+      end
+    ) do |handle|
+      assert_eventually_task_fail(handle:, message_contains: 'Cannot wait in this context')
+    end
+
+    execute_workflow(
+      PatchActivationWorkflow,
+      'random',
+      false,
+      patch_activation_callback: proc do |_input|
+        Temporalio::Workflow.random.rand
+        true
+      end
+    ) do |handle|
+      assert_eventually_task_fail(handle:, message_contains: 'Cannot use random in this context')
+    end
+  end
+
+  def test_unactivated_patch_can_roll_out_to_old_worker
+    task_queue = "tq-#{SecureRandom.uuid}"
+    workflow_id = "wf-#{SecureRandom.uuid}"
+    callback_calls = 0
+    handle = nil
+
+    new_worker = Temporalio::Worker.new(
+      client: env.client,
+      task_queue:,
+      workflows: [PatchActivationRolloutWorkflow],
+      patch_activation_callback: proc do |_input|
+        callback_calls += 1
+        false
+      end
+    )
+    new_worker.run do
+      started_handle = env.client.start_workflow(PatchActivationRolloutWorkflow, id: workflow_id, task_queue:)
+      handle = started_handle
+      assert_eventually { assert_equal 1, callback_calls }
+      assert_equal 'new-0', started_handle.query(PatchActivationRolloutWorkflow.state)
+    end
+
+    raise unless handle
+
+    workflow_handle = handle #: Temporalio::Client::WorkflowHandle
+    old_worker = Temporalio::Worker.new(
+      client: env.client,
+      task_queue:,
+      workflows: [PatchActivationOldRolloutWorkflow]
+    )
+    old_worker.run do
+      workflow_handle.signal(PatchActivationOldRolloutWorkflow.release)
+      assert_equal 'old', workflow_handle.result
+    end
+  end
+
+  def test_activated_patch_replays_on_unactivated_new_worker
+    task_queue = "tq-#{SecureRandom.uuid}"
+    workflow_id = "wf-#{SecureRandom.uuid}"
+    activated_calls = 0
+    unactivated_calls = 0
+    handle = nil
+
+    activated_worker = Temporalio::Worker.new(
+      client: env.client,
+      task_queue:,
+      workflows: [PatchActivationRolloutWorkflow],
+      patch_activation_callback: proc do |_input|
+        activated_calls += 1
+        true
+      end
+    )
+    activated_worker.run do
+      started_handle = env.client.start_workflow(PatchActivationRolloutWorkflow, id: workflow_id, task_queue:)
+      handle = started_handle
+      assert_eventually { assert_equal 1, activated_calls }
+      assert_equal 'new-0', started_handle.query(PatchActivationRolloutWorkflow.state)
+    end
+
+    raise unless handle
+
+    workflow_handle = handle #: Temporalio::Client::WorkflowHandle
+    unactivated_worker = Temporalio::Worker.new(
+      client: env.client,
+      task_queue:,
+      workflows: [PatchActivationRolloutWorkflow],
+      patch_activation_callback: proc do |_input|
+        unactivated_calls += 1
+        false
+      end
+    )
+    unactivated_worker.run do
+      workflow_handle.signal(PatchActivationRolloutWorkflow.release)
+      assert_equal 'new', workflow_handle.result
+      assert_equal 0, unactivated_calls
     end
   end
 
@@ -2700,7 +2968,10 @@ class WorkerWorkflowTest < Test
 
       return 'Done' if info.attempt != 1
 
-      raise Temporalio::Error::ApplicationError.new('Intentional failure', category: Temporalio::Error::ApplicationError::Category::BENIGN)
+      raise Temporalio::Error::ApplicationError.new(
+        'Intentional failure',
+        category: Temporalio::Error::ApplicationError::Category::BENIGN
+      )
     end
   end
 

--- a/temporalio/test/workflow_utils.rb
+++ b/temporalio/test/workflow_utils.rb
@@ -31,6 +31,7 @@ module WorkflowUtils
     interceptors: [],
     on_worker_run: nil,
     unsafe_workflow_io_enabled: false,
+    patch_activation_callback: nil,
     priority: Temporalio::Priority.default,
     start_workflow_client: client,
     tuner: Temporalio::Worker::Tuner.create_fixed
@@ -47,6 +48,7 @@ module WorkflowUtils
       max_heartbeat_throttle_interval:,
       interceptors:,
       unsafe_workflow_io_enabled:,
+      patch_activation_callback:,
       tuner:
     )
     worker.run do


### PR DESCRIPTION
## What was changed

  Added an experimental worker option, `patch_activation_callback`, that can decide whether a newly encountered
  `Workflow.patched` call should be activated.

  The callback receives `Temporalio::Worker::PatchActivationInput`, including workflow info and patch ID. If it
  returns `false`, the patch is treated as inactive and no patch marker is recorded. Replay, deprecated patches, and
  already-recorded patch markers continue to follow history.

  ## Why?

  Users would like to roll out workflow changes that introduce `Workflow.patched` without requiring every new-code
  worker to immediately activate the patch.

  Without this, a new worker can record a patch marker that an older worker cannot handle if the workflow later
  replays there. Allowing workers to defer patch activation makes slow rolling deployments quieter and safer.

  ## Checklist

  1. Closes https://github.com/temporalio/sdk-ruby/issues/480

  2. How was this tested:
  Added tests

  3. Any docs updates needed?
  README and changelog updated