### PR TITLE
chore(release): wait for release on smoke test runners

### DIFF
--- a/.github/actions/release-smoke-package/action.yml
+++ b/.github/actions/release-smoke-package/action.yml
@@ -21,6 +21,30 @@ runs:
         bundler-cache: false
         cargo-cache: false
 
+    # Rubygems visibility can differ by runner, so each smoke-test runner waits itself.
+    - name: Wait for version in compact-index
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        deadline=$(( $(date +%s) + 1500 )) # 25 minutes
+        version_re="^${VERSION//./\\.}[ -]"
+        url="https://index.rubygems.org/info/temporalio"
+        while true; do
+          body=$(curl -fsSL "$url" 2>/dev/null || true)
+          if echo "$body" | grep -qE "$version_re"; then
+            echo "temporalio $VERSION visible in compact-index"
+            exit 0
+          fi
+          if [[ $(date +%s) -ge $deadline ]]; then
+            echo "Timed out waiting for temporalio $VERSION in compact-index" >&2
+            exit 1
+          fi
+          echo "Not yet in compact-index; sleeping 15s..."
+          sleep 15
+        done
+
     - name: Install gem and run workflow smoke test
       shell: bash
       env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,8 +6,6 @@ run-name: Release from ${{ github.ref_name }}
 #   verify          → validate version/changelog, assemble release-dist artifact
 #   publish         → push to rubygems.org (gated by the `rubygems` GitHub
 #                     Environment: required reviewer clicks Approve here)
-#   wait            → poll rubygems compact-index until the new version is
-#                     visible to `gem install`
 #   smoke_published → install from rubygems.org and run a workflow
 #   create_draft    → open a draft GitHub Release with the changelog notes
 
@@ -123,44 +121,11 @@ jobs:
       artifact-name: ${{ needs.verify.outputs.artifact_name }}
       host: https://rubygems.org
 
-  wait:
-    needs:
-      - verify
-      - publish
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    steps:
-      # Wait for gems to appear on rubygems. Uses the same endpoint that
-      # gem install does, to avoid caching inconsistencies.
-      - name: Wait for version in compact-index
-        env:
-          VERSION: ${{ needs.verify.outputs.version }}
-        run: |
-          set -euo pipefail
-          deadline=$(( $(date +%s) + 1500 )) # 25 minutes
-          version_re="^${VERSION//./\\.}[ -]"
-          url="https://index.rubygems.org/info/temporalio"
-          while true; do
-            body=$(curl -fsSL "$url" 2>/dev/null || true)
-            if echo "$body" | grep -qE "$version_re"; then
-              echo "temporalio $VERSION visible in compact-index"
-              exit 0
-            fi
-            if [[ $(date +%s) -ge $deadline ]]; then
-              echo "Timed out waiting for temporalio $VERSION in compact-index" >&2
-              exit 1
-            fi
-            echo "Not yet in compact-index; sleeping 15s..."
-            sleep 15
-          done
-
   smoke_published:
     name: Smoke test rubygems.org package
     needs:
       - verify
-      - wait
+      - publish
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Move the waiting on the gem to be visible to the actual runners that will fetch the package

## Why?
Can't rely on one GH runner seeing the gem meaning all GH runners will see the gem.

Hit this in the 1.7.0 release and needed to manually keep retrying one job until it landed on a runner that could see the gem.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
👀 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
