### PR TITLE
Defer schedule catchup window default to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Schedule policies now omit an unspecified catch-up window so the Temporal Server applies its default (currently one year).
+
 #### `Workflow.suggest_continue_as_new_reasons` returns workflow enum values
 
 Workflow activations containing continue-as-new suggestion reasons previously failed because the

--- a/temporalio/lib/temporalio/client/schedule.rb
+++ b/temporalio/lib/temporalio/client/schedule.rb
@@ -733,7 +733,8 @@ module Temporalio
       # @!attribute overlap
       #   @return [OverlapPolicy] Controls what happens when an action is started while another is still running.
       # @!attribute catchup_window
-      #   @return [Float] After a Temporal server is unavailable, amount of time in the past to execute missed actions.
+      #   @return [Float, nil] After a Temporal server is unavailable, amount of time in the past to execute missed
+      #     actions. If unset, this is omitted so the Temporal server applies its default (currently one year).
       # @!attribute pause_on_failure
       #   @return [Boolean] Whether to pause the schedule if an action fails or times out. Note: For workflows, this
       #     only applies after all retries have been exhausted.
@@ -752,13 +753,14 @@ module Temporalio
         # Create a schedule policy.
         #
         # @param overlap [OverlapPolicy] Controls what happens when an action is started while another is still running.
-        # @param catchup_window [Float] After a Temporal server is unavailable, amount of time in the past to execute
-        #   missed actions.
+        # @param catchup_window [Float, nil] After a Temporal server is unavailable, amount of time in the past to
+        #   execute missed actions. If unset, this is omitted so the Temporal server applies its default (currently one
+        #   year).
         # @param pause_on_failure [Boolean] Whether to pause the schedule if an action fails or times out. Note: For
         #   workflows, this only applies after all retries have been exhausted.
         def initialize(
           overlap: OverlapPolicy::SKIP,
-          catchup_window: 365 * 24 * 60 * 60.0,
+          catchup_window: nil,
           pause_on_failure: false
         )
           super

--- a/temporalio/rbi/temporalio/client/schedule.rbi
+++ b/temporalio/rbi/temporalio/client/schedule.rbi
@@ -377,7 +377,7 @@ class Temporalio::Client::Schedule::Policy < ::Data
   sig do
     params(
       overlap: Integer,
-      catchup_window: T.any(Integer, Float),
+      catchup_window: T.nilable(T.any(Integer, Float)),
       pause_on_failure: T::Boolean
     ).void
   end
@@ -386,7 +386,7 @@ class Temporalio::Client::Schedule::Policy < ::Data
   sig { returns(Integer) }
   def overlap; end
 
-  sig { returns(T.any(Integer, Float)) }
+  sig { returns(T.nilable(T.any(Integer, Float))) }
   def catchup_window; end
 
   sig { returns(T::Boolean) }

--- a/temporalio/sig/temporalio/client/schedule.rbs
+++ b/temporalio/sig/temporalio/client/schedule.rbs
@@ -239,14 +239,14 @@ module Temporalio
 
       class Policy
         attr_reader overlap: OverlapPolicy::enum
-        attr_reader catchup_window: duration
+        attr_reader catchup_window: duration?
         attr_reader pause_on_failure: bool
 
         def self._from_proto: (Api::Schedule::V1::SchedulePolicies raw_policies) -> Policy
 
         def initialize: (
           ?overlap: OverlapPolicy::enum,
-          ?catchup_window: duration,
+          ?catchup_window: duration?,
           ?pause_on_failure: bool
         ) -> void
 

--- a/temporalio/test/client_schedule_test.rb
+++ b/temporalio/test/client_schedule_test.rb
@@ -9,6 +9,15 @@ require 'test'
 class ClientScheduleTest < Test
   also_run_all_tests_in_fiber
 
+  def test_default_catchup_window_is_omitted
+    policy = Temporalio::Client::Schedule::Policy.new
+    assert_nil policy.catchup_window
+    refute policy._to_proto.has_catchup_window?
+
+    policy = Temporalio::Client::Schedule::Policy.new(catchup_window: 5 * 60.0)
+    assert_equal 5 * 60.0, policy._to_proto.catchup_window.to_f
+  end
+
   def test_basics # rubocop:disable Metrics/AbcSize
     expected_ids = []
     assert_no_schedules
@@ -133,6 +142,8 @@ class ClientScheduleTest < Test
     handle.update { Temporalio::Client::Schedule::Update.new(schedule: new_schedule) }
     desc = handle.describe
     refute_equal expected_updated_at, desc.info.last_updated_at
+    assert_nil new_schedule.policy.catchup_window
+    assert_equal 365 * 24 * 60 * 60.0, desc.schedule.policy.catchup_window
 
     # Attempt to create duplicate
     assert_raises(Temporalio::Error::ScheduleAlreadyRunningError) do


### PR DESCRIPTION
## What changed
- Default `catchup_window` to `nil` rather than one year.
- Omit the protobuf field when unset.
- Update YARD, RBS, RBI, tests, and the changelog.
- Add server-backed coverage for the resolved one-year default.

## Why
The SDK should leave the value unset and allow the Temporal Server to own the default.


## Breaking changes
An unconfigured policy returns `nil` before server round-tripping. Described schedules return the server-resolved duration.