### PR TITLE
make log messages respond to #to_s with the message string

### DIFF
--- a/temporalio/lib/temporalio/scoped_logger.rb
+++ b/temporalio/lib/temporalio/scoped_logger.rb
@@ -106,6 +106,9 @@ module Temporalio
         message_str = message.is_a?(String) ? message : message.inspect
         "#{message_str} #{scoped_values}"
       end
+
+      # @return [String] The log message.
+      alias to_s message
     end
   end
 end


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

log messages will now respond to `#to_s` by returning the string message.

## Why?

most loggers rely on the #to_s variant of this object. That includes semantic-logger, for which we're carrying a monkeypatch like this to make ends meet.

I didn't add any tests, as there's nothing around the log message being specced, and this seems low-level enough to skip, but say the word and I'll add.