### PR TITLE
fix(worker): deliver fiber activity cancellation via scheduler fiber_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ to docs, or any other relevant information.
 
 - `Temporalio::Client::WorkflowHandle#result` no longer returns `nil` while a workflow is still
   running when a history long poll expires without returning an event.
+- Canceling a fiber-executor activity no longer wedges the worker. Cancellation was delivered with
+  `Fiber#raise` from the worker's task-dispatch fiber, which under a scheduler that resumes fibers
+  with `Fiber#transfer` (such as `async`) never returns, permanently stopping the worker from
+  dispatching any further activity tasks or workflow activations. The exception is now delivered
+  through the scheduler's `fiber_interrupt` hook when it provides one.
 
 ## [v1.6.0] - 2026-07-16
 

--- a/temporalio/lib/temporalio/worker/activity_executor/fiber.rb
+++ b/temporalio/lib/temporalio/worker/activity_executor/fiber.rb
@@ -39,20 +39,17 @@ module Temporalio
           return unless defn.cancel_raise
 
           fiber = ::Fiber.current
-          # Cancel callbacks run on the canceler's fiber, which for activity cancellation is the
-          # worker's single task-dispatch fiber. Fiber#raise uses resume semantics, so under a
-          # scheduler that drives fibers with Fiber#transfer (e.g. async) the target never returns
-          # to its resumer and the dispatch fiber is suspended forever, wedging the whole worker.
-          # Schedulers expose fiber_interrupt (Ruby 3.3+) to perform the raise themselves, which
-          # returns to the caller immediately.
           scheduler = ::Fiber.scheduler
           scheduler = nil unless scheduler.respond_to?(:fiber_interrupt)
           context&.cancellation&.add_cancel_callback do
             error = Error::CanceledError.new('Activity canceled')
-            if scheduler
-              scheduler.fiber_interrupt(fiber, error)
-            else
+            # Directly raising from another fiber can strand a `Fiber#transfer`
+            # based scheduler's current fiber, so we defer to the scheduler to interrupt.
+            # If on the same fiber, we can just raise directly.
+            if scheduler.nil? || ::Fiber.current.equal?(fiber)
               fiber.raise(error)
+            else
+              scheduler.fiber_interrupt(fiber, error)
             end
           end
         end

--- a/temporalio/lib/temporalio/worker/activity_executor/fiber.rb
+++ b/temporalio/lib/temporalio/worker/activity_executor/fiber.rb
@@ -39,8 +39,21 @@ module Temporalio
           return unless defn.cancel_raise
 
           fiber = ::Fiber.current
+          # Cancel callbacks run on the canceler's fiber, which for activity cancellation is the
+          # worker's single task-dispatch fiber. Fiber#raise uses resume semantics, so under a
+          # scheduler that drives fibers with Fiber#transfer (e.g. async) the target never returns
+          # to its resumer and the dispatch fiber is suspended forever, wedging the whole worker.
+          # Schedulers expose fiber_interrupt (Ruby 3.3+) to perform the raise themselves, which
+          # returns to the caller immediately.
+          scheduler = ::Fiber.scheduler
+          scheduler = nil unless scheduler.respond_to?(:fiber_interrupt)
           context&.cancellation&.add_cancel_callback do
-            fiber.raise(Error::CanceledError.new('Activity canceled'))
+            error = Error::CanceledError.new('Activity canceled')
+            if scheduler
+              scheduler.fiber_interrupt(fiber, error)
+            else
+              fiber.raise(error)
+            end
           end
         end
       end

--- a/temporalio/test/worker_activity_test.rb
+++ b/temporalio/test/worker_activity_test.rb
@@ -520,6 +520,57 @@ class WorkerActivityTest < Test
     end
   end
 
