### PR TITLE
feat: add FailureConverter hook for attribute encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Added `FailureConverter` `process_common_attributes:` to customize the value sent to the payload converter when
+  encoding common failure attributes.
+
 - Added the `Temporalio::Worker` `max_eager_activity_reservations_per_workflow_task:` option to
   configure the number of activity slots reserved for eager execution per workflow task. Values
   must be positive; use `disable_eager_activity_execution: true` to disable eager execution.

--- a/temporalio/lib/temporalio/converters/failure_converter.rb
+++ b/temporalio/lib/temporalio/converters/failure_converter.rb
@@ -21,8 +21,11 @@ module Temporalio
       #
       # @param encode_common_attributes [Boolean] If +true+, the message and stack trace of the failure will be moved
       #   into the encoded attribute section of the failure which can be encoded with a codec.
-      def initialize(encode_common_attributes: false)
+      # @param process_common_attributes [Proc, nil] If present, called with the message and stack trace of failure
+      #   before they are converted to a payload.
+      def initialize(encode_common_attributes: false, process_common_attributes: nil)
         @encode_common_attributes = encode_common_attributes
+        @process_common_attributes = process_common_attributes
       end
 
       # Convert a Ruby error to a Temporal failure.
@@ -104,9 +107,9 @@ module Temporalio
 
         # If encoding common attributes, move message and stack trace
         if @encode_common_attributes
-          failure.encoded_attributes = converter.to_payload(
-            { message: failure.message, stack_trace: failure.stack_trace }
-          )
+          common_attributes = { message: failure.message, stack_trace: failure.stack_trace }
+          common_attributes = @process_common_attributes.call(common_attributes) if @process_common_attributes
+          failure.encoded_attributes = converter.to_payload(common_attributes)
           failure.message = 'Encoded failure'
           failure.stack_trace = ''
         end

--- a/temporalio/rbi/temporalio/converters/failure_converter.rbi
+++ b/temporalio/rbi/temporalio/converters/failure_converter.rbi
@@ -6,8 +6,13 @@ class Temporalio::Converters::FailureConverter
   sig { returns(Temporalio::Converters::FailureConverter) }
   def self.default; end
 
-  sig { params(encode_common_attributes: T::Boolean).void }
-  def initialize(encode_common_attributes: T.unsafe(nil)); end
+  sig do
+    params(
+      encode_common_attributes: T::Boolean,
+      process_common_attributes: T.nilable(T.proc.params(arg0: T::Hash[Symbol, T.nilable(String)]).returns(Object))
+    ).void
+  end
+  def initialize(encode_common_attributes: T.unsafe(nil), process_common_attributes: T.unsafe(nil)); end
 
   sig { returns(T::Boolean) }
   attr_reader :encode_common_attributes

--- a/temporalio/sig/temporalio/converters/failure_converter.rbs
+++ b/temporalio/sig/temporalio/converters/failure_converter.rbs
@@ -3,7 +3,10 @@ module Temporalio
     class FailureConverter
       def self.default: -> FailureConverter
 
-      def initialize: (?encode_common_attributes: bool) -> void
+      def initialize: (
+        ?encode_common_attributes: bool,
+        ?process_common_attributes: ^(Hash[Symbol, String?]) -> untyped
+      ) -> void
 
       def to_failure: (Exception error, DataConverter | PayloadConverter converter) -> Api::Failure::V1::Failure
       def from_failure: (Api::Failure::V1::Failure failure, DataConverter | PayloadConverter converter) -> Exception

--- a/temporalio/test/converters/failure_converter_test.rb
+++ b/temporalio/test/converters/failure_converter_test.rb
@@ -9,6 +9,33 @@ module Converters
   class FailureConverterTest < Test
     class CustomError < StandardError; end
 
+    class FailureAttributesWrapper
+      attr_reader :attributes
+
+      def initialize(attributes)
+        @attributes = attributes
+      end
+    end
+
+    class FailureAttributesPayloadConverter < Temporalio::Converters::PayloadConverter
+      attr_reader :values
+
+      def initialize
+        @values = []
+      end
+
+      def to_payload(value, hint: nil)
+        raise 'Expected wrapped failure attributes' unless value.is_a?(FailureAttributesWrapper)
+
+        @values << value
+        Temporalio::Api::Common::V1::Payload.new
+      end
+
+      def from_payload(payload, hint: nil)
+        raise NotImplementedError
+      end
+    end
+
     def test_failure_with_causes
       # Make multiple nested errors
       orig_err = assert_raises do
@@ -87,6 +114,34 @@ module Converters
       assert_equal orig_err.cause.cause.cause.backtrace, new_err.cause.cause.cause.backtrace
       assert_equal 'Custom error class', new_err.cause.cause.cause.message
       assert_equal 'CustomError', new_err.cause.cause.cause.type
+    end
+
+    def test_process_common_attributes_before_payload_conversion
+      received_attributes = nil
+      payload_converter = FailureAttributesPayloadConverter.new
+      converter = Temporalio::Converters::DataConverter.new(
+        payload_converter:,
+        failure_converter: Temporalio::Converters::FailureConverter.new(
+          encode_common_attributes: true,
+          process_common_attributes: lambda { |attributes|
+            received_attributes = attributes
+            FailureAttributesWrapper.new(attributes)
+          }
+        )
+      )
+
+      error = StandardError.new('failure message')
+      error.set_backtrace(['first.rb:1', 'second.rb:2'])
+      failure = converter.to_failure(error)
+
+      assert_equal(
+        { message: 'failure message', stack_trace: "first.rb:1\nsecond.rb:2" },
+        received_attributes
+      )
+      assert_equal 1, payload_converter.values.length
+      assert_equal received_attributes, payload_converter.values.first.attributes
+      assert_equal 'Encoded failure', failure.message
+      assert_empty failure.stack_trace
     end
 
     # TODO(cretz): Test with encoded

--- a/temporalio/test/converters/failure_converter_test.rb
+++ b/temporalio/test/converters/failure_converter_test.rb
@@ -21,10 +21,11 @@ module Converters
       attr_reader :values
 
       def initialize
+        super
         @values = []
       end
 
-      def to_payload(value, hint: nil)
+      def to_payload(value, **_kwargs)
         raise 'Expected wrapped failure attributes' unless value.is_a?(FailureAttributesWrapper)
 
         @values << value


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add `process_common_attributes` as a keyword param for `FailureConverter` that allows customization of the failure attributes before they get passed to the failure converter.

## Why?
See #520 for details on why this is helpful.

## Checklist
<!--- add/delete as needed --->

1. Closes #520 

2. How was this tested:
Small unit test to verify the hook is used.

3. Any docs updates needed?
N/A