### PR TITLE
Expose Core console log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Added `Temporalio::Runtime::LoggingOptions#log_format` to select compact, pretty, or
+  newline-delimited JSON output for Core logs written to the console.
 - Added `FailureConverter` `process_common_attributes:` to customize the value sent to the payload converter when
   encoding common failure attributes.
 

--- a/temporalio/Cargo.lock
+++ b/temporalio/Cargo.lock
@@ -4217,6 +4217,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4227,10 +4237,13 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/temporalio/ext/src/runtime.rs
+++ b/temporalio/ext/src/runtime.rs
@@ -15,8 +15,8 @@ use temporalio_common::protos::temporal::api::worker::v1::environment_info::{
 };
 use temporalio_common::telemetry::metrics::core::MetricCallBufferer;
 use temporalio_common::telemetry::{
-    HistogramBucketOverrides, Logger, MetricTemporality, OtelCollectorOptions, OtlpProtocol,
-    PrometheusExporterOptions, TelemetryOptions, build_otlp_metric_exporter,
+    HistogramBucketOverrides, Logger, LoggerFormat, MetricTemporality, OtelCollectorOptions,
+    OtlpProtocol, PrometheusExporterOptions, TelemetryOptions, build_otlp_metric_exporter,
     start_prometheus_metric_exporter,
 };
 use temporalio_sdk_core::telemetry::MetricsCallBuffer;
@@ -94,6 +94,15 @@ impl Runtime {
                 } else {
                     Some(Logger::Console {
                         filter: logging.member(id!("log_filter"))?,
+                        format: logging
+                            .member::<Option<String>>(id!("log_format"))?
+                            .map(|format| match format.as_str() {
+                                "compact" => Ok(LoggerFormat::Compact),
+                                "pretty" => Ok(LoggerFormat::Pretty),
+                                "json" => Ok(LoggerFormat::Json),
+                                _ => Err(error!("Unrecognized console log format")),
+                            })
+                            .transpose()?,
                     })
                 }
             }

--- a/temporalio/lib/temporalio/internal/bridge/runtime.rb
+++ b/temporalio/lib/temporalio/internal/bridge/runtime.rb
@@ -18,6 +18,7 @@ module Temporalio
 
         LoggingOptions = Struct.new(
           :log_filter,
+          :log_format,
           :forward_to # Optional
         )
 

--- a/temporalio/lib/temporalio/runtime.rb
+++ b/temporalio/lib/temporalio/runtime.rb
@@ -46,20 +46,32 @@ module Temporalio
     end
 
     LoggingOptions = Data.define(
-      :log_filter
+      :log_filter,
+      :log_format
       # TODO(cretz): forward_to
     )
+
+    # Formats for Core logs written to the console.
+    module ConsoleLogFormat
+      COMPACT = :compact
+      PRETTY = :pretty
+      JSON = :json
+    end
 
     # Logging options for runtime telemetry.
     #
     # @!attribute log_filter
     #   @return [LoggingFilterOptions, String] Logging filter for Core, default is new {LoggingFilterOptions} with no
     #     parameters.
+    # @!attribute log_format
+    #   @return [ConsoleLogFormat, nil] Format for Core logs written to the console. If unset, Core preserves its
+    #     existing output selection, including `TEMPORAL_CORE_PRETTY_LOGS` support.
     class LoggingOptions
       # Create logging options
       #
       # @param log_filter [LoggingFilterOptions, String] Logging filter for Core.
-      def initialize(log_filter: LoggingFilterOptions.new)
+      # @param log_format [ConsoleLogFormat, nil] Format for Core logs written to the console.
+      def initialize(log_filter: LoggingFilterOptions.new, log_format: nil)
         super
       end
 
@@ -73,7 +85,8 @@ module Temporalio
                         log_filter._to_bridge
                       else
                         raise 'Log filter must be string or LoggingFilterOptions'
-                      end
+                      end,
+          log_format: log_format&.to_s
         )
       end
     end

--- a/temporalio/lib/temporalio/runtime.rb
+++ b/temporalio/lib/temporalio/runtime.rb
@@ -64,8 +64,8 @@ module Temporalio
     #   @return [LoggingFilterOptions, String] Logging filter for Core, default is new {LoggingFilterOptions} with no
     #     parameters.
     # @!attribute log_format
-    #   @return [ConsoleLogFormat, nil] Format for Core logs written to the console. If unset, Core preserves its
-    #     existing output selection, including `TEMPORAL_CORE_PRETTY_LOGS` support.
+    #   @return [ConsoleLogFormat, nil] Format for Core logs written to the console. If unset, this defaults to compact
+    #     output.
     class LoggingOptions
       # Create logging options
       #

--- a/temporalio/rbi/temporalio/internal/bridge/runtime.rbi
+++ b/temporalio/rbi/temporalio/internal/bridge/runtime.rbi
@@ -78,14 +78,20 @@ end
 class Temporalio::Internal::Bridge::Runtime::LoggingOptions < ::Struct
   extend T::Sig
 
