### PR TITLE
Fix anonymous block parameter in Workflow::Future RBI

### DIFF
--- a/temporalio/rbi/temporalio/workflow/future.rbi
+++ b/temporalio/rbi/temporalio/workflow/future.rbi
@@ -13,7 +13,7 @@ class Temporalio::Workflow::Future
   attr_reader :failure
 
   sig { params(block: T.nilable(T.proc.returns(Elem))).void }
-  def initialize(&); end
+  def initialize(&block); end
 
   sig { returns(T::Boolean) }
   def done?; end


### PR DESCRIPTION
## What was changed

In `rbi/temporalio/workflow/future.rbi`, renamed the anonymous block parameter from `&` to `&block` on line 16 of `Temporalio::Workflow::Future#initialize`:

```ruby
# before
sig { params(block: T.nilable(T.proc.returns(Elem))).void }
def initialize(&); end

# after
sig { params(block: T.nilable(T.proc.returns(Elem))).void }
def initialize(&block); end
```

## Why?

The `sig` declares a parameter named `block:`, but the method definition used `&` (anonymous block forwarding). Sorbet requires the parameter name in the sig to match the name in the method definition. With the anonymous form, Sorbet raises two errors (5003):

```
Malformed sig. Type not specified for parameter &
Unknown parameter name block
```

The actual Ruby source at `lib/temporalio/workflow/future.rb` already uses `&block` — the RBI was inconsistent with the implementation.

This also fixes a secondary issue for users of [[tapioca](https://github.com/Shopify/tapioca)](https://github.com/Shopify/tapioca): when tapioca generates a merged gem RBI by combining runtime reflection (which produces `&block`) with this bundled RBI (which had `&`), the name mismatch caused the `rbi` gem to emit `&&block` — a parse error — in versions before 0.3.10. Consistent naming eliminates the mismatch regardless of `rbi` gem version.

## Checklist

1. Closes N/A — this is a one-line RBI correction with no associated issue
    
2. How was this tested:
    
    - Confirmed `srb tc` no longer raises errors 5003 ("Malformed sig" / "Unknown parameter name") against this class after the change
    - Confirmed tapioca gem RBI generation no longer requires post-processing to fix the sig/method mismatch
3. Any docs updates needed? No