### PR TITLE
fix(client): eagerly consume workflow history when getting workflow result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- `Temporalio::Client::WorkflowHandle#result` now preserves fiber-local `Thread.current[]` context
+  while fetching workflow history, allowing gRPC interceptors to apply request-scoped RPC options.
 - `Temporalio::Client::WorkflowHandle#result` no longer returns `nil` while a workflow is still
   running when a history long poll expires without returning an event.
 

--- a/temporalio/lib/temporalio/client/workflow_handle.rb
+++ b/temporalio/lib/temporalio/client/workflow_handle.rb
@@ -86,19 +86,14 @@ module Temporalio
         hist_run_id = result_run_id
         loop do
           # Get close event
-          event = begin
-            fetch_history_events(
-              wait_new_event: true,
-              event_filter_type: Api::Enums::V1::HistoryEventFilterType::HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
-              skip_archival: true,
-              specific_run_id: hist_run_id,
-              rpc_options:
-            ).next
-          rescue StopIteration
-            # Timeskipping server can return empty events with no continuation token, this will surface as an empty
-            # iterator.
-            next
-          end
+          event = fetch_history_events(
+            wait_new_event: true,
+            event_filter_type: Api::Enums::V1::HistoryEventFilterType::HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
+            skip_archival: true,
+            specific_run_id: hist_run_id,
+            rpc_options:
+          ).find { true }
+          next unless event
 
           # Check each close type'
           case event.event_type

--- a/temporalio/test/client_workflow_test.rb
+++ b/temporalio/test/client_workflow_test.rb
@@ -26,6 +26,35 @@ class ClientWorkflowTest < Test
     end
   end
 
+  def test_result_preserves_fiber_local_context_for_history_rpc
+    context_key = :temporalio_test_result_context
+    context = :my_context
+    contexts = []
+    workflow_service = env.client.workflow_service
+    original_fetch = workflow_service.method(:get_workflow_execution_history)
+    workflow_service.define_singleton_method(:get_workflow_execution_history) do |request, **kwargs|
+      contexts << Thread.current[context_key]
+      original_fetch.call(request, **kwargs)
+    end
+    previous_context = Thread.current[context_key]
+    Thread.current[context_key] = context
+
+    env.with_kitchen_sink_worker do |task_queue|
+      handle = env.client.start_workflow(
+        'kitchen_sink',
+        { actions: [{ result: { value: 'done' } }] },
+        id: "wf-#{SecureRandom.uuid}",
+        task_queue:
+      )
+      assert_equal 'done', handle.result
+    end
+
+    assert_equal [context], contexts
+  ensure
+    workflow_service.singleton_class.send(:remove_method, :get_workflow_execution_history) if workflow_service
+    Thread.current[context_key] = previous_context
+  end
+
   def test_workflow_exists
     env.with_kitchen_sink_worker do |task_queue|
       # Create a workflow that hangs


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Use internal iteration in `WorkflowHandle#result`

## Why?
All other client operations allow caller to dictate if iteration is [external/internal](https://docs.ruby-lang.org/en/master/Enumerator.html#class-enumerator-external-iteration-and-fiber).

The use of external iteration here is confusing and can lead to thread locals being unexpectedly absent. 

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added regression test that displayed faulty behavior.

3. Any docs updates needed?
N/A
