### PR TITLE
Add missing require for payload_codec in data_converter

### DIFF
--- a/temporalio/lib/temporalio/converters/data_converter.rb
+++ b/temporalio/lib/temporalio/converters/data_converter.rb
@@ -2,6 +2,7 @@
 
 require 'temporalio/api'
 require 'temporalio/converters/failure_converter'
+require 'temporalio/converters/payload_codec'
 require 'temporalio/converters/payload_converter'
 
 module Temporalio


### PR DESCRIPTION
## Summary

- Add `require 'temporalio/converters/payload_codec'` to `data_converter.rb`
- `DataConverter` accepts a `payload_codec:` parameter but the `PayloadCodec` class was not required, so users doing `require 'temporalio/converters'` would get `DataConverter` without `PayloadCodec` being loaded

## Test plan

- [ ] `require 'temporalio/converters'` now loads `PayloadCodec` alongside `PayloadConverter` and `FailureConverter`
- [ ] No circular dependency introduced (payload_codec.rb has no requires that depend on data_converter.rb)

Fixes #333