### PR TITLE
Document root workflow namespace omission

### DIFF
--- a/temporalio/lib/temporalio/workflow/info.rb
+++ b/temporalio/lib/temporalio/workflow/info.rb
@@ -57,7 +57,8 @@ module Temporalio
     #   @return [RetryPolicy, nil] Retry policy for the workflow.
     # @!attribute root
     #   @return [RootInfo, nil] Root information for the workflow. This is nil in pre-1.27.0 server versions or if there
-    #     is no root (i.e. the root is itself).
+    #     is no root (i.e. the root is itself). Its namespace is not retained and may differ from this workflow's
+    #     namespace for cross-namespace child workflows. Track it separately if needed.
     # @!attribute run_id
     #   @return [String] Run ID for the workflow.
     # @!attribute run_timeout
@@ -93,7 +94,8 @@ module Temporalio
         :workflow_id
       )
 
-      # Information about a root of a workflow.
+      # Information about a root of a workflow. Its namespace is not retained and may differ from the current
+      # workflow's namespace for cross-namespace child workflows. Track it separately if needed.
       #
       # @!attribute run_id
       #   @return [String] Run ID for the root.


### PR DESCRIPTION
## What was changed
Document that root workflow execution information omits its namespace. The root namespace may differ for cross-namespace child workflows and must be tracked separately.

## Why?
Completes the documentation requirement from temporalio/features#605.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes to YARD docs with no code or API behavior impact.
> 
> **Overview**
> **Documentation-only** update to `Workflow::Info#root` and `Workflow::Info::RootInfo` in the Ruby SDK.
> 
> The docs now state that **root execution info does not include a namespace**, and that the root’s namespace can differ from the current workflow’s when using **cross-namespace child workflows**. Callers who need the root namespace must **track it separately** (unlike `ParentInfo`, which still documents a `namespace` field).
> 
> This aligns with temporalio/features#605; runtime behavior and types are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e21a6199ee821ecac80db36f3ab7c5e6bd2f45fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->