-  sig { params(log_filter: T.nilable(String)).void }
-  def initialize(log_filter); end
+  sig { params(log_filter: T.nilable(String), log_format: T.nilable(String)).void }
+  def initialize(log_filter, log_format); end
 
   sig { returns(T.nilable(String)) }
   def log_filter; end
 
   sig { params(_: T.nilable(String)).void }
   def log_filter=(_); end
+
+  sig { returns(T.nilable(String)) }
+  def log_format; end
+
+  sig { params(_: T.nilable(String)).void }
+  def log_format=(_); end
 end
 
 class Temporalio::Internal::Bridge::Runtime::MetricsOptions < ::Struct

--- a/temporalio/rbi/temporalio/runtime.rbi
+++ b/temporalio/rbi/temporalio/runtime.rbi
@@ -39,8 +39,17 @@ class Temporalio::Runtime::LoggingOptions < ::Data
   sig { returns(T.any(Temporalio::Runtime::LoggingFilterOptions, String)) }
   def log_filter; end
 
-  sig { params(log_filter: T.any(Temporalio::Runtime::LoggingFilterOptions, String)).void }
-  def initialize(log_filter: T.unsafe(nil)); end
+  sig { returns(T.nilable(Symbol)) }
+  def log_format; end
+
+  sig { params(log_filter: T.any(Temporalio::Runtime::LoggingFilterOptions, String), log_format: T.nilable(Symbol)).void }
+  def initialize(log_filter: T.unsafe(nil), log_format: T.unsafe(nil)); end
+end
+
+module Temporalio::Runtime::ConsoleLogFormat
+  COMPACT = T.let(T.unsafe(nil), Symbol)
+  JSON = T.let(T.unsafe(nil), Symbol)
+  PRETTY = T.let(T.unsafe(nil), Symbol)
 end
 
 class Temporalio::Runtime::LoggingFilterOptions < ::Data

--- a/temporalio/sig/temporalio/internal/bridge/runtime.rbs
+++ b/temporalio/sig/temporalio/internal/bridge/runtime.rbs
@@ -28,9 +28,11 @@ module Temporalio
     
         class LoggingOptions
           attr_accessor log_filter: String?
+          attr_accessor log_format: String?
     
           def initialize: (
-            log_filter: String?
+            log_filter: String?,
+            log_format: String?
           ) -> void
         end
     

--- a/temporalio/sig/temporalio/runtime.rbs
+++ b/temporalio/sig/temporalio/runtime.rbs
@@ -14,12 +14,22 @@ module Temporalio
 
     class LoggingOptions
       attr_reader log_filter: LoggingFilterOptions | String
+      attr_reader log_format: ConsoleLogFormat::enum?
 
       def initialize: (
-        ?log_filter: LoggingFilterOptions | String
+        ?log_filter: LoggingFilterOptions | String,
+        ?log_format: ConsoleLogFormat::enum?
       ) -> void
 
       def _to_bridge: -> Internal::Bridge::Runtime::LoggingOptions
+    end
+
+    module ConsoleLogFormat
+      COMPACT: :compact
+      PRETTY: :pretty
+      JSON: :json
+
+      type enum = :compact | :pretty | :json
     end
 
     type logging_filter_level = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'

--- a/temporalio/test/runtime_test.rb
+++ b/temporalio/test/runtime_test.rb
@@ -149,6 +149,21 @@ class RuntimeTest < Test
     assert_equal RUBY_VERSION, captured&.runtime_version
   end
 
+  def test_runtime_console_log_format
+    captured = capture_bridge_runtime_options do
+      Temporalio::Runtime.new(
+        telemetry: Temporalio::Runtime::TelemetryOptions.new(
+          logging: Temporalio::Runtime::LoggingOptions.new(
+            log_format: Temporalio::Runtime::ConsoleLogFormat::JSON
+          )
+        )
+      )
+    end
+    logging = captured&.telemetry&.logging
+    refute_nil logging
+    assert_equal 'json', logging&.log_format
+  end
+
   # Capture the Options struct that Runtime#initialize passes to Internal::Bridge::Runtime.new
   # without actually spinning up a native runtime. Shims out the two bridge calls Runtime#initialize
   # makes on the returned object: run_command_loop (from a background thread) and the metric-meter


### PR DESCRIPTION
## What was changed

Added `LoggingOptions#log_format` and `ConsoleLogFormat` values so applications can select compact, pretty, or newline-delimited JSON output for Core logs written to the console. The option is represented in RBS/RBI and passed through the native bridge to Core.

## Why?

Applications that ingest logs as structured data need Core to emit JSON directly instead of human-oriented text with ANSI formatting.

## Checklist

1. Closes https://github.com/temporalio/sdk-ruby/issues/523
2. How was this tested:
   - `bundle exec rake rubocop yard steep`
   - `bundle exec rake compile`
   - `bundle exec rake rust_lint`
   - `TEMPORAL_SORBET_RUNTIME_CHECK=1 bundle exec rake test TESTOPTS="--name=test_runtime_console_log_format"`
3. Any docs updates needed? YARD documentation, RBS/RBI signatures, and the changelog are updated.
