### PR TITLE
Add `skip-changelog` label to release PR

### DIFF
--- a/temporalio/extra/release/scripts/prepare_release.rb
+++ b/temporalio/extra/release/scripts/prepare_release.rb
@@ -217,7 +217,7 @@ module PrepareRelease
        '--head', branch_name(version),
        '--title', "Prepare release #{version}",
        '--body', "Prepare release #{version}.",
-       '--label', 'skip-changelog'],  # Make CI allow the changes
+       '--label', 'skip-changelog'], # Make CI allow the changes
       cwd: cwd
     )
   end

--- a/temporalio/extra/release/scripts/prepare_release.rb
+++ b/temporalio/extra/release/scripts/prepare_release.rb
@@ -216,7 +216,8 @@ module PrepareRelease
        '--base', 'main',
        '--head', branch_name(version),
        '--title', "Prepare release #{version}",
-       '--body', "Prepare release #{version}."],
+       '--body', "Prepare release #{version}.",
+       '--label', 'skip-changelog'],  # Make CI allow the changes
       cwd: cwd
     )
   end

--- a/temporalio/extra/release/test/prepare_release_test.rb
+++ b/temporalio/extra/release/test/prepare_release_test.rb
@@ -252,7 +252,8 @@ class TestPrepareRelease < Minitest::Test
           '--base', 'main',
           '--head', 'chore/release-1.6.1',
           '--title', 'Prepare release 1.6.1',
-          '--body', 'Prepare release 1.6.1.'
+          '--body', 'Prepare release 1.6.1.',
+          '--label', 'skip-changelog'
         ],
         calls[0][0]
       )


### PR DESCRIPTION
CI will reject CHANGELOG changes outside `Unreleased`, which the release PR always does since it moves unreleased changes to a release section. So skip that check.