### PR TITLE
fix: Preserve workflow task failure errors through illegal call validator rescues

### DIFF
--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/illegal_call_tracer.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/illegal_call_tracer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'temporalio/internal/workflow_task_failure_error'
 require 'temporalio/worker/illegal_workflow_call_validator'
 require 'temporalio/workflow'
 
@@ -92,6 +93,11 @@ module Temporalio
                                     ))
                     nil
                   rescue Exception => e # rubocop:disable Lint/RescueException
+                    # Errors that invalidate the whole workflow task (e.g. an async DeadlockError landing while the
+                    # validator runs) must propagate with their class intact so they fail the task instead of being
+                    # flattened into a NondeterminismError message that futures may store
+                    raise if e.is_a?(Internal::WorkflowTaskFailureError)
+
                     ", reason: #{e}"
                   end
                 else
@@ -108,6 +114,9 @@ module Temporalio
                                             ))
                       nil
                     rescue Exception => e # rubocop:disable Lint/RescueException
+                      # See workflow-task-failure comment on the class-level validator rescue above
+                      raise if e.is_a?(Internal::WorkflowTaskFailureError)
+
                       ", reason: #{e}"
                     end
                   end

--- a/temporalio/test/deadlock_test.rb
+++ b/temporalio/test/deadlock_test.rb
@@ -65,6 +65,22 @@ class DeadlockTest < Test
     end
   end
 
+  module ValidatorInterruptProbe
+    def self.probe; end
+  end
+
+  class DeadlockDuringValidatorWorkflow < Temporalio::Workflow::Definition
+    def execute
+      Temporalio::Workflow::Future.new do
+        ValidatorInterruptProbe.probe
+        Temporalio::Workflow.execute_activity(BasicActivity, 1, start_to_close_timeout: 10)
+      end
+      # Future intentionally not waited (mirrors a fanout blocked on all_of with other
+      # futures pending) so a stored failure would never surface
+      Temporalio::Workflow.wait_condition { false }
+    end
+  end
+
   class ProtobufObjectCachePartialCommandsWorkflow < Temporalio::Workflow::Definition
     ACTIVITY_COUNT = 6
     BLOCK_AFTER_ACTIVITY_COUNT = 3
@@ -139,6 +155,48 @@ class DeadlockTest < Test
         end
         assert_operator events.count(&:workflow_task_completed_event_attributes), :>, completed_workflow_tasks
       end
+    end
+  ensure
+    handle&.terminate
+  end
+
+  def test_deadlock_during_illegal_call_validator_fails_workflow_task
+    task_queue = "tq-#{SecureRandom.uuid}"
+    # Simulates the deadlock watchdog's async raise landing while an illegal call
+    # validator block is executing (e.g. Thread::Mutex#synchronize inside protobuf's
+    # ObjectCache during ScheduleActivity arg serialization)
+    illegal_calls = Temporalio::Worker.default_illegal_workflow_calls.merge(
+      'DeadlockTest::ValidatorInterruptProbe' => [
+        Temporalio::Worker::IllegalWorkflowCallValidator.new(method_name: :probe) do |_info|
+          raise Temporalio::Worker::WorkflowExecutor::ThreadPool::DeadlockError,
+                '[TMPRL1101] Potential deadlock detected: simulated async deadlock raise'
+        end
+      ]
+    )
+    worker = Temporalio::Worker.new(
+      client: env.client,
+      task_queue:,
+      workflows: [DeadlockDuringValidatorWorkflow],
+      activities: [BasicActivity],
+      illegal_workflow_calls: illegal_calls
+    )
+    # @type var handle: untyped
+    handle = nil
+    worker.run do
+      handle = env.client.start_workflow(
+        DeadlockDuringValidatorWorkflow,
+        id: "wf-#{SecureRandom.uuid}",
+        task_queue:
+      )
+      assert_eventually_task_fail(handle:, message_contains: 'Potential deadlock detected')
+      # The DeadlockError class must survive the tracer. A laundered
+      # NondeterminismError would read "Cannot access ..." and, when raised inside a
+      # future, be stored instead of failing the task at all
+      failure_messages = handle.fetch_history_events.filter_map do |event|
+        event.workflow_task_failed_event_attributes&.failure&.message
+      end
+      refute_empty(failure_messages)
+      failure_messages.each { |message| refute_includes(message, 'Cannot access') }
     end
   ensure
     handle&.terminate

--- a/temporalio/test/deadlock_test.rb
+++ b/temporalio/test/deadlock_test.rb
@@ -180,14 +180,12 @@ class DeadlockTest < Test
       activities: [BasicActivity],
       illegal_workflow_calls: illegal_calls
     )
-    # @type var handle: untyped
-    handle = nil
+    handle = env.client.start_workflow(
+      DeadlockDuringValidatorWorkflow,
+      id: "wf-#{SecureRandom.uuid}",
+      task_queue:
+    )
     worker.run do
-      handle = env.client.start_workflow(
-        DeadlockDuringValidatorWorkflow,
-        id: "wf-#{SecureRandom.uuid}",
-        task_queue:
-      )
       assert_eventually_task_fail(handle:, message_contains: 'Potential deadlock detected')
       # The DeadlockError class must survive the tracer. A laundered
       # NondeterminismError would read "Cannot access ..." and, when raised inside a


### PR DESCRIPTION
## What was changed

The illegal call tracer's validator rescue blocks (`IllegalCallTracer#initialize`, both branches) now re-raise exceptions marked with `Internal::WorkflowTaskFailureError` instead of flattening them into the `", reason: #{e}"` string of a `Workflow::NondeterminismError`.

## Why?

The deadlock detector raises `DeadlockError` asynchronously into the workflow thread (`Timeout.timeout` in `thread_pool.rb`). If that raise lands while an `IllegalWorkflowCallValidator` block is executing — in our production incidents, the `Thread::Mutex#synchronize` validator hit via protobuf's `ObjectCache` during `ScheduleActivity` arg serialization — the tracer's `rescue Exception` converts it into a `NondeterminismError` string. The `WorkflowTaskFailureError` marker from #467 is destroyed, so `Future#initialize` stores the error instead of failing the workflow task, and the activation completes with a partial command batch (a consumed-but-unscheduled activity id). Replay then fails permanently with `[TMPRL1100] Activity id of scheduled event 'N' does not match activity id of activity command 'N-1'`.

With this change the marker class survives the validator path, the existing #467 machinery re-raises it out of the future, and the workflow task fails and retries — the same contract as when the deadlock lands outside a traced call.

## Checklist

1. Closes #503

2. How was this tested:

Added `test_deadlock_during_illegal_call_validator_fails_workflow_task` to `deadlock_test.rb`: a custom validator raises `DeadlockError` (standing in for the async watchdog raise landing mid-validator) inside a `Workflow::Future` that is never waited. Pre-fix, the error is silently stored and no workflow task ever fails; post-fix, the task fails with the deadlock message (and the test asserts the failure is not the laundered `"Cannot access ..."` form). I could not run the suite locally (no Rust toolchain for the bridge), so relying on CI here; the equivalent behavior change has been validated in production via a monkeypatch on 1.5.0.

3. Any docs updates needed?

N/A

Made with [Cursor](https://cursor.com)