+  class FiberCancellationActivity < Temporalio::Activity::Definition
+    activity_executor :fiber
+
+    attr_reader :canceled
+
+    def initialize
+      @started = Queue.new
+      @canceled = false
+    end
+
+    def execute
+      @started.push(nil)
+      # Heartbeat every 50ms waiting for cancel
+      loop do
+        sleep(0.05)
+        Temporalio::Activity::Context.current.heartbeat
+      end
+    rescue Temporalio::Error::CanceledError
+      @canceled = true
+      raise
+    end
+
+    def wait_started
+      @started.pop
+    end
+  end
+
+  def test_fiber_cancellation
+    skip_if_fibers_not_supported!
+    # Tests are doubly executed in threaded and fiber, so we start a new Async block just in case
+    Async do
+      act = FiberCancellationActivity.new
+      execute_activity(
+        act,
+        cancel_on_signal: 'cancel-activity',
+        wait_for_cancellation: true,
+        heartbeat_timeout: 0.8
+      ) do |handle|
+        # Wait for it to start
+        act.wait_started
+        # Send activity cancel
+        handle.signal('cancel-activity')
+        # The workflow can only reach a terminal state if the worker's task-dispatch fiber
+        # survived delivering the cancellation to the activity fiber
+        error = assert_raises(Temporalio::Error::WorkflowFailedError) { handle.result }
+        assert_kind_of Temporalio::Error::CanceledError, error.cause
+        assert act.canceled
+      end
+    end
+  end
+
   class WorkerShutdownActivity < Temporalio::Activity::Definition
     attr_reader :canceled
 

--- a/temporalio/test/worker_activity_test.rb
+++ b/temporalio/test/worker_activity_test.rb
@@ -475,6 +475,35 @@ class WorkerActivityTest < Test
     end
   end
 
+  class FiberShieldingActivity < ShieldingActivity
+    activity_executor :fiber # steep:ignore
+  end
+
+  def test_activity_shielding_fiber
+    skip_if_fibers_not_supported!
+
+    Async do
+      act = FiberShieldingActivity.new
+      execute_activity(
+        act,
+        cancel_on_signal: 'cancel-activity',
+        wait_for_cancellation: true,
+        heartbeat_timeout: 0.8
+      ) do |handle|
+        # Wait for it to be waiting
+        act.wait_until_waiting
+        # Send activity cancel
+        handle.signal('cancel-activity')
+        # Wait for completion
+        error = assert_raises(Temporalio::Error::WorkflowFailedError) { handle.result }
+        assert_kind_of Temporalio::Error::CanceledError, error.cause
+        # Confirm thrown in activity but the proper levels reached
+        assert act.canceled
+        assert_equal 2, act.levels_reached
+      end
+    end
+  end
+
   class NoRaiseCancellationActivity < Temporalio::Activity::Definition
     activity_cancel_raise false
     attr_reader :canceled


### PR DESCRIPTION
…interrupt

Cancel callbacks run on the canceler's fiber, which for activity cancellation is the worker's single task-dispatch fiber. `Fiber#raise` uses resume semantics, so under a scheduler that drives fibers with `Fiber#transfer` (such as `async`) the target fiber never returns to its resumer and the dispatch fiber is suspended forever. The worker then stops dispatching all work -- activity tasks and workflow activations alike -- while the process and the reactor stay healthy.

Deliver the exception through `Fiber::Scheduler#fiber_interrupt` (Ruby 3.3+) when the scheduler provides one, so the raise is performed by the scheduler itself and the caller returns immediately. Schedulers without the hook keep the existing `Fiber#raise` behavior.

Fixes #518

## What was changed
Moves from raising on a fiber to using the scheduler interrupt for CanceledErrors.

## Why?
Prevents FIber based workers from stalling.

## Checklist
1. Closes #518

2. Tested against the reproduction harness on #518 and confirmed that activities proceed as expected

3. **WARNING**: Due to the nature of the bug, the new test case just hangs the entire test suite on the unpatched code - I didn't see an easy way to have it just go red quickly. On the patched code it runs as expected.
