### PR TITLE
Warn on unawaited workflow futures with failures

### DIFF
--- a/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance.rb
@@ -90,6 +90,7 @@ module Temporalio
           @buffered_signals = {} # Keyed by signal name, value is array of signal jobs
           # TODO(cretz): Should these be sets instead? Both should be fairly low counts.
           @in_progress_handlers = [] # Value is HandlerExecution
+          @futures_with_failures = [] # Value is Workflow::Future
           @patches_notified = []
           @definition = details.definition
           @interceptors = details.interceptors
@@ -226,6 +227,7 @@ module Temporalio
             !c.cancel_workflow_execution.nil?
           end
             warn_on_any_unfinished_handlers
+            warn_on_any_unawaited_failed_futures
           end
 
           # Return success or failure
@@ -814,6 +816,23 @@ module Temporalio
           return @scoped_logger_info unless update_info
 
           @scoped_logger_info.merge({ update_id: update_info.id, update_name: update_info.name })
+        end
+
+        def track_future_with_failure(future)
+          @futures_with_failures << future
+        end
+
+        def warn_on_any_unawaited_failed_futures
+          unawaited = @futures_with_failures.reject(&:awaited?)
+          return if unawaited.empty?
+
+          failures_str = JSON.generate(unawaited.map { |f| { type: f.failure.class.name, message: f.failure.message } })
+          warn(
+            "[TMPRL1103] Workflow #{info.workflow_id} finished with #{unawaited.size} unawaited failed " \
+            "future(s). These failures were silently swallowed because the future was never awaited with `wait` " \
+            "or `wait_no_raise`. This is usually a bug — if the failure is expected, await the future and handle " \
+            "the error. Unawaited failures: #{failures_str}"
+          )
         end
 
         def warn_on_any_unfinished_handlers

--- a/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
+++ b/temporalio/lib/temporalio/internal/worker/workflow_instance/context.rb
@@ -59,6 +59,10 @@ module Temporalio
             @instance.current_deployment_version
           end
 
+          def track_future_with_failure(future)
+            @instance.track_future_with_failure(future)
+          end
+
           def current_history_length
             @instance.current_history_length
           end

--- a/temporalio/lib/temporalio/workflow/future.rb
+++ b/temporalio/lib/temporalio/workflow/future.rb
@@ -76,6 +76,7 @@ module Temporalio
         @done = false
         @result = nil
         @failure = nil
+        @awaited = false
         @block_given = block_given?
         return unless block_given?
 
@@ -89,6 +90,7 @@ module Temporalio
           @failure = e
         ensure
           @done = true
+          Workflow._current_or_nil&.track_future_with_failure(self) if @failure
         end
       end
 
@@ -132,12 +134,18 @@ module Temporalio
         @done = true
       end
 
+      # @return [Boolean] True if the future's result or failure has been observed via {wait} or {wait_no_raise}.
+      def awaited?
+        @awaited
+      end
+
       # Wait on the future to complete. This will return the success or raise the failure. To not raise, use
       # {wait_no_raise}.
       #
       # @return [Object] Result on success.
       # @raise [Exception] Failure if occurred.
       def wait
+        @awaited = true
         Workflow.wait_condition(cancellation: nil) { done? }
         Kernel.raise failure if failure? # steep:ignore
 
@@ -148,6 +156,7 @@ module Temporalio
       #
       # @return [Object, nil] Result on success or nil on failure.
       def wait_no_raise
+        @awaited = true
         Workflow.wait_condition(cancellation: nil) { done? }
         result
       end


### PR DESCRIPTION
## Summary

- Add warning when a workflow completes with futures that failed but were never awaited
- Follows the same pattern as the existing "warn on unfinished handlers" feature ([TMPRL1102])
- New warning code: **[TMPRL1103]**

### Changes

- **`Future`**: Add `@awaited` flag, set to `true` when `wait` or `wait_no_raise` is called. On block completion with a failure, register the future with the current workflow instance.
- **`WorkflowInstance`**: Track futures with failures in `@futures_with_failures`. At workflow completion (alongside `warn_on_any_unfinished_handlers`), check for unawaited failed futures and emit a `[TMPRL1103]` warning listing the failure types and messages.
- **`Context`**: Delegate `track_future_with_failure` to the instance.

### Example warning

```
[TMPRL1103] Workflow my-workflow finished with 2 unawaited failed future(s). These failures were silently swallowed because the future was never awaited with `wait` or `wait_no_raise`. This is usually a bug — if the failure is expected, await the future and handle the error. Unawaited failures: [{"type":"Temporalio::Error::ActivityError","message":"activity failed"}]
```

## Test plan

- [ ] Create a workflow that spawns a future that fails, doesn't await it, and completes — verify [TMPRL1103] warning
- [ ] Create a workflow that spawns a future that fails, awaits it with `wait_no_raise` — verify no warning
- [ ] Verify the warning only fires on non-replaying workflow completions (same gate as [TMPRL1102])

Fixes #185