### PR TITLE
ci(release): add stub release-publish and gems-publish workflows

### DIFF
--- a/.github/workflows/gems-publish.yml
+++ b/.github/workflows/gems-publish.yml
@@ -1,15 +1,6 @@
 name: Gems Publish
 run-name: Gems Publish (stub — real logic on a feature branch)
 
-# Stub. Reusable-workflow file that release-publish.yml references
-# via `uses: ./.github/workflows/gems-publish.yml`. Local reusable
-# references are resolved from the calling workflow's ref, so when
-# release-publish.yml is dispatched from a feature branch, the branch's
-# real gems-publish.yml is what actually runs.
-#
-# This stub only executes if a workflow on main happens to invoke it —
-# which is not intended.
-
 on:
   workflow_call:
     inputs:
@@ -32,12 +23,10 @@ permissions:
 
 jobs:
   placeholder:
-    name: Placeholder — real publish logic on a feature branch
+    name: placeholder
     runs-on: ubuntu-latest
     steps:
       - name: Explain
         run: |
-          echo "Stub gems-publish.yml on main. If this ran, a caller on"
-          echo "main invoked the reusable workflow before the real logic"
-          echo "was merged. Nothing has been published."
+          echo "Stub gems-publish.yml on main."
           exit 1

--- a/.github/workflows/gems-publish.yml
+++ b/.github/workflows/gems-publish.yml
@@ -1,0 +1,43 @@
+name: Gems Publish
+run-name: Gems Publish (stub — real logic on a feature branch)
+
+# Stub. Reusable-workflow file that release-publish.yml references
+# via `uses: ./.github/workflows/gems-publish.yml`. Local reusable
+# references are resolved from the calling workflow's ref, so when
+# release-publish.yml is dispatched from a feature branch, the branch's
+# real gems-publish.yml is what actually runs.
+#
+# This stub only executes if a workflow on main happens to invoke it —
+# which is not intended.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      artifact-name:
+        required: true
+        type: string
+      host:
+        required: false
+        type: string
+        default: https://rubygems.org
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Placeholder — real publish logic on a feature branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain
+        run: |
+          echo "Stub gems-publish.yml on main. If this ran, a caller on"
+          echo "main invoked the reusable workflow before the real logic"
+          echo "was merged. Nothing has been published."
+          exit 1

--- a/.github/workflows/gems-publish.yml
+++ b/.github/workflows/gems-publish.yml
@@ -1,5 +1,5 @@
 name: Gems Publish
-run-name: Gems Publish (stub — real logic on a feature branch)
+run-name: Gems Publish (stub)
 
 on:
   workflow_call:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,6 +1,5 @@
 name: Release Publish
-run-name: Release Publish (stub — real logic on a feature branch)
-
+run-name: Release Publish (stub)
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,37 @@
+name: Release Publish
+run-name: Release Publish (stub — real logic on a feature branch)
+
+# Stub. Registers the workflow on the default branch so that
+# `workflow_dispatch` becomes available and the full logic
+# (added on a feature branch) can be dispatched with --ref for
+# end-to-end testing before it lands on main.
+#
+# When the feature branch is merged, this file will be replaced by
+# the real release-publish pipeline.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Placeholder — dispatch from a feature branch, not from main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain
+        run: |
+          cat <<'EOF'
+          This is a stub release-publish.yml.
+
+          The real release pipeline lives on a feature branch. When
+          workflow_dispatch is triggered with --ref pointing at that
+          branch, GitHub loads the workflow YAML from that ref, not
+          from main, so the branch's real pipeline runs.
+
+          If you are seeing this message, you dispatched from main
+          before the feature branch was merged. Nothing has been
+          published; this stub does not push anything.
+          EOF
+          exit 1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,13 +1,6 @@
 name: Release Publish
 run-name: Release Publish (stub — real logic on a feature branch)
 
-# Stub. Registers the workflow on the default branch so that
-# `workflow_dispatch` becomes available and the full logic
-# (added on a feature branch) can be dispatched with --ref for
-# end-to-end testing before it lands on main.
-#
-# When the feature branch is merged, this file will be replaced by
-# the real release-publish pipeline.
 
 on:
   workflow_dispatch: {}
@@ -17,21 +10,12 @@ permissions:
 
 jobs:
   placeholder:
-    name: Placeholder — dispatch from a feature branch, not from main
+    name: placeholder
     runs-on: ubuntu-latest
     steps:
       - name: Explain
         run: |
           cat <<'EOF'
           This is a stub release-publish.yml.
-
-          The real release pipeline lives on a feature branch. When
-          workflow_dispatch is triggered with --ref pointing at that
-          branch, GitHub loads the workflow YAML from that ref, not
-          from main, so the branch's real pipeline runs.
-
-          If you are seeing this message, you dispatched from main
-          before the feature branch was merged. Nothing has been
-          published; this stub does not push anything.
           EOF
           exit 1


### PR DESCRIPTION
## Summary

Bootstrap PR that adds stub versions of `.github/workflows/release-publish.yml` and `.github/workflows/gems-publish.yml` to main, to allow testing of automated release process.
