### PR TITLE
fix(client): handle time skipping server long poll response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ to docs, or any other relevant information.
 - User metadata fields (static_summary, static_details, current_details, activity summary, timer
   summary) are no longer marked as experimental.
 
+### Fixed
+
+- `Temporalio::Client::WorkflowHandle#result` no longer returns `nil` while a workflow is still
+  running when a history long poll expires without returning an event.
+
 ## [v1.6.0] - 2026-07-16
 
 ### Added

--- a/temporalio/lib/temporalio/client/workflow_handle.rb
+++ b/temporalio/lib/temporalio/client/workflow_handle.rb
@@ -95,6 +95,8 @@ module Temporalio
               rpc_options:
             ).next
           rescue StopIteration
+            # Timeskipping server can return empty events with no continuation token, this will surface as an empty
+            # iterator.
             next
           end
 

--- a/temporalio/lib/temporalio/client/workflow_handle.rb
+++ b/temporalio/lib/temporalio/client/workflow_handle.rb
@@ -86,13 +86,17 @@ module Temporalio
         hist_run_id = result_run_id
         loop do
           # Get close event
-          event = fetch_history_events(
-            wait_new_event: true,
-            event_filter_type: Api::Enums::V1::HistoryEventFilterType::HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
-            skip_archival: true,
-            specific_run_id: hist_run_id,
-            rpc_options:
-          ).next
+          event = begin
+            fetch_history_events(
+              wait_new_event: true,
+              event_filter_type: Api::Enums::V1::HistoryEventFilterType::HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
+              skip_archival: true,
+              specific_run_id: hist_run_id,
+              rpc_options:
+            ).next
+          rescue StopIteration
+            next
+          end
 
           # Check each close type'
           case event.event_type

--- a/temporalio/test/client_test.rb
+++ b/temporalio/test/client_test.rb
@@ -140,6 +140,30 @@ class ClientTest < Test
     end
   end
 
+  class EmptyFirstHistoryEventsInterceptor
+    include Temporalio::Client::Interceptor
+
+    def intercept_client(next_interceptor)
+      Outbound.new(next_interceptor)
+    end
+
+    class Outbound < Temporalio::Client::Interceptor::Outbound
+      def initialize(next_interceptor)
+        super
+        @first_history_fetch = true
+      end
+
+      def fetch_workflow_history_events(input)
+        if @first_history_fetch
+          @first_history_fetch = false
+          return Enumerator.new { |_yielder| nil }
+        end
+
+        super
+      end
+    end
+  end
+
   def test_interceptor
     # Create client with interceptor
     track = TrackCallsInterceptor.new
@@ -186,6 +210,23 @@ class ClientTest < Test
   class SimpleWorkflow < Temporalio::Workflow::Definition
     def execute(name)
       "Hello, #{name}!"
+    end
+  end
+
+  def test_result_retries_when_history_fetch_returns_no_events
+    client = Temporalio::Client.new(
+      **env.client.options.with(interceptors: [EmptyFirstHistoryEventsInterceptor.new]).to_h
+    ) # steep:ignore
+    task_queue = "tq-#{SecureRandom.uuid}"
+
+    Temporalio::Worker.new(client:, task_queue:, workflows: [SimpleWorkflow]).run do
+      handle = client.start_workflow(
+        SimpleWorkflow,
+        'Temporal',
+        id: "wf-#{SecureRandom.uuid}",
+        task_queue:
+      )
+      assert_equal 'Hello, Temporal!', handle.result
     end
   end
 

--- a/temporalio/test/client_test.rb
+++ b/temporalio/test/client_test.rb
@@ -140,30 +140,6 @@ class ClientTest < Test
     end
   end
 
-  class EmptyFirstHistoryEventsInterceptor
-    include Temporalio::Client::Interceptor
-
-    def intercept_client(next_interceptor)
-      Outbound.new(next_interceptor)
-    end
-
-    class Outbound < Temporalio::Client::Interceptor::Outbound
-      def initialize(next_interceptor)
-        super
-        @first_history_fetch = true
-      end
-
-      def fetch_workflow_history_events(input)
-        if @first_history_fetch
-          @first_history_fetch = false
-          return Enumerator.new { |_yielder| nil }
-        end
-
-        super
-      end
-    end
-  end
-
   def test_interceptor
     # Create client with interceptor
     track = TrackCallsInterceptor.new
@@ -213,20 +189,36 @@ class ClientTest < Test
     end
   end
 
-  def test_result_retries_when_history_fetch_returns_no_events
-    client = Temporalio::Client.new(
-      **env.client.options.with(interceptors: [EmptyFirstHistoryEventsInterceptor.new]).to_h
-    ) # steep:ignore
+  def test_result_retries_when_history_long_poll_returns_no_events
+    workflow_service = env.client.workflow_service
+    original_fetch = workflow_service.method(:get_workflow_execution_history)
+    empty_responses_remaining = 2
+    history_fetch_count = 0
+    workflow_service.define_singleton_method(:get_workflow_execution_history) do |request, **kwargs|
+      history_fetch_count += 1
+      if empty_responses_remaining.positive?
+        empty_responses_remaining -= 1
+        Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse.new
+      else
+        original_fetch.call(request, **kwargs)
+      end
+    end
     task_queue = "tq-#{SecureRandom.uuid}"
 
-    Temporalio::Worker.new(client:, task_queue:, workflows: [SimpleWorkflow]).run do
-      handle = client.start_workflow(
-        SimpleWorkflow,
-        'Temporal',
-        id: "wf-#{SecureRandom.uuid}",
-        task_queue:
-      )
-      assert_equal 'Hello, Temporal!', handle.result
+    begin
+      Temporalio::Worker.new(client: env.client, task_queue:, workflows: [SimpleWorkflow]).run do
+        handle = env.client.start_workflow(
+          SimpleWorkflow,
+          'Temporal',
+          id: "wf-#{SecureRandom.uuid}",
+          task_queue:
+        )
+        assert_equal 'Hello, Temporal!', handle.result
+      end
+      assert_equal 0, empty_responses_remaining
+      assert_operator history_fetch_count, :>=, 3
+    ensure
+      workflow_service.singleton_class.send(:remove_method, :get_workflow_execution_history)
     end
   end
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Catch iteration error when fetching workflow results and continue calling.

## Why?
Timeskipping server can return both no events and no continuation token during long polls.

## Checklist
<!--- add/delete as needed --->

1. Closes #499

2. How was this tested:
Added test with mocked empty history.

3. Any docs updates needed?
N/